### PR TITLE
Name the worktree in the Spanreed heading

### DIFF
--- a/README.md
+++ b/README.md
@@ -228,7 +228,10 @@ output remains unfiltered.
 
 Stormlight resolves working directories automatically. Linked Git worktrees share
 one workspace group, while each worktree remains a distinct execution root.
-Independent clones and non-Git directories remain separate.
+Independent clones and non-Git directories remain separate. Because a grouped
+workspace can hold several checkouts, the Spanreed heading names the worktree
+an agent is working in — `worktree fix-auth` beside its provider and state —
+and stays silent for agents in the main checkout.
 
 Press `n` in the Workspaces pane to open the Add Workspace modal. Yazi and
 manual path entry are the only actions; current workspaces appear below as

--- a/internal/ui/input_test.go
+++ b/internal/ui/input_test.go
@@ -1591,6 +1591,69 @@ func TestInteractionHidesPreviousAgentTranscript(t *testing.T) {
 	}
 }
 
+func TestInteractionHeadingNamesTheWorktree(t *testing.T) {
+	checkout := workspace.Context{
+		ID:            "git:/repo/.git",
+		Kind:          workspace.KindGit,
+		Name:          "repo",
+		Root:          "/repo",
+		ExecutionRoot: "/repo",
+	}
+	worktree := checkout
+	worktree.ExecutionRoot = "/repo/.claude/worktrees/fix-auth"
+
+	model := NewModel(stubBackend{})
+	model.catalogWorkspaces = []workspace.Context{checkout}
+	model.agents = []agent.Agent{
+		{ID: "main", Name: "main", Cwd: "/repo", Workspace: checkout},
+		{
+			ID:        "linked",
+			Name:      "linked",
+			Cwd:       "/repo/.claude/worktrees/fix-auth",
+			Workspace: worktree,
+		},
+	}
+
+	model.rebuildGroups(checkout.ID, "linked")
+	model.interactionID = "linked"
+	rendered := ansi.Strip(model.renderInteraction(80, 20))
+	if !strings.Contains(rendered, "worktree fix-auth") {
+		t.Fatalf("heading hides the worktree:\n%s", rendered)
+	}
+
+	model.rebuildGroups(checkout.ID, "main")
+	model.interactionID = "main"
+	rendered = ansi.Strip(model.renderInteraction(80, 20))
+	if strings.Contains(rendered, "worktree") {
+		t.Fatalf("main checkout claims a worktree:\n%s", rendered)
+	}
+}
+
+// A narrow pane drops the path before the badge: the path restates the
+// worktree, the badge is the only token that names it.
+func TestInteractionMetaKeepsWorktreeOverPath(t *testing.T) {
+	wide := ansi.Strip(interactionMeta(
+		"claude  working", "fix-auth", "~/repo/.claude/worktrees/fix-auth", 80,
+	))
+	if !strings.Contains(wide, "worktree fix-auth") ||
+		!strings.Contains(wide, "~/repo") {
+		t.Fatalf("wide meta line lost a token: %q", wide)
+	}
+
+	narrow := ansi.Strip(interactionMeta(
+		"claude  working", "fix-auth", "~/repo/.claude/worktrees/fix-auth", 34,
+	))
+	if !strings.Contains(narrow, "worktree fix-auth") {
+		t.Fatalf("narrow meta line dropped the worktree: %q", narrow)
+	}
+	if strings.Contains(narrow, "~/repo") {
+		t.Fatalf("narrow meta line kept the path: %q", narrow)
+	}
+	if width := ansi.StringWidth(narrow); width > 34 {
+		t.Fatalf("meta line overflows the pane: %d columns in %q", width, narrow)
+	}
+}
+
 func TestInteractionRefreshPreservesScrollPosition(t *testing.T) {
 	workspaceContext := workspace.DirectoryContext("/workspace")
 	model := NewModel(stubBackend{})

--- a/internal/ui/spanreed.go
+++ b/internal/ui/spanreed.go
@@ -35,9 +35,12 @@ func (m Model) renderInteraction(width, height int) string {
 	if badge := modeBadge(managedAgent.Mode); badge != "" {
 		metaParts = append(metaParts, badge)
 	}
-	metaParts = append(metaParts, shortPath(managedAgent.Cwd))
-	metaText := strings.TrimSpace(strings.Join(metaParts, "  "))
-	meta := mutedStyle.Render(truncate(metaText, width))
+	meta := interactionMeta(
+		strings.Join(metaParts, "  "),
+		worktreeLabel(managedAgent),
+		shortPath(managedAgent.Cwd),
+		width,
+	)
 	if managedAgent.ProcessLive && managedAgent.Attention.Urgent() {
 		// Prompts are answered in the agent's own terminal; the dashboard's
 		// job is pointing at the pane, loudly.
@@ -126,6 +129,34 @@ func (m Model) renderInteraction(width, height int) string {
 		transcript,
 		composer,
 	)
+}
+
+// interactionMeta renders the heading's subtitle. In the main checkout it is
+// one muted line — status tokens then path — truncated as a whole. In a
+// linked worktree the tree's name is set in accent between the two: a path
+// alone never says which of a workspace's checkouts an agent is editing, so
+// the badge is the last token to yield width, and the path — which merely
+// restates it — is the first.
+func interactionMeta(status, worktree, path string, width int) string {
+	if worktree == "" {
+		return mutedStyle.Render(
+			truncate(strings.TrimSpace(status+"  "+path), width),
+		)
+	}
+	rendered := mutedStyle.Render(truncate(status, width))
+	badge := truncate(
+		"worktree "+worktree,
+		max(0, width-lipgloss.Width(rendered)-2),
+	)
+	if badge == "" {
+		return rendered
+	}
+	rendered += "  " + accentStyle.Render(badge)
+	remaining := width - lipgloss.Width(rendered) - 2
+	if path != "" && remaining > 0 {
+		rendered += "  " + mutedStyle.Render(truncate(path, remaining))
+	}
+	return rendered
 }
 
 func cleanInteraction(content string, width int, providerID agent.Provider) string {

--- a/internal/ui/state.go
+++ b/internal/ui/state.go
@@ -227,6 +227,22 @@ func effectiveWorkspace(managedAgent agent.Agent) workspace.Context {
 	return value
 }
 
+// worktreeLabel names the linked Git worktree an agent runs in, and is empty
+// when the agent works the main checkout or isn't in Git at all. Linked
+// worktrees share a --git-common-dir with their checkout, so the resolver
+// files them under one workspace: Root is the checkout every worktree hangs
+// off, ExecutionRoot the tree this agent actually edits.
+func worktreeLabel(managedAgent agent.Agent) string {
+	value := effectiveWorkspace(managedAgent)
+	if value.Kind != workspace.KindGit || value.ExecutionRoot == "" {
+		return ""
+	}
+	if directoryKey(value.ExecutionRoot) == directoryKey(value.Root) {
+		return ""
+	}
+	return filepath.Base(value.ExecutionRoot)
+}
+
 func (m *Model) moveSelection(delta int) {
 	m.moveSelectionIn(m.activePane, delta)
 }


### PR DESCRIPTION
Linked worktrees share a workspace group, so one workspace can hold several checkouts and the Spanreed heading's path was the only thing telling them apart — the token that truncates first when the pane is narrow.

The meta line now sets the worktree's name in accent between the status tokens and the path:

```
fake working AUTO  worktree spanreed-worktree-badge  /Volumes/repos/stormlight/.…
```

Agents in the main checkout are unchanged. The worktree is read off the workspace the resolver already built (a git workspace whose execution root differs from its root), so no extra git spawns in the render path. Verified end-to-end against a live dashboard with one agent per checkout; unit tests cover the badge, its absence, and width priority.

Fixes #41