### PR TITLE
Paint the transcript rendered from the JSONL history

### DIFF
--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -104,7 +104,13 @@ target pane; they are not interpolated into shell command strings.
 The Spanreed pane shows the normalized transcript and composer, with the
 native terminal as the fallback. Transcript rendering retains only SGR
 styling from tmux capture
-output; other terminal control sequences are discarded. Claude and Codex
+output; other terminal control sequences are discarded. A session rendered
+from a provider's own JSONL transcript arrives unstyled, so the renderer
+paints it: prompts, replies, tool calls, and trimmed results take the
+palette in `internal/theme`, and the markdown Claude writes (headings,
+literals, emphasis) is read back as styling. Wrapping replays the styling in
+effect at the head of every continuation row and closes it at the row's end,
+so no color runs into the neighboring pane. Claude and Codex
 interactions focus on content from the first populated prompt and remove only
 the trailing empty composer/status block. The tmux capture remains the
 provider-neutral fallback. Messages

--- a/go.mod
+++ b/go.mod
@@ -7,6 +7,7 @@ require (
 	github.com/charmbracelet/bubbletea v1.3.10
 	github.com/charmbracelet/lipgloss v1.1.0
 	github.com/charmbracelet/x/ansi v0.11.6
+	github.com/muesli/termenv v0.16.0
 	github.com/pelletier/go-toml/v2 v2.4.3
 	github.com/spf13/cobra v1.10.2
 )
@@ -28,7 +29,6 @@ require (
 	github.com/mattn/go-runewidth v0.0.19 // indirect
 	github.com/muesli/ansi v0.0.0-20230316100256-276c6243b2f6 // indirect
 	github.com/muesli/cancelreader v0.2.2 // indirect
-	github.com/muesli/termenv v0.16.0 // indirect
 	github.com/rivo/uniseg v0.4.7 // indirect
 	github.com/spf13/pflag v1.0.9 // indirect
 	github.com/xo/terminfo v0.0.0-20220910002029-abceb7e1c41e // indirect

--- a/internal/app/service.go
+++ b/internal/app/service.go
@@ -285,7 +285,7 @@ func (s *Service) transcriptCapture(ctx context.Context, id string, lines int) (
 			managedAgent.Attention.Urgent()
 		if busy && managedAgent.ProcessLive {
 			if live, err := s.runtime.Capture(ctx, id, lines); err == nil {
-				rendered += "\n──── live ────\n" + live
+				rendered += "\n" + provider.LiveDivider() + "\n" + live
 			}
 		}
 		return rendered, true

--- a/internal/provider/transcript.go
+++ b/internal/provider/transcript.go
@@ -6,6 +6,9 @@ import (
 	"fmt"
 	"os"
 	"strings"
+
+	"github.com/charmbracelet/lipgloss"
+	"github.com/trentkm/stormlight/internal/theme"
 )
 
 // Claude Code appends every completed message of a session to a JSONL
@@ -13,6 +16,11 @@ import (
 // conversation from that file gives Spanreed the entire session history —
 // the terminal screen alone cannot: Claude runs in the alternate screen,
 // so tmux never accumulates scrollback for it.
+//
+// The file carries no styling, so the renderer supplies it: a transcript
+// that reads as one gray slab is a worse trade than the scrollback it buys.
+// Structure is colored where the JSONL states it (prompt, reply, tool call,
+// result) and prose is colored where Claude's own markdown says so.
 
 const (
 	// transcriptResultLines caps how many lines of a tool result are
@@ -21,7 +29,30 @@ const (
 	// transcriptScanBuffer must fit the largest JSONL line; tool results
 	// carry whole files.
 	transcriptScanBuffer = 16 * 1024 * 1024
+	// liveDividerText separates the rendered history from the live pane
+	// capture appended while a turn is in flight.
+	liveDividerText = "──── live ────"
 )
+
+var (
+	promptMarkStyle = lipgloss.NewStyle().Foreground(theme.Accent).Bold(true)
+	promptTextStyle = lipgloss.NewStyle().Foreground(theme.Text).Bold(true)
+	replyMarkStyle  = lipgloss.NewStyle().Foreground(theme.Done).Bold(true)
+	toolMarkStyle   = lipgloss.NewStyle().Foreground(theme.Working).Bold(true)
+	toolNameStyle   = lipgloss.NewStyle().Foreground(theme.Text).Bold(true)
+	toolArgStyle    = lipgloss.NewStyle().Foreground(theme.Muted)
+	resultStyle     = lipgloss.NewStyle().Foreground(theme.Muted)
+	headingStyle    = lipgloss.NewStyle().Foreground(theme.Accent).Bold(true)
+	codeStyle       = lipgloss.NewStyle().Foreground(theme.Code)
+	boldStyle       = lipgloss.NewStyle().Bold(true)
+	dividerStyle    = lipgloss.NewStyle().Foreground(theme.Border)
+)
+
+// LiveDivider is the rule drawn between the rendered transcript and the
+// live pane capture.
+func LiveDivider() string {
+	return dividerStyle.Render(liveDividerText)
+}
 
 type transcriptLine struct {
 	Type        string          `json:"type"`
@@ -92,7 +123,9 @@ func renderTranscriptUser(out *strings.Builder, content json.RawMessage) int {
 		if prompt == "" {
 			return 0
 		}
-		out.WriteString("\n❯ " + indentContinuations(prompt, "  ") + "\n")
+		out.WriteString("\n")
+		writeEntry(out, promptMarkStyle.Render("❯ "), prompt,
+			func(line string) string { return promptTextStyle.Render(line) })
 		return 1
 	}
 	var blocks []transcriptBlock
@@ -125,11 +158,15 @@ func renderTranscriptAssistant(out *strings.Builder, content json.RawMessage) in
 			if text == "" {
 				continue
 			}
-			out.WriteString("\n⏺ " + indentContinuations(text, "  ") + "\n")
+			out.WriteString("\n")
+			writeEntry(out, replyMarkStyle.Render("⏺ "), text, prosepainter())
 			entries++
 		case "tool_use":
-			out.WriteString("\n⏺ " + block.Name +
-				"(" + transcriptToolArgument(block.Input) + ")\n")
+			out.WriteString("\n" +
+				toolMarkStyle.Render("⏺ ") +
+				toolNameStyle.Render(block.Name) +
+				toolArgStyle.Render("("+transcriptToolArgument(block.Input)+")") +
+				"\n")
 			entries++
 		}
 	}
@@ -183,16 +220,85 @@ func trimTranscriptResult(result string) string {
 		if index == 0 {
 			prefix = "  ⎿ "
 		}
-		out.WriteString(prefix + transcriptEllipsis(line, 200) + "\n")
+		out.WriteString(resultStyle.Render(prefix+transcriptEllipsis(line, 200)) + "\n")
 	}
 	if hidden := len(lines) - len(shown); hidden > 0 {
-		out.WriteString(fmt.Sprintf("    … +%d lines\n", hidden))
+		out.WriteString(resultStyle.Render(
+			fmt.Sprintf("    … +%d lines", hidden)) + "\n")
 	}
 	return out.String()
 }
 
-func indentContinuations(text, indent string) string {
-	return strings.ReplaceAll(text, "\n", "\n"+indent)
+// writeEntry writes one conversation entry: marker then first line, with
+// continuations indented under it. paint styles each source line on its own
+// so every rendered row carries — and closes — its own styling, which is
+// what the transcript pane needs to wrap and highlight rows independently.
+func writeEntry(
+	out *strings.Builder,
+	marker, text string,
+	paint func(string) string,
+) {
+	for index, line := range strings.Split(text, "\n") {
+		prefix := "  "
+		if index == 0 {
+			prefix = marker
+		}
+		out.WriteString(prefix + paint(line) + "\n")
+	}
+}
+
+// prosepainter returns a painter for one assistant message. Claude writes
+// markdown, so the renderer reads it back: fenced blocks and inline literals
+// take the code tint, headings the accent, ** spans go bold. Delimiters are
+// dropped — they were instructions to a renderer, and this is the renderer.
+// The closure holds the fence state, which spans lines.
+func prosepainter() func(string) string {
+	fenced := false
+	return func(line string) string {
+		if strings.HasPrefix(strings.TrimSpace(line), "```") {
+			fenced = !fenced
+			return codeStyle.Render(line)
+		}
+		if fenced {
+			return codeStyle.Render(line)
+		}
+		return styleProse(line)
+	}
+}
+
+func styleProse(line string) string {
+	trimmed := strings.TrimLeft(line, " ")
+	if heading := strings.TrimLeft(trimmed, "#"); heading != trimmed {
+		indent := line[:len(line)-len(trimmed)]
+		return indent + headingStyle.Render(strings.TrimSpace(heading))
+	}
+	return styleInline(line)
+}
+
+// styleInline paints `literals` and **emphasis** inside a single line.
+// Unclosed delimiters are left as written: a lone backtick is punctuation.
+func styleInline(line string) string {
+	var out strings.Builder
+	for index := 0; index < len(line); {
+		rest := line[index:]
+		switch {
+		case strings.HasPrefix(rest, "**"):
+			if end := strings.Index(rest[2:], "**"); end > 0 {
+				out.WriteString(boldStyle.Render(rest[2 : 2+end]))
+				index += end + 4
+				continue
+			}
+		case rest[0] == '`':
+			if end := strings.IndexByte(rest[1:], '`'); end > 0 {
+				out.WriteString(codeStyle.Render(rest[1 : 1+end]))
+				index += end + 2
+				continue
+			}
+		}
+		out.WriteByte(line[index])
+		index++
+	}
+	return out.String()
 }
 
 func transcriptEllipsis(value string, limit int) string {

--- a/internal/provider/transcript_test.go
+++ b/internal/provider/transcript_test.go
@@ -5,7 +5,20 @@ import (
 	"path/filepath"
 	"strings"
 	"testing"
+
+	"github.com/charmbracelet/lipgloss"
+	"github.com/charmbracelet/x/ansi"
+	"github.com/muesli/termenv"
 )
+
+// withColor forces a color profile for the default renderer: tests run
+// without a terminal, where lipgloss renders everything plain.
+func withColor(t *testing.T) {
+	t.Helper()
+	previous := lipgloss.ColorProfile()
+	lipgloss.SetColorProfile(termenv.TrueColor)
+	t.Cleanup(func() { lipgloss.SetColorProfile(previous) })
+}
 
 func TestRenderClaudeTranscriptRendersConversation(t *testing.T) {
 	path := filepath.Join(t.TempDir(), "session.jsonl")
@@ -25,10 +38,11 @@ func TestRenderClaudeTranscriptRendersConversation(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	rendered, ok := RenderClaudeTranscript(path)
+	styled, ok := RenderClaudeTranscript(path)
 	if !ok {
 		t.Fatal("transcript was not rendered")
 	}
+	rendered := ansi.Strip(styled)
 	for _, want := range []string{
 		"❯ fix the parser\n  please",
 		"⏺ Looking at the parser now.",
@@ -44,6 +58,54 @@ func TestRenderClaudeTranscriptRendersConversation(t *testing.T) {
 	}
 	if strings.Contains(rendered, "meta noise") || strings.Contains(rendered, "hmm") {
 		t.Fatalf("meta or thinking content leaked:\n%s", rendered)
+	}
+}
+
+func TestRenderClaudeTranscriptPaintsConversation(t *testing.T) {
+	withColor(t)
+	path := filepath.Join(t.TempDir(), "session.jsonl")
+	lines := []string{
+		`{"type":"user","message":{"role":"user","content":"fix the parser"}}`,
+		`{"type":"assistant","message":{"content":[` +
+			`{"type":"text","text":"## Plan\nCall ` + "`parse()`" +
+			` and make it **fast**.\n` + "```go\\nx := 1\\n```" + `"},` +
+			`{"type":"tool_use","name":"Bash","input":{"command":"go test ./..."}}]}}`,
+		`{"type":"user","message":{"content":[{"type":"tool_result",` +
+			`"content":"ok"}]}}`,
+	}
+	if err := os.WriteFile(path, []byte(strings.Join(lines, "\n")+"\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	rendered, ok := RenderClaudeTranscript(path)
+	if !ok {
+		t.Fatal("transcript was not rendered")
+	}
+	byText := map[string]string{}
+	for _, line := range strings.Split(rendered, "\n") {
+		byText[strings.TrimSpace(ansi.Strip(line))] = line
+	}
+	for _, want := range []struct{ text, styled string }{
+		{"❯ fix the parser", promptMarkStyle.Render("❯ ")},
+		{"⏺ Plan", headingStyle.Render("Plan")},
+		{"Call parse() and make it fast.", codeStyle.Render("parse()")},
+		{"Call parse() and make it fast.", boldStyle.Render("fast")},
+		{"x := 1", codeStyle.Render("x := 1")},
+		{"⏺ Bash(go test ./...)", toolNameStyle.Render("Bash")},
+		{"⎿ ok", resultStyle.Render("  ⎿ ok")},
+	} {
+		line, ok := byText[want.text]
+		if !ok {
+			t.Fatalf("missing line %q in:\n%q", want.text, rendered)
+		}
+		if !strings.Contains(line, want.styled) {
+			t.Fatalf("line %q is unpainted: %q, want %q",
+				want.text, line, want.styled)
+		}
+	}
+	// Markdown delimiters were instructions to a renderer, not content.
+	if strings.Contains(ansi.Strip(rendered), "**") {
+		t.Fatalf("emphasis delimiters survived:\n%s", ansi.Strip(rendered))
 	}
 }
 

--- a/internal/theme/theme.go
+++ b/internal/theme/theme.go
@@ -1,0 +1,27 @@
+// Package theme holds Stormlight's palette.
+//
+// The colors live here rather than inside internal/ui because the Claude
+// transcript renderer paints its own output: only the renderer knows which
+// run of text is a prompt, a tool call, or a trimmed result, and rebuilding
+// that structure downstream from markers would be guesswork.
+package theme
+
+import "github.com/charmbracelet/lipgloss"
+
+var (
+	Accent       = lipgloss.Color("#62AEEF")
+	Text         = lipgloss.AdaptiveColor{Light: "#24323A", Dark: "#D7DEE5"}
+	Muted        = lipgloss.AdaptiveColor{Light: "#70808A", Dark: "#74818B"}
+	Working      = lipgloss.AdaptiveColor{Light: "#26799D", Dark: "#61AFEF"}
+	Waiting      = lipgloss.AdaptiveColor{Light: "#A86600", Dark: "#E5C07B"}
+	Done         = lipgloss.AdaptiveColor{Light: "#257A4A", Dark: "#72C087"}
+	Failed       = lipgloss.AdaptiveColor{Light: "#B33838", Dark: "#E06C75"}
+	Border       = lipgloss.AdaptiveColor{Light: "#AAB3B9", Dark: "#59636B"}
+	Select       = lipgloss.AdaptiveColor{Light: "#E1E4E6", Dark: "#3D4245"}
+	SelectedText = lipgloss.AdaptiveColor{Light: "#172027", Dark: "#F3F5F6"}
+	DangerBg     = lipgloss.AdaptiveColor{Light: "#F2D5D1", Dark: "#552B29"}
+	// Code tints literals and fenced blocks in rendered transcripts — a
+	// teal drawn from the wordmark's cool end so code reads as a different
+	// substance than prose without competing with the status colors.
+	Code = lipgloss.AdaptiveColor{Light: "#0E7C6B", Dark: "#8FDCCB"}
+)

--- a/internal/ui/input_test.go
+++ b/internal/ui/input_test.go
@@ -126,8 +126,10 @@ func TestCleanInteractionPreservesColorAndFocusesConversation(t *testing.T) {
 	if !strings.Contains(got, "\x1b[") {
 		t.Fatalf("ANSI styling was removed: %q", got)
 	}
-	if !strings.Contains(got, "❯ hello\x1b[0m\x1b[m\n\n") {
-		t.Fatalf("prompt style was not reset before the blank line: %q", got)
+	for index, row := range strings.Split(got, "\n") {
+		if left := activeSGR(row); left != "" {
+			t.Fatalf("row %d leaves styling open (%q): %q", index, left, row)
+		}
 	}
 	if strings.Contains(plain, "Welcome back") ||
 		strings.Contains(plain, "Usage policy") ||
@@ -137,6 +139,23 @@ func TestCleanInteractionPreservesColorAndFocusesConversation(t *testing.T) {
 	if !strings.Contains(plain, "❯ hello") ||
 		!strings.Contains(plain, "Hello! How can I help?") {
 		t.Fatalf("conversation content was lost:\n%s", plain)
+	}
+}
+
+func TestCleanInteractionCarriesStyleAcrossWrappedRows(t *testing.T) {
+	content := "\x1b[36m" + strings.Repeat("word ", 12) + "\x1b[0m"
+
+	rows := strings.Split(cleanInteraction(content, 20, agent.Provider("custom")), "\n")
+	if len(rows) < 3 {
+		t.Fatalf("line did not wrap into enough rows: %q", rows)
+	}
+	for index, row := range rows {
+		if !strings.HasPrefix(row, "\x1b[36m") {
+			t.Fatalf("row %d lost the color it continues: %q", index, row)
+		}
+		if left := activeSGR(row); left != "" {
+			t.Fatalf("row %d leaves styling open (%q): %q", index, left, row)
+		}
 	}
 }
 

--- a/internal/ui/spanreed.go
+++ b/internal/ui/spanreed.go
@@ -145,15 +145,21 @@ func cleanInteraction(content string, width int, providerID agent.Provider) stri
 			wrapped = wrapTranscriptLine(line, width)
 		}
 		wrappedLines := strings.Split(wrapped, "\n")
-		for index, wrappedLine := range wrappedLines {
-			wrappedLine = trimANSIRight(wrappedLine)
+		// Wrapping cuts a styled run in half: the opening SGR sits on the
+		// first row and the reset on the last. Every row is reopened with
+		// the styling still in effect and closed again, because each row is
+		// laid beside another pane — an unterminated color would run into
+		// the neighbor, and a row that never reopened would lose its color.
+		carried := ""
+		for _, wrappedLine := range wrappedLines {
+			wrappedLine = trimANSIRight(carried + wrappedLine)
 			blank := strings.TrimSpace(ansi.Strip(wrappedLine)) == ""
+			carried = activeSGR(wrappedLine)
+			if carried != "" {
+				wrappedLine += ansi.ResetStyle
+			}
 			if blank && previousBlank {
 				continue
-			}
-			if !blank && index == len(wrappedLines)-1 &&
-				strings.Contains(line, "\x1b[") {
-				wrappedLine += ansi.ResetStyle
 			}
 			compacted = append(compacted, wrappedLine)
 			previousBlank = blank
@@ -250,6 +256,53 @@ func isSGRSequence(sequence string) bool {
 	return len(sequence) >= 3 &&
 		strings.HasPrefix(sequence, "\x1b[") &&
 		strings.HasSuffix(sequence, "m")
+}
+
+// activeSGR returns the styling a line leaves switched on: every SGR
+// sequence since the last reset, in order, ready to be replayed at the head
+// of the row that continues it.
+func activeSGR(line string) string {
+	var active []string
+	var state byte
+	for len(line) > 0 {
+		sequence, _, consumed, next := ansi.DecodeSequence(line, state, nil)
+		if consumed <= 0 {
+			break
+		}
+		if isSGRSequence(sequence) {
+			if opensWithReset(sequence) {
+				active = active[:0]
+			}
+			if !isResetSGR(sequence) {
+				active = append(active, sequence)
+			}
+		}
+		line = line[consumed:]
+		state = next
+	}
+	return strings.Join(active, "")
+}
+
+// sgrParameters returns an SGR sequence's parameters: "\x1b[1;31m" → 1, 31.
+// A bare "\x1b[m" is the implicit reset, so it yields one empty parameter.
+func sgrParameters(sequence string) []string {
+	return strings.Split(sequence[2:len(sequence)-1], ";")
+}
+
+// opensWithReset reports whether a sequence starts by clearing all styling,
+// which "\x1b[0;31m" does before setting red.
+func opensWithReset(sequence string) bool {
+	first := sgrParameters(sequence)[0]
+	return first == "" || strings.TrimLeft(first, "0") == ""
+}
+
+func isResetSGR(sequence string) bool {
+	for _, parameter := range sgrParameters(sequence) {
+		if parameter != "" && strings.TrimLeft(parameter, "0") != "" {
+			return false
+		}
+	}
+	return true
 }
 
 func focusConversation(lines []string, providerID agent.Provider) []string {

--- a/internal/ui/styles.go
+++ b/internal/ui/styles.go
@@ -9,20 +9,23 @@ import (
 	"strings"
 
 	"github.com/charmbracelet/lipgloss"
+	"github.com/trentkm/stormlight/internal/theme"
 )
 
+// The palette lives in internal/theme so the transcript renderer can paint
+// with the same colors; these are the names the dashboard reads by.
 var (
-	colorAccent       = lipgloss.Color("#62AEEF")
-	colorText         = lipgloss.AdaptiveColor{Light: "#24323A", Dark: "#D7DEE5"}
-	colorMuted        = lipgloss.AdaptiveColor{Light: "#70808A", Dark: "#74818B"}
-	colorWorking      = lipgloss.AdaptiveColor{Light: "#26799D", Dark: "#61AFEF"}
-	colorWaiting      = lipgloss.AdaptiveColor{Light: "#A86600", Dark: "#E5C07B"}
-	colorDone         = lipgloss.AdaptiveColor{Light: "#257A4A", Dark: "#72C087"}
-	colorFailed       = lipgloss.AdaptiveColor{Light: "#B33838", Dark: "#E06C75"}
-	colorBorder       = lipgloss.AdaptiveColor{Light: "#AAB3B9", Dark: "#59636B"}
-	colorSelect       = lipgloss.AdaptiveColor{Light: "#E1E4E6", Dark: "#3D4245"}
-	colorSelectedText = lipgloss.AdaptiveColor{Light: "#172027", Dark: "#F3F5F6"}
-	colorDangerBg     = lipgloss.AdaptiveColor{Light: "#F2D5D1", Dark: "#552B29"}
+	colorAccent       = theme.Accent
+	colorText         = theme.Text
+	colorMuted        = theme.Muted
+	colorWorking      = theme.Working
+	colorWaiting      = theme.Waiting
+	colorDone         = theme.Done
+	colorFailed       = theme.Failed
+	colorBorder       = theme.Border
+	colorSelect       = theme.Select
+	colorSelectedText = theme.SelectedText
+	colorDangerBg     = theme.DangerBg
 
 	titleStyle = lipgloss.NewStyle().Bold(true).Foreground(colorText)
 	// attentionBandStyle is the unmissable full-width bar for an agent


### PR DESCRIPTION
Reading a session from Claude's own transcript file is what buys Spanreed
the entire history — the agent runs on the alternate screen, so tmux never
accumulates scrollback for it. But that file carries no styling, so the pane
went from a colored terminal capture to a gray slab the moment history
kicked in. The scroll was worth having; the trade was not.

## Color where the structure is known

`internal/provider/transcript.go` is the only place that knows which run of
text is a prompt, a reply, a tool call, or a trimmed result — so it paints
them there, rather than having the UI reconstruct that from markers it just
finished flattening:

- `❯` accent, prompt text bold — user turns are what you scan for.
- `⏺` green for assistant prose; `⏺` blue for a tool call, with the tool
  name bold and its argument muted.
- `⎿` results and the `… +N lines` note dim, the way a result should read.

Claude writes markdown into that file, so the renderer reads it back:
headings take the accent, `` `literals` `` and fenced blocks a teal, `**spans**`
go bold. The delimiters are dropped — they were instructions to a renderer,
and this is the renderer.

The palette moves to `internal/theme` so the renderer and the dashboard
light from one source; `internal/ui` keeps its `colorAccent`-style names as
aliases over it.

## Wrapping had to learn the same trick

`ansi.Wrap` leaves a split style's opening SGR on the first row and its
reset on the last. Two consequences, both live before this change and both
made obvious by having more color to lose: continuation rows dropped their
styling, and the first row's color ran off the end into the pane next door,
since every transcript row is laid beside another column. `cleanInteraction`
now replays the styling in effect at the head of every continuation row and
closes it at the row's end. The tmux capture path benefits equally.

## Verification

Beyond the unit tests, this was checked against real bytes, per
CLAUDE.md:

- A full 10,460-row session rendered through `provider` →
  `cleanInteraction` leaves **0** rows with styling still open.
- The dashboard was then run headless on a scratch tmux socket against that
  same transcript, and `capture-pane -e` confirms the green `⏺`, teal
  literals, blue `❯`, and muted `⎿` reach the screen — and survive the
  inactive-pane dim, which composes with them as designed.

`docs/architecture.md` is updated; it claimed transcript rendering retains
only SGR from tmux capture output, which is no longer the whole story.

`go build ./...`, `go vet ./...`, and `go test ./...` are green on this
branch. `github.com/muesli/termenv` moves from indirect to direct: it is
already in the build via lipgloss, and one test names it to force a color
profile, since tests run without a TTY and would otherwise assert against
deliberately unpainted output.