### PR TITLE
Name an agent when you launch it

### DIFF
--- a/README.md
+++ b/README.md
@@ -193,11 +193,17 @@ different: the agent is idle at its own composer, so a Spanreed reply is the
 answer.
 
 Pressing `n` in Agents or Spanreed inherits the current workspace context.
-The centered form contains a vertical `Coding agent` picker and a wrapping task
-composer. Use `j` / `k` to choose Codex, Claude, or another configured coding
-agent, then press `Enter` to compose and `Enter` again to launch. Shell remains
-available through `stormlight dispatch --provider shell`, but is not presented as
-a conversational coding agent.
+The centered form contains a vertical `Coding agent` picker, an optional name,
+and a wrapping task composer. Use `j` / `k` to choose Codex, Claude, or another
+configured coding agent, then press `Enter` to compose and `Enter` again to
+launch. Shell remains available through `stormlight dispatch --provider shell`,
+but is not presented as a conversational coding agent.
+
+`Tab` reaches the name field, which `Enter` on the picker skips past. Leave it
+empty and the agent is named after its task; fill it in and that name is what
+the agent list and its tmux window carry (the same thing `R` sets afterward,
+and what `stormlight dispatch --name` has always taken). The field drops out
+of the form in panes too short to hold both it and the task composer.
 
 Press `e` from the coding-agent picker or `Ctrl-o` from the task composer to
 edit the task in Neovim. The saved text returns to the form. Neovim opens in a

--- a/internal/tmux/runtime.go
+++ b/internal/tmux/runtime.go
@@ -182,7 +182,10 @@ func (r *Runtime) Dispatch(ctx context.Context, req session.DispatchRequest) (ag
 	if err != nil {
 		return agent.Agent{}, fmt.Errorf("create agent id: %w", err)
 	}
-	name := strings.TrimSpace(req.Name)
+	// A user-chosen name becomes the tmux window name verbatim, so it goes
+	// through the same whitespace collapse as Rename — a newline or tab in
+	// a window name confuses every tmux format string that prints it.
+	name := metadataValue(req.Name)
 	if name == "" {
 		name = windowName(req.Provider, req.Task)
 	}

--- a/internal/tmux/runtime_test.go
+++ b/internal/tmux/runtime_test.go
@@ -119,6 +119,56 @@ func TestWindowName(t *testing.T) {
 	}
 }
 
+// A user-supplied name becomes the tmux window name; only the derived slug
+// falls back to the task.
+func TestDispatchNamesTheWindow(t *testing.T) {
+	for _, testCase := range []struct {
+		name string
+		want string
+	}{
+		{name: "", want: "cl-fix-the-oauth-callback"},
+		{name: "  oauth   review\n", want: "oauth review"},
+	} {
+		runner := &dispatchRunner{}
+		runtime := &Runtime{runner: runner, sessionName: "stormlight"}
+		if _, err := runtime.Dispatch(context.Background(), session.DispatchRequest{
+			Provider: agent.ProviderClaude,
+			Name:     testCase.name,
+			Task:     "Fix the OAuth callback",
+			Cwd:      t.TempDir(),
+			Launch:   session.Launch{Path: "/usr/bin/claude"},
+		}); err != nil {
+			t.Fatal(err)
+		}
+		if runner.windowName != testCase.want {
+			t.Fatalf("window name for %q = %q, want %q",
+				testCase.name, runner.windowName, testCase.want)
+		}
+	}
+}
+
+// dispatchRunner answers just enough tmux for Dispatch and records the name
+// the new window was created with.
+type dispatchRunner struct {
+	windowName string
+}
+
+func (r *dispatchRunner) Run(_ context.Context, _ []byte, args ...string) (string, error) {
+	if len(args) == 0 {
+		return "", nil
+	}
+	switch args[0] {
+	case "show-options":
+		return "1", nil
+	case "new-window", "new-session":
+		if index := slices.Index(args, "-n"); index >= 0 && index+1 < len(args) {
+			r.windowName = args[index+1]
+		}
+		return "@7" + fieldSeparator + "%7", nil
+	}
+	return "", nil
+}
+
 func TestLaunchRoundTrip(t *testing.T) {
 	want := session.Launch{
 		Path: "/path/with spaces/codex",

--- a/internal/ui/chrome.go
+++ b/internal/ui/chrome.go
@@ -147,10 +147,15 @@ func (m Model) commandHints() string {
 			return "j/k location  Enter choose  m mode  e edit path  Esc cancel"
 		case dispatchCustomPath:
 			return "type to filter  Enter choose  ↑/↓ pick  Backspace up  Esc cancel"
+		case dispatchName:
+			return "name this agent  Enter task  Tab fields  Esc cancel"
 		default:
 			hints := "Enter launch"
 			if m.nvimPath != "" {
 				hints += "  Ctrl-o Neovim"
+			}
+			if m.dispatchNameVisible() {
+				hints += "  Shift-Tab name"
 			}
 			return hints + "  Esc cancel"
 		}

--- a/internal/ui/dispatch.go
+++ b/internal/ui/dispatch.go
@@ -145,12 +145,19 @@ func (m Model) updateDispatch(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 			}
 			m.focusForm()
 			return m, nil
+		case dispatchName:
+			m.formFocus = dispatchTask
+			m.focusForm()
+			return m, nil
 		case dispatchTask:
 			return m.submitDispatch()
 		}
 	}
 
 	switch m.formFocus {
+	case dispatchName:
+		m.nameInput = m.nameInput.Update(msg)
+		return m, nil
 	case dispatchTask:
 		var cmd tea.Cmd
 		m.taskInput, cmd = m.taskInput.Update(msg)
@@ -159,19 +166,18 @@ func (m Model) updateDispatch(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 	return m, nil
 }
 
-func (m Model) renderDispatchModal(width, height int) string {
+func (m Model) dispatchModalDimensions(width, height int) (int, int) {
 	preferredWidth := 62
-	preferredHeight := 18
+	preferredHeight := 21
 	if m.chooseDispatchDirectory {
 		preferredWidth = 78
-		preferredHeight = 24
+		preferredHeight = 27
 	}
-	modalWidth, modalHeight := modalDimensions(
-		width,
-		height,
-		preferredWidth,
-		preferredHeight,
-	)
+	return modalDimensions(width, height, preferredWidth, preferredHeight)
+}
+
+func (m Model) renderDispatchModal(width, height int) string {
+	modalWidth, modalHeight := m.dispatchModalDimensions(width, height)
 	innerWidth := max(1, modalWidth-2)
 	innerHeight := max(1, modalHeight-2)
 	return renderModal(
@@ -242,6 +248,21 @@ func (m Model) renderDispatch(width int) string {
 	return m.renderDispatchAt(width, max(12, m.height-5))
 }
 
+// roomyForm reports whether the new-agent form has height to spare. A tight
+// form drops its breathing room and the optional name row; the task
+// composer is never what gets cut.
+func roomyForm(height int) bool {
+	return height >= 15
+}
+
+// dispatchNameVisible answers the same question against the modal the
+// current terminal actually produces, so focus can skip a field that isn't
+// drawn — a cursor in an invisible input is worse than no field at all.
+func (m Model) dispatchNameVisible() bool {
+	_, modalHeight := m.dispatchModalDimensions(m.bodyDimensions())
+	return roomyForm(max(1, modalHeight-2))
+}
+
 func (m Model) renderDispatchAt(width, height int) string {
 	providerStyle := titleStyle
 	if m.formFocus == dispatchProvider {
@@ -249,9 +270,13 @@ func (m Model) renderDispatchAt(width, height int) string {
 	}
 
 	directoryStyle := titleStyle
+	nameStyle := titleStyle
 	taskStyle := titleStyle
 	if m.formFocus == dispatchDirectory {
 		directoryStyle = accentStyle
+	}
+	if m.formFocus == dispatchName {
+		nameStyle = accentStyle
 	}
 	if m.formFocus == dispatchTask {
 		taskStyle = accentStyle
@@ -302,11 +327,24 @@ func (m Model) renderDispatchAt(width, height int) string {
 		}
 	}
 
-	roomy := height >= 15
+	roomy := roomyForm(height)
 	if roomy {
 		lines = append(lines, "")
 	}
 	lines = append(lines, "  "+m.renderDispatchModeLine(contentWidth))
+
+	if roomy {
+		lines = append(lines,
+			"",
+			"  "+m.renderDispatchSectionTitle(
+				nameStyle,
+				"Name",
+				"optional",
+				contentWidth,
+			),
+			"    "+m.renderNameField(max(10, contentWidth-2)),
+		)
+	}
 
 	taskDetail := fmt.Sprintf(
 		"%d chars",
@@ -338,6 +376,15 @@ func indentLines(block, prefix string) string {
 		rows[i] = prefix + row
 	}
 	return strings.Join(rows, "\n")
+}
+
+// renderNameField draws the optional agent name as a single row. It stays
+// unboxed on purpose: the task composer's border marks where the multi-line
+// field is, and a second box around a one-liner would read as equal weight.
+func (m Model) renderNameField(width int) string {
+	input := m.nameInput
+	input.SetWidth(width)
+	return input.View()
 }
 
 func (m Model) renderTaskComposer(width, height int) string {
@@ -629,10 +676,13 @@ func (m Model) renderProviderRows(width int) []string {
 
 func (m *Model) focusForm() {
 	m.cwdInput.Blur()
+	m.nameInput.Blur()
 	m.taskInput.Blur()
 	switch m.formFocus {
 	case dispatchCustomPath:
 		m.pathNav.filter.Focus()
+	case dispatchName:
+		m.nameInput.Focus()
 	case dispatchTask:
 		m.taskInput.Focus()
 	}
@@ -689,6 +739,7 @@ func (m *Model) handlePathNavKey(msg tea.KeyMsg) bool {
 
 func (m *Model) blurForm() {
 	m.cwdInput.Blur()
+	m.nameInput.Blur()
 	m.taskInput.Blur()
 }
 
@@ -855,31 +906,25 @@ func (m *Model) editSelectedDirectory() {
 	m.focusForm()
 }
 
+// dispatchFocusOrder is the tab cycle through the new-agent form, in the
+// order the fields are drawn.
+func (m Model) dispatchFocusOrder() []dispatchFocus {
+	focuses := []dispatchFocus{dispatchProvider}
+	if m.chooseDispatchDirectory {
+		focuses = append(focuses, dispatchDirectory)
+		if selected, ok := m.selectedDirectory(); ok &&
+			selected.kind == directoryCustom {
+			focuses = append(focuses, dispatchCustomPath)
+		}
+	}
+	if m.dispatchNameVisible() {
+		focuses = append(focuses, dispatchName)
+	}
+	return append(focuses, dispatchTask)
+}
+
 func (m *Model) moveDispatchFocus(delta int) {
-	if !m.chooseDispatchDirectory {
-		focuses := []dispatchFocus{dispatchProvider, dispatchTask}
-		current := 0
-		if m.formFocus == dispatchTask {
-			current = 1
-		}
-		m.formFocus = focuses[(current+delta+len(focuses))%len(focuses)]
-		m.focusForm()
-		return
-	}
-	focuses := []dispatchFocus{
-		dispatchProvider,
-		dispatchDirectory,
-		dispatchTask,
-	}
-	if selected, ok := m.selectedDirectory(); ok &&
-		selected.kind == directoryCustom {
-		focuses = []dispatchFocus{
-			dispatchProvider,
-			dispatchDirectory,
-			dispatchCustomPath,
-			dispatchTask,
-		}
-	}
+	focuses := m.dispatchFocusOrder()
 	current := 0
 	for index, focus := range focuses {
 		if focus == m.formFocus {
@@ -887,8 +932,7 @@ func (m *Model) moveDispatchFocus(delta int) {
 			break
 		}
 	}
-	current = (current + delta + len(focuses)) % len(focuses)
-	m.formFocus = focuses[current]
+	m.formFocus = focuses[(current+delta+len(focuses))%len(focuses)]
 	m.focusForm()
 }
 
@@ -899,6 +943,7 @@ func (m Model) submitDispatch() (tea.Model, tea.Cmd) {
 	}
 	request := app.DispatchRequest{
 		Provider: m.providers[m.providerIndex].ID,
+		Name:     strings.TrimSpace(m.nameInput.Value()),
 		Cwd:      strings.TrimSpace(m.cwdInput.Value()),
 		Task:     strings.TrimSpace(m.taskInput.Value()),
 		Mode:     m.dispatchMode,
@@ -915,6 +960,7 @@ func (m Model) submitDispatch() (tea.Model, tea.Cmd) {
 	m.blurForm()
 	m.status = "Dispatching " + m.providers[m.providerIndex].Label
 	m.taskInput.SetValue("")
+	m.nameInput.SetValue("")
 	return m, dispatchCmd(m.backend, request)
 }
 

--- a/internal/ui/input_test.go
+++ b/internal/ui/input_test.go
@@ -357,6 +357,131 @@ func TestNewAgentModalPreservesDashboardContext(t *testing.T) {
 	assertViewFitsPane(t, model, 119, 29)
 }
 
+func TestDispatchOptionalNameReachesTheRequest(t *testing.T) {
+	directory := t.TempDir()
+	backend := &recordingBackend{
+		providers: []provider.Info{{ID: agent.ProviderClaude, Label: "Claude"}},
+	}
+	model := NewModel(backend)
+	updated, _ := model.Update(tea.WindowSizeMsg{Width: 120, Height: 34})
+	model = updated.(Model)
+	model.initialCwd = directory
+	updated, _ = model.beginDispatch(false)
+	model = updated.(Model)
+
+	view := ansi.Strip(model.View())
+	if !strings.Contains(view, "Name") || !strings.Contains(view, "optional") {
+		t.Fatalf("new-agent form has no optional name field:\n%s", view)
+	}
+
+	// Tab from the provider list lands on the name before the task, so the
+	// field is reachable without leaving the keyboard home row.
+	updated, _ = model.Update(tea.KeyMsg{Type: tea.KeyTab})
+	model = updated.(Model)
+	if model.formFocus != dispatchName {
+		t.Fatalf("tab focus = %v, want the name field", model.formFocus)
+	}
+	for _, key := range []string{"j", "u", "d", "g", "e"} {
+		updated, _ = model.Update(runeKey(key))
+		model = updated.(Model)
+	}
+	if got := model.nameInput.Value(); got != "judge" {
+		t.Fatalf("name field value = %q, want %q", got, "judge")
+	}
+
+	// Enter moves on to the task rather than launching a nameless agent.
+	updated, _ = model.Update(tea.KeyMsg{Type: tea.KeyEnter})
+	model = updated.(Model)
+	if model.formFocus != dispatchTask {
+		t.Fatalf("focus after naming = %v, want the task field", model.formFocus)
+	}
+	model.taskInput.SetValue("score the rewrite")
+
+	updated, command := model.submitDispatch()
+	model = updated.(Model)
+	if command != nil {
+		command()
+	}
+	if backend.request.Name != "judge" {
+		t.Fatalf("dispatch name = %q, want %q", backend.request.Name, "judge")
+	}
+	if backend.request.Task != "score the rewrite" {
+		t.Fatalf("dispatch task = %q", backend.request.Task)
+	}
+	if model.nameInput.Value() != "" {
+		t.Fatalf("name survived the launch: %q", model.nameInput.Value())
+	}
+}
+
+func TestDispatchWithoutANameLaunchesUnnamed(t *testing.T) {
+	directory := t.TempDir()
+	backend := &recordingBackend{
+		providers: []provider.Info{{ID: agent.ProviderClaude, Label: "Claude"}},
+	}
+	model := NewModel(backend)
+	updated, _ := model.Update(tea.WindowSizeMsg{Width: 120, Height: 34})
+	model = updated.(Model)
+	model.initialCwd = directory
+	updated, _ = model.beginDispatch(false)
+	model = updated.(Model)
+
+	// Enter on the provider skips straight past the optional name.
+	updated, _ = model.Update(tea.KeyMsg{Type: tea.KeyEnter})
+	model = updated.(Model)
+	if model.formFocus != dispatchTask {
+		t.Fatalf("Enter focus = %v, want the task field", model.formFocus)
+	}
+	model.taskInput.SetValue("investigate the flake")
+
+	updated, command := model.submitDispatch()
+	if command != nil {
+		command()
+	}
+	if backend.request.Name != "" {
+		t.Fatalf("unnamed dispatch carried name %q", backend.request.Name)
+	}
+}
+
+// A short pane drops the optional name row, so focus must not stop there.
+func TestDispatchFocusSkipsHiddenNameField(t *testing.T) {
+	backend := &recordingBackend{
+		providers: []provider.Info{{ID: agent.ProviderClaude, Label: "Claude"}},
+	}
+	model := NewModel(backend)
+	model.mode = modeDispatch
+	updated, _ := model.Update(tea.WindowSizeMsg{Width: 40, Height: 16})
+	model = updated.(Model)
+
+	if model.dispatchNameVisible() {
+		t.Fatal("compact form claims room for the name field")
+	}
+	updated, _ = model.Update(tea.KeyMsg{Type: tea.KeyTab})
+	model = updated.(Model)
+	if model.formFocus == dispatchName {
+		t.Fatal("focus landed on a name field that is not drawn")
+	}
+}
+
+// Shrinking the terminal while the name field is focused must move focus
+// out of the field the next render will drop.
+func TestDispatchShrinkReleasesHiddenNameField(t *testing.T) {
+	backend := &recordingBackend{
+		providers: []provider.Info{{ID: agent.ProviderClaude, Label: "Claude"}},
+	}
+	model := NewModel(backend)
+	model.mode = modeDispatch
+	updated, _ := model.Update(tea.WindowSizeMsg{Width: 120, Height: 34})
+	model = updated.(Model)
+	model.formFocus = dispatchName
+	model.focusForm()
+
+	updated, _ = model.Update(tea.WindowSizeMsg{Width: 40, Height: 16})
+	model = updated.(Model)
+	if model.formFocus != dispatchTask {
+		t.Fatalf("focus after shrink = %v, want the task field", model.formFocus)
+	}
+}
+
 func TestModalRendersCompleteBorder(t *testing.T) {
 	rendered := ansi.Strip(renderModal("content", 32, 8))
 	lines := strings.Split(rendered, "\n")

--- a/internal/ui/layout.go
+++ b/internal/ui/layout.go
@@ -54,9 +54,14 @@ func (m Model) renderHeader() string {
 	return left + strings.Repeat(" ", gap) + right + " "
 }
 
+// bodyDimensions is the area modals and the dashboard share: the terminal
+// minus the header, status, and hint chrome.
+func (m Model) bodyDimensions() (int, int) {
+	return max(1, m.width-1), max(1, m.height-4)
+}
+
 func (m Model) renderBody() string {
-	contentHeight := max(1, m.height-4)
-	width := max(1, m.width-1)
+	width, contentHeight := m.bodyDimensions()
 	dashboard := m.renderDashboardBody(width, contentHeight)
 	switch m.mode {
 	case modeDispatch:

--- a/internal/ui/model.go
+++ b/internal/ui/model.go
@@ -107,6 +107,7 @@ const (
 	dispatchProvider dispatchFocus = iota
 	dispatchDirectory
 	dispatchCustomPath
+	dispatchName
 	dispatchTask
 )
 
@@ -131,6 +132,7 @@ type Model struct {
 	providers               []provider.Info
 	providerIndex           int
 	cwdInput                lineInput
+	nameInput               lineInput
 	taskInput               textarea.Model
 	sendInput               textarea.Model
 	initialCwd              string
@@ -255,6 +257,8 @@ func NewModelWithOptions(backend Backend, current surface.Surface, options Optio
 	cwdInput := newLineInput("")
 	cwdInput.SetValue(cwd)
 
+	nameInput := newLineInput("Named after the task")
+
 	taskInput := newTaskInput("What should the agent do?")
 
 	sendInput := newTaskInput("Reply to the selected agent")
@@ -270,6 +274,7 @@ func NewModelWithOptions(backend Backend, current surface.Surface, options Optio
 		surface:            current,
 		providers:          backend.Providers(),
 		cwdInput:           cwdInput,
+		nameInput:          nameInput,
 		taskInput:          taskInput,
 		sendInput:          sendInput,
 		initialCwd:         cwd,
@@ -311,6 +316,13 @@ func (m Model) Update(message tea.Msg) (tea.Model, tea.Cmd) {
 		} else {
 			m.interaction.Width = interactionWidth
 			m.interaction.Height = contentHeight
+		}
+		// A shrink can drop the optional name row out of the form; typing
+		// must not keep landing in a field that is no longer drawn.
+		if m.mode == modeDispatch && m.formFocus == dispatchName &&
+			!m.dispatchNameVisible() {
+			m.formFocus = dispatchTask
+			m.focusForm()
 		}
 		return m, tea.Batch(m.loadInteractionCmd(), m.syncAgentWindowsCmd())
 


### PR DESCRIPTION
The new-agent form only ever named agents after their first prompt, so the agent list read as a wall of half-sentences. `Tab` now reaches an optional name field between the picker and the task composer; `Enter` on the picker still skips straight to the task, so launching without a name is unchanged.

The name lands where every other name does — the tmux window — through the same whitespace collapse `Rename` uses, so the agent list, the window, and a later `R` all agree. `stormlight dispatch --name` already took one; the form just never offered it.

A pane too short for both drops the name row, not the task composer, and focus follows: the tab cycle skips a field that isn't drawn, and a shrink that hides it releases focus to the task.

Verified in the headless tmux harness at 120x36 (both the `n` and `o` forms) and at 48x18 (name row dropped, task composer intact). `go test ./...` passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)