### PR TITLE
Require a worktree per task, and retire the permission bridge's last traces

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -24,6 +24,44 @@ the right way the first time:
 - Commit and push completed work as it lands; don't let it pile up.
 - Commits carry no AI attribution — no `Co-Authored-By` trailers.
 
+## Work in a worktree
+
+Every task starts in its own git worktree, branched off `main` — never in the
+primary checkout:
+
+```sh
+git worktree add -b <branch> .claude/worktrees/<branch> main
+```
+
+`/.claude/` is gitignored, so worktrees parked there stay invisible to the
+repo. Remove one once its work has landed:
+
+```sh
+git worktree remove .claude/worktrees/<branch> && git branch -d <branch>
+```
+
+The reason is concurrency: more than one agent works this repo at a time. Two
+agents sharing a checkout produce uncommitted changes neither can attribute,
+and a commit from one sweeps up whatever the other had half-finished. A
+worktree makes each task's diff its own.
+
+A worktree isolates the tree and nothing else. The rest is on you:
+
+- **The installed binary.** `~/.local/bin/stormlight` is a global singleton,
+  and managed tmux windows re-invoke `stormlight` from `PATH` — so an install
+  from one worktree silently changes what every other worktree's agents run.
+  Build into the worktree and prepend it to `PATH` for end-to-end runs;
+  install to `~/.local/bin` only when updating the everyday binary is the
+  point.
+- **The tmux server.** Parallel runs need separate sockets
+  (`STORMLIGHT_TMUX_SOCKET=stormlight-<branch>`), or they will list, resize,
+  and kill each other's agents.
+- **XDG state**, exactly as the headless testing section below requires.
+
+Linked worktrees share one `--git-common-dir`, so Stormlight groups them into
+a single workspace while keeping each checkout a distinct execution root —
+working this way dogfoods the feature.
+
 ## Dev loop
 
 ```sh

--- a/README.md
+++ b/README.md
@@ -184,11 +184,13 @@ Code and Codex read image files referenced by path. On macOS this uses
 (`brew install pngpaste`), falling back to AppleScript; on Linux it uses
 `wl-paste` or `xclip`.
 
-Claude permission requests replace the transcript with an inline action. Use
-`j` / `k` and `Enter`, or press `y` to allow once, `a` to accept Claude's
-persisted permission suggestion, `n` to deny, or `t` to review the request in
-the native terminal. If the dashboard closes while a request is pending,
-Stormlight stops handling it and Claude presents its native prompt.
+Approval and authentication prompts are answered in the agent's own terminal:
+Stormlight raises attention and points at the pane rather than reimplementing
+the provider's prompt. While one is pending, the reply box stands down — `i` /
+`s` redirects you to `Enter`, and a prompt arriving mid-compose closes the
+composer and parks your draft for when you return. A plain question is
+different: the agent is idle at its own composer, so a Spanreed reply is the
+answer.
 
 Pressing `n` in Agents or Spanreed inherits the current workspace context.
 The centered form contains a vertical `Coding agent` picker and a wrapping task
@@ -270,8 +272,9 @@ Stormlight injects agent-scoped lifecycle integration for managed providers:
 
 - Codex uses its external `agent-turn-complete` notification to become idle and
   publish the latest response summary.
-- Claude uses `UserPromptSubmit`, `PermissionRequest`, permission notification,
-  and `Stop` hooks to report state and bridge approval choices into Spanreed.
+- Claude uses `UserPromptSubmit`, `Notification`, and `Stop` hooks to report
+  state; the permission notification raises attention on the agent whose
+  terminal is holding the prompt.
 - Replies sent from the dashboard mark any provider working immediately.
 
 The runtime also exposes an `event` command so other provider hooks can report

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -148,10 +148,9 @@ me" and from "just idle".
 
 The current implementation uses tmux options as the source of truth because
 managed processes cannot outlive the tmux server. The workspace catalog is an
-atomic JSON file independent of tmux. Ephemeral pending actions live under
-`$XDG_RUNTIME_DIR/stormlight/actions` when available, otherwise under the
-Stormlight state directory. A future daemon may add an append-only event journal
-for agents that survive tmux restarts or run remotely.
+atomic JSON file independent of tmux, as are the dashboard's column
+preferences. A future daemon may add an append-only event journal for agents
+that survive tmux restarts or run remotely.
 
 ## Workspace boundary
 

--- a/main.go
+++ b/main.go
@@ -771,28 +771,6 @@ func newProviderEventCommand(socket, sessionName *string, cfg config.Config) *co
 	}
 }
 
-func updatePermissionAgent(
-	service *app.Service,
-	id string,
-	activity agent.Activity,
-	attention agent.Attention,
-	summary string,
-) {
-	ctx, cancel := context.WithTimeout(context.Background(), 3*time.Second)
-	defer cancel()
-	if err := service.Update(ctx, id, session.Update{
-		Activity:  activity,
-		Attention: attention,
-		Summary:   summary,
-	}); err != nil {
-		diagnostic.Logger().Warn(
-			"permission state update failed",
-			"agent_id", id,
-			"error", err,
-		)
-	}
-}
-
 func newRunCommand(socket, sessionName *string, cfg config.Config) *cobra.Command {
 	var id string
 	var window string


### PR DESCRIPTION
Two documentation changes, one of which drops a dead function.

## Retire the permission bridge's last traces

The inline approval flow is gone from the code — prompts are answered in
the agent's own terminal, and `provider_test.go:222` already guards the
`PermissionRequest` hook against resurfacing. The docs never caught up:

- README described answering permission requests inline with `y` / `a` /
  `n` / `t` action keys.
- README's provider-lifecycle list still named a `PermissionRequest` hook.
  The real Claude hooks are `UserPromptSubmit`, `Notification`, and `Stop`.
- `docs/architecture.md` pointed at `$XDG_RUNTIME_DIR/stormlight/actions`
  for pending actions. That path appears nowhere in the source.

`main.go` also carried `updatePermissionAgent`, which lost its last caller
when the bridge came out. `go vet` does not flag unused functions, so it
sat there quietly.

The replacement README text describes what actually happens, including a
distinction the code makes but the docs did not: `Attention.TerminalOwned()`
covers approval and auth, so those prompts own the agent's input and the
composer stands down (parking your draft). A plain *question* is urgent but
not terminal-owned — the agent idles at its own composer, so a Spanreed
reply is the answer.

## Require a worktree per task

More than one agent works this repo at a time. While I was preparing this
change, a concurrent worker committed into the shared checkout and later
reset it — so a set of test files appeared in `git status` mid-task,
attributable to nobody, and `main` moved twice underneath me. That is the
failure mode this section exists to prevent.

Beyond the rule itself, the section names the three things a worktree does
*not* isolate, all specific to how Stormlight works:

- `~/.local/bin/stormlight` is a global singleton, and managed tmux windows
  re-invoke `stormlight` from `PATH` — so an install from one worktree
  silently changes what every other worktree's agents execute.
- Parallel runs need separate tmux sockets or they will list, resize, and
  kill each other's agents.
- XDG state needs the isolation the headless-testing section already demands.

## Verification

Per the Philosophy section, the new guidance was checked against reality
rather than assumed:

- `git worktree add -b <branch> .claude/worktrees/<branch> main` works here,
  and `/.claude/` being gitignored does keep the worktree out of
  `git status`.
- `git worktree remove` + `git branch -d` cleans up fully.
- Both checkouts report `--git-common-dir` = `/Volumes/repos/stormlight/.git`
  with different `--show-toplevel`, which is exactly what
  `internal/workspace/git.go:55` turns into one workspace group with
  distinct execution roots — so the dogfooding claim holds.

`go build ./...`, `go vet ./...`, and `go test ./...` are green on this
branch.
