### PR TITLE
Pin the pure logic: parsing, attention tiers, catalog names

### DIFF
--- a/internal/agent/agent_test.go
+++ b/internal/agent/agent_test.go
@@ -29,6 +29,59 @@ func TestSortPrioritizesAttentionThenActivity(t *testing.T) {
 	}
 }
 
+func TestAttentionTiersDriveUrgencyOwnershipAndRank(t *testing.T) {
+	for _, testCase := range []struct {
+		name          string
+		attention     Attention
+		urgent        bool
+		terminalOwned bool
+		rank          int
+	}{
+		{"approval", AttentionApproval, true, true, 0},
+		{"auth", AttentionAuth, true, true, 0},
+		// A plain question is urgent but answerable with text, so the
+		// agent's own terminal does not own the input.
+		{"question", AttentionQuestion, true, false, 0},
+		{"waiting", AttentionWaiting, false, false, 1},
+		{"none", AttentionNone, false, false, 2},
+	} {
+		t.Run(testCase.name, func(t *testing.T) {
+			if got := testCase.attention.Urgent(); got != testCase.urgent {
+				t.Fatalf("Urgent() = %v, want %v", got, testCase.urgent)
+			}
+			if got := testCase.attention.TerminalOwned(); got != testCase.terminalOwned {
+				t.Fatalf("TerminalOwned() = %v, want %v", got, testCase.terminalOwned)
+			}
+			if got := testCase.attention.Rank(); got != testCase.rank {
+				t.Fatalf("Rank() = %d, want %d", got, testCase.rank)
+			}
+		})
+	}
+}
+
+func TestParseModeDefaultsWhenUnsetAndRejectsUnknown(t *testing.T) {
+	mode, err := ParseMode("")
+	if err != nil || mode != DefaultMode {
+		t.Fatalf("empty mode = %q, err = %v", mode, err)
+	}
+
+	for _, value := range []string{"ask", "edits", "auto"} {
+		mode, err := ParseMode(value)
+		if err != nil {
+			t.Fatalf("ParseMode(%q) = %v", value, err)
+		}
+		if mode != PermissionMode(value) {
+			t.Fatalf("ParseMode(%q) = %q", value, mode)
+		}
+	}
+
+	for _, value := range []string{"yolo", "Auto", "edit"} {
+		if _, err := ParseMode(value); err == nil {
+			t.Fatalf("ParseMode(%q) was accepted", value)
+		}
+	}
+}
+
 func TestDisplaySummaryFallsBackToTask(t *testing.T) {
 	managedAgent := Agent{Task: "  inspect the parser  "}
 	if got := managedAgent.DisplaySummary(); got != "inspect the parser" {

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -122,6 +122,83 @@ mode = "yolo"
 	}
 }
 
+func TestEffectiveTOMLFillsBuiltinDefaults(t *testing.T) {
+	rendered, err := Config{}.EffectiveTOML("stormlight-sock", "stormlight-agents")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	for _, want := range []string{
+		`provider = 'codex'`,
+		`mode = '` + string(agent.DefaultMode) + `'`,
+		`session = 'stormlight-agents'`,
+		`socket = 'stormlight-sock'`,
+		`return_keys = ['C-6', 'C-^']`,
+		`rows = 'compact'`,
+		`level = 'info'`,
+	} {
+		if !strings.Contains(rendered, want) {
+			t.Fatalf("rendered config missing %q:\n%s", want, rendered)
+		}
+	}
+}
+
+func TestEffectiveTOMLKeepsFileValuesOverDefaults(t *testing.T) {
+	socket := ""
+	cfg := Config{
+		Defaults: Defaults{Provider: "claude", Mode: "ask", Session: "mine"},
+		Tmux:     Tmux{Socket: &socket, ReturnKeys: []string{"F12"}},
+		UI:       UI{Rows: "sideways"},
+		Log:      Log{Level: "debug"},
+	}
+
+	rendered, err := cfg.EffectiveTOML("stormlight-sock", "stormlight-agents")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	for _, want := range []string{
+		`provider = 'claude'`,
+		`mode = 'ask'`,
+		`session = 'mine'`,
+		`socket = ''`,
+		`return_keys = ['F12']`,
+		`rows = 'sideways'`,
+		`level = 'debug'`,
+	} {
+		if !strings.Contains(rendered, want) {
+			t.Fatalf("rendered config missing %q:\n%s", want, rendered)
+		}
+	}
+	// An explicit empty socket means "the default tmux server" and must not
+	// be overwritten by the built-in.
+	if strings.Contains(rendered, "stormlight-sock") {
+		t.Fatalf("explicit empty socket was replaced:\n%s", rendered)
+	}
+}
+
+func TestEffectiveTOMLRoundTripsThroughLoad(t *testing.T) {
+	rendered, err := Config{}.EffectiveTOML("stormlight-sock", "stormlight-agents")
+	if err != nil {
+		t.Fatal(err)
+	}
+	writeConfig(t, rendered)
+
+	cfg, warnings, err := Load()
+	if err != nil {
+		t.Fatalf("rendered config did not parse: %v\n%s", err, rendered)
+	}
+	if len(warnings) != 0 {
+		t.Fatalf("rendered config produced warnings %#v:\n%s", warnings, rendered)
+	}
+	if cfg.Defaults.Provider != "codex" || cfg.Defaults.Session != "stormlight-agents" {
+		t.Fatalf("defaults did not survive the round trip: %#v", cfg.Defaults)
+	}
+	if cfg.SocketOr("fallback") != "stormlight-sock" {
+		t.Fatalf("socket = %q", cfg.SocketOr("fallback"))
+	}
+}
+
 func TestWriteTemplateRefusesToOverwrite(t *testing.T) {
 	t.Setenv("XDG_CONFIG_HOME", t.TempDir())
 	path, err := WriteTemplate(false)

--- a/internal/workspace/catalog_test.go
+++ b/internal/workspace/catalog_test.go
@@ -55,3 +55,191 @@ func TestCatalogRemovesPath(t *testing.T) {
 		t.Fatalf("paths = %#v", paths)
 	}
 }
+
+func TestSetNamePersistsTrimmedOverrideAndAddsMissingPath(t *testing.T) {
+	root := t.TempDir()
+	catalogPath := filepath.Join(t.TempDir(), "workspaces.json")
+	canonicalRoot, err := canonicalDirectory(root)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// The path is not in the catalog yet; SetName must add it so the name
+	// survives for workspaces discovered through their agents.
+	if err := NewCatalogAt(catalogPath).SetName(root, "  Stormlight  "); err != nil {
+		t.Fatal(err)
+	}
+
+	reopened := NewCatalogAt(catalogPath)
+	paths, err := reopened.Paths()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(paths) != 1 || paths[0] != canonicalRoot {
+		t.Fatalf("paths = %#v", paths)
+	}
+	names, err := reopened.Names()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if names[canonicalRoot] != "Stormlight" {
+		t.Fatalf("names = %#v", names)
+	}
+}
+
+func TestSetNameOverwritesAndEmptyNameClearsOverride(t *testing.T) {
+	root := t.TempDir()
+	catalog := NewCatalogAt(filepath.Join(t.TempDir(), "workspaces.json"))
+	canonicalRoot, err := canonicalDirectory(root)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if err := catalog.SetName(root, "first"); err != nil {
+		t.Fatal(err)
+	}
+	if err := catalog.SetName(root, "second"); err != nil {
+		t.Fatal(err)
+	}
+	names, err := catalog.Names()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if names[canonicalRoot] != "second" {
+		t.Fatalf("names = %#v", names)
+	}
+
+	// Whitespace-only is treated as empty and removes the override without
+	// dropping the path itself.
+	if err := catalog.SetName(root, "   "); err != nil {
+		t.Fatal(err)
+	}
+	names, err = catalog.Names()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, ok := names[canonicalRoot]; ok {
+		t.Fatalf("override survived clearing: %#v", names)
+	}
+	paths, err := catalog.Paths()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(paths) != 1 {
+		t.Fatalf("clearing a name dropped the path: %#v", paths)
+	}
+}
+
+func TestRemoveDiscardsTheNameOverride(t *testing.T) {
+	root := t.TempDir()
+	catalogPath := filepath.Join(t.TempDir(), "workspaces.json")
+	catalog := NewCatalogAt(catalogPath)
+	canonicalRoot, err := canonicalDirectory(root)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if err := catalog.SetName(root, "Stormlight"); err != nil {
+		t.Fatal(err)
+	}
+	if err := catalog.Remove(root); err != nil {
+		t.Fatal(err)
+	}
+
+	// A stale name would resurface if the same path were added back later.
+	if err := catalog.Add(root); err != nil {
+		t.Fatal(err)
+	}
+	names, err := NewCatalogAt(catalogPath).Names()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, ok := names[canonicalRoot]; ok {
+		t.Fatalf("removed name came back: %#v", names)
+	}
+}
+
+func TestNamesReturnsACopyCallersCannotMutate(t *testing.T) {
+	root := t.TempDir()
+	catalog := NewCatalogAt(filepath.Join(t.TempDir(), "workspaces.json"))
+	canonicalRoot, err := canonicalDirectory(root)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := catalog.SetName(root, "Stormlight"); err != nil {
+		t.Fatal(err)
+	}
+
+	names, err := catalog.Names()
+	if err != nil {
+		t.Fatal(err)
+	}
+	names[canonicalRoot] = "mutated"
+	delete(names, canonicalRoot)
+
+	fresh, err := catalog.Names()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if fresh[canonicalRoot] != "Stormlight" {
+		t.Fatalf("caller mutation leaked into the catalog: %#v", fresh)
+	}
+}
+
+func TestCatalogRejectsCorruptAndFutureVersionFiles(t *testing.T) {
+	for _, testCase := range []struct{ name, content string }{
+		{"unparsable json", "{not json"},
+		{"future version", `{"version": 99, "paths": []}`},
+	} {
+		t.Run(testCase.name, func(t *testing.T) {
+			path := filepath.Join(t.TempDir(), "workspaces.json")
+			if err := os.WriteFile(path, []byte(testCase.content), 0o600); err != nil {
+				t.Fatal(err)
+			}
+			if _, err := NewCatalogAt(path).Paths(); err == nil {
+				t.Fatal("corrupt catalog was accepted")
+			}
+		})
+	}
+}
+
+func TestMissingCatalogFileReadsAsEmpty(t *testing.T) {
+	paths, err := NewCatalogAt(filepath.Join(t.TempDir(), "absent.json")).Paths()
+	if err != nil {
+		t.Fatalf("missing catalog was an error: %v", err)
+	}
+	if len(paths) != 0 {
+		t.Fatalf("paths = %#v", paths)
+	}
+}
+
+func TestCatalogPathPrefersExplicitFileThenStateHome(t *testing.T) {
+	stateHome := t.TempDir()
+	home := t.TempDir()
+	explicit := filepath.Join(t.TempDir(), "custom.json")
+
+	t.Setenv("HOME", home)
+	t.Setenv("XDG_STATE_HOME", stateHome)
+	t.Setenv("STORMLIGHT_WORKSPACES_FILE", explicit)
+	if got := catalogPath(); got != explicit {
+		t.Fatalf("explicit file override = %q", got)
+	}
+
+	t.Setenv("STORMLIGHT_WORKSPACES_FILE", "")
+	want := filepath.Join(stateHome, "stormlight", "workspaces.json")
+	if got := catalogPath(); got != want {
+		t.Fatalf("state home path = %q, want %q", got, want)
+	}
+
+	t.Setenv("XDG_STATE_HOME", "")
+	want = filepath.Join(home, ".local", "state", "stormlight", "workspaces.json")
+	if got := catalogPath(); got != want {
+		t.Fatalf("home fallback path = %q, want %q", got, want)
+	}
+
+	// NewCatalog must agree with catalogPath, or an isolated test run would
+	// silently edit the real catalog.
+	if got := NewCatalog().path; got != want {
+		t.Fatalf("NewCatalog path = %q, want %q", got, want)
+	}
+}

--- a/main_test.go
+++ b/main_test.go
@@ -5,6 +5,8 @@ import (
 	"strings"
 	"testing"
 	"time"
+
+	"github.com/trentkm/stormlight/internal/agent"
 )
 
 func TestRootCommandUsesStormlightIdentityAndDefaultSession(t *testing.T) {
@@ -105,5 +107,92 @@ func TestDashboardSessionNamesAreTemporaryAndDistinct(t *testing.T) {
 	second := dashboardSessionName(42, time.Unix(0, 2))
 	if !strings.HasPrefix(first, "stormlight-ui-42-") || first == second {
 		t.Fatalf("session names are not unique: %q, %q", first, second)
+	}
+}
+
+func TestParseActivityAcceptsKnownStatesAndRejectsOthers(t *testing.T) {
+	for _, value := range []string{
+		"", "starting", "working", "idle", "completed", "failed", "stopped",
+	} {
+		got, err := parseActivity(value)
+		if err != nil {
+			t.Fatalf("parseActivity(%q) = %v", value, err)
+		}
+		if got != agent.Activity(value) {
+			t.Fatalf("parseActivity(%q) = %q", value, got)
+		}
+	}
+
+	for _, value := range []string{"running", "Working", "done", "idle "} {
+		if _, err := parseActivity(value); err == nil {
+			t.Fatalf("parseActivity(%q) was accepted", value)
+		}
+	}
+}
+
+func TestParseAttentionTreatsNoneAndEmptyAsCleared(t *testing.T) {
+	for _, value := range []string{"none", ""} {
+		got, err := parseAttention(value)
+		if err != nil {
+			t.Fatalf("parseAttention(%q) = %v", value, err)
+		}
+		if got != agent.AttentionNone {
+			t.Fatalf("parseAttention(%q) = %q, want cleared", value, got)
+		}
+	}
+
+	for _, value := range []string{"question", "approval", "auth", "waiting"} {
+		got, err := parseAttention(value)
+		if err != nil {
+			t.Fatalf("parseAttention(%q) = %v", value, err)
+		}
+		if got != agent.Attention(value) {
+			t.Fatalf("parseAttention(%q) = %q", value, got)
+		}
+	}
+
+	for _, value := range []string{"urgent", "Question", "blocked"} {
+		if _, err := parseAttention(value); err == nil {
+			t.Fatalf("parseAttention(%q) was accepted", value)
+		}
+	}
+}
+
+func TestShortIDTruncatesToEightCharacters(t *testing.T) {
+	for _, testCase := range []struct{ id, want string }{
+		{"", ""},
+		{"abc", "abc"},
+		{"12345678", "12345678"},
+		{"123456789", "12345678"},
+	} {
+		if got := shortID(testCase.id); got != testCase.want {
+			t.Fatalf("shortID(%q) = %q, want %q", testCase.id, got, testCase.want)
+		}
+	}
+}
+
+func TestTruncatePlainCollapsesWhitespaceAndCountsRunes(t *testing.T) {
+	for _, testCase := range []struct {
+		name   string
+		value  string
+		length int
+		want   string
+	}{
+		{"shorter than limit", "hello", 10, "hello"},
+		{"exactly the limit", "abcde", 5, "abcde"},
+		{"collapses runs of whitespace", "  a \n  b\tc  ", 10, "a b c"},
+		{"ellipsis replaces the final rune", "abcdefghij", 5, "abcd…"},
+		{"limit of one takes a bare rune", "abcde", 1, "a"},
+		{"limit of zero is empty", "abcde", 0, ""},
+		{"multibyte counted as runes not bytes", "héllo wörld", 5, "héll…"},
+		{"wide runes are not split", "🌊🌊🌊🌊", 3, "🌊🌊…"},
+	} {
+		t.Run(testCase.name, func(t *testing.T) {
+			got := truncatePlain(testCase.value, testCase.length)
+			if got != testCase.want {
+				t.Fatalf("truncatePlain(%q, %d) = %q, want %q",
+					testCase.value, testCase.length, got, testCase.want)
+			}
+		})
 	}
 }


### PR DESCRIPTION
Test-only change. No production code is touched.

Coverage was 64.8%, which looked low until you split it by cause. The core
packages were fine; the gaps were process orchestration (tmux, `main` wiring)
and one-line delegations in `internal/app`. Those are harness or mock territory.
What was genuinely untested was a layer of pure functions that decide what the
dashboard believes — so that is what this covers.

## What is pinned

**Provider hook parsing** (`main_test.go`) — `parseActivity` and `parseAttention`
gain their error paths and the rule that `"none"` and `""` both mean cleared.
`truncatePlain` gains its `length <= 1` guard and rune-vs-byte counting, so
accented and emoji workspace names cannot be split mid-rune. Plus `shortID`.

**Attention tiers** (`internal/agent`) — one table pins `Urgent`,
`TerminalOwned`, and `Rank` together across every attention value. The
question-is-urgent-but-not-terminal-owned distinction drives both triage sort
order and whether a reply belongs in Spanreed or the agent's own terminal; it
should fail loudly if either half drifts.

**Config rendering** (`internal/config`) — `EffectiveTOML` defaults,
file-values-win, and a round trip back through `Load()` asserting zero warnings.
That last one catches `stormlight config` emitting something its own loader
rejects.

**Workspace catalog rename flow** (`internal/workspace`) — `SetName` trimming,
adding a missing path, and clearing without dropping the path; `Remove`
discarding the override so a stale name cannot resurface on re-add; corrupt and
future-version files erroring rather than silently resetting. The `catalogPath`
test asserts `NewCatalog` agrees with it — a divergence there is exactly what
would have a test run edit the real catalog.

## Coverage

| Package | Before | After |
|---|---|---|
| `internal/agent` | 48.4% | 87.1% |
| `internal/config` | 63.6% | 79.4% |
| `internal/workspace` | 54.1% | 65.0% |
| `main` | 22.4% | 27.2% |
| **total** | **64.8%** | **66.6%** |

`go vet` clean, `go build` succeeds, full suite passes.

## Deliberately not covered

`internal/app` stays at 18.9% and `internal/session` still has no tests. Those
are one-line delegations to the runtime interface and a pure interface file
respectively — covering them would test the mock.

## Follow-up

`truncatePlain` panics on a negative length (`runes[:length]`, main.go:925).
Unreachable today since both callers pass literals (24 and 60), so this PR
tests the reachable branches rather than pinning a panic. Worth a guard if it
ever takes a computed width.

🤖 Generated with [Claude Code](https://claude.com/claude-code)