### PR TITLE
Let Enter and Tab reach the optional agent name

### DIFF
--- a/internal/ui/chrome.go
+++ b/internal/ui/chrome.go
@@ -134,21 +134,20 @@ func (m Model) commandHints() string {
 	case modeDispatch:
 		switch m.formFocus {
 		case dispatchProvider:
-			hints := "j/k choose  Enter task"
-			if m.chooseDispatchDirectory {
-				hints = "j/k choose  Enter location"
-			}
-			hints += "  m mode"
+			hints := "j/k choose  Enter " + m.nextDispatchField() + "  m mode"
 			if m.nvimPath != "" {
 				hints += "  e Neovim"
 			}
 			return hints + "  Esc cancel"
 		case dispatchDirectory:
-			return "j/k location  Enter choose  m mode  e edit path  Esc cancel"
+			return "j/k location  Enter " + m.nextDispatchField() +
+				"  m mode  e edit path  Esc cancel"
 		case dispatchCustomPath:
-			return "type to filter  Enter choose  ↑/↓ pick  Backspace up  Esc cancel"
+			return "Enter choose  ↑/↓ pick  Backspace up  Tab " +
+				m.nextDispatchField() + "  Esc cancel"
 		case dispatchName:
-			return "name this agent  Enter task  Tab fields  Esc cancel"
+			return "name this agent  Enter " + m.nextDispatchField() +
+				"  Tab fields  Esc cancel"
 		default:
 			hints := "Enter launch"
 			if m.nvimPath != "" {

--- a/internal/ui/dispatch.go
+++ b/internal/ui/dispatch.go
@@ -32,14 +32,17 @@ func (m Model) updateDispatch(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 	}
 	m.dispatchPrefix = ""
 
+	// The picker owns almost every key while it has focus, but not Tab:
+	// Tab is the form's field cycle, and a picker that swallows it strands
+	// the fields below with no way forward. ↑/↓ and Ctrl-n/p move the
+	// highlight instead.
 	if m.formFocus == dispatchCustomPath &&
 		key != "esc" && key != "ctrl+c" && key != "ctrl+[" &&
-		key != "ctrl+s" && key != "shift+tab" {
+		key != "ctrl+s" && key != "tab" && key != "shift+tab" {
 		if confirmed := m.handlePathNavKey(msg); confirmed {
 			m.cwdInput.SetValue(m.pathNav.chosen())
 			m.pickerStart = m.pathNav.chosen()
-			m.formFocus = dispatchTask
-			m.focusForm()
+			m.moveDispatchFocus(1)
 		}
 		return m, nil
 	}
@@ -118,20 +121,17 @@ func (m Model) updateDispatch(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 			return m, nil
 		}
 	case "enter":
+		// Enter advances one step through the form's own field order, so it
+		// can never skip a field Tab would stop on — the optional name row
+		// used to fall in exactly that gap.
 		switch m.formFocus {
-		case dispatchProvider:
-			if m.chooseDispatchDirectory {
-				m.formFocus = dispatchDirectory
-			} else {
-				m.formFocus = dispatchTask
-			}
-			m.focusForm()
+		case dispatchProvider, dispatchName:
+			m.moveDispatchFocus(1)
 			return m, nil
 		case dispatchDirectory:
 			selected, ok := m.selectedDirectory()
 			if !ok {
-				m.formFocus = dispatchTask
-				m.focusForm()
+				m.moveDispatchFocus(1)
 				return m, nil
 			}
 			switch selected.kind {
@@ -140,14 +140,10 @@ func (m Model) updateDispatch(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 			case directoryCustom:
 				m.formFocus = dispatchCustomPath
 				m.startPathNav()
+				m.focusForm()
 			default:
-				m.formFocus = dispatchTask
+				m.moveDispatchFocus(1)
 			}
-			m.focusForm()
-			return m, nil
-		case dispatchName:
-			m.formFocus = dispatchTask
-			m.focusForm()
 			return m, nil
 		case dispatchTask:
 			return m.submitDispatch()
@@ -703,7 +699,7 @@ func (m *Model) startPathNav() {
 // chose a directory (available via pathNav.chosen()).
 func (m *Model) handlePathNavKey(msg tea.KeyMsg) bool {
 	switch msg.String() {
-	case "tab", "down", "ctrl+n":
+	case "down", "ctrl+n":
 		m.pathNav.moveHighlight(1)
 		return false
 	case "up", "ctrl+p":
@@ -912,8 +908,12 @@ func (m Model) dispatchFocusOrder() []dispatchFocus {
 	focuses := []dispatchFocus{dispatchProvider}
 	if m.chooseDispatchDirectory {
 		focuses = append(focuses, dispatchDirectory)
-		if selected, ok := m.selectedDirectory(); ok &&
-			selected.kind == directoryCustom {
+		// The field holding focus is always part of the order, even if the
+		// directory row that opened it has since gone away — otherwise a
+		// move from it has no anchor and silently restarts at the top.
+		if selected, ok := m.selectedDirectory(); (ok &&
+			selected.kind == directoryCustom) ||
+			m.formFocus == dispatchCustomPath {
 			focuses = append(focuses, dispatchCustomPath)
 		}
 	}
@@ -921,6 +921,32 @@ func (m Model) dispatchFocusOrder() []dispatchFocus {
 		focuses = append(focuses, dispatchName)
 	}
 	return append(focuses, dispatchTask)
+}
+
+// nextDispatchField names the field Enter and Tab move to from here. The
+// hints quote it, so what the footer promises and where focus lands come
+// from the same order.
+func (m Model) nextDispatchField() string {
+	focuses := m.dispatchFocusOrder()
+	current := 0
+	for index, focus := range focuses {
+		if focus == m.formFocus {
+			current = index
+			break
+		}
+	}
+	switch focuses[(current+1)%len(focuses)] {
+	case dispatchProvider:
+		return "agent"
+	case dispatchDirectory:
+		return "location"
+	case dispatchCustomPath:
+		return "path"
+	case dispatchName:
+		return "name"
+	default:
+		return "task"
+	}
 }
 
 func (m *Model) moveDispatchFocus(delta int) {

--- a/internal/ui/flows_test.go
+++ b/internal/ui/flows_test.go
@@ -404,3 +404,82 @@ func TestComposerRuleAndVisibleRows(t *testing.T) {
 		t.Fatalf("visible rows = %d", rows)
 	}
 }
+
+// dispatchFixture opens the new-agent form on a terminal roomy enough to
+// draw the optional name row.
+func dispatchFixture(t *testing.T) Model {
+	t.Helper()
+	model := flowModelFixture(t, &flowBackend{})
+	updated, _ := model.Update(tea.WindowSizeMsg{Width: 120, Height: 40})
+	model = updated.(Model)
+	next, _ := model.beginDispatch(true)
+	model = next.(Model)
+	if !model.dispatchNameVisible() {
+		t.Fatal("fixture terminal is too short to draw the name row")
+	}
+	return model
+}
+
+func selectCustomDirectory(t *testing.T, model *Model) {
+	t.Helper()
+	for index := range model.directories {
+		if model.directories[index].kind == directoryCustom {
+			model.selectDirectoryIndex(index)
+			return
+		}
+	}
+	t.Fatal("no custom-path row in the directory choices")
+}
+
+func TestDispatchEnterReachesTheNameField(t *testing.T) {
+	model := dispatchFixture(t)
+	for _, want := range []dispatchFocus{dispatchName, dispatchTask} {
+		next, _ := model.updateDispatch(tea.KeyMsg{Type: tea.KeyEnter})
+		model = next.(Model)
+		if model.formFocus != want {
+			t.Fatalf("enter landed on focus %d, want %d", model.formFocus, want)
+		}
+	}
+}
+
+func TestDispatchTabEscapesThePathPicker(t *testing.T) {
+	model := dispatchFixture(t)
+	selectCustomDirectory(t, &model)
+	next, _ := model.updateDispatch(tea.KeyMsg{Type: tea.KeyEnter})
+	model = next.(Model)
+	if model.formFocus != dispatchCustomPath {
+		t.Fatalf("enter did not open the path picker: focus %d", model.formFocus)
+	}
+	after, _ := model.updateDispatch(tea.KeyMsg{Type: tea.KeyTab})
+	model = after.(Model)
+	if model.formFocus != dispatchName {
+		t.Fatalf("tab out of the picker landed on %d, want name", model.formFocus)
+	}
+}
+
+func TestDispatchNameAcceptsTypedRunes(t *testing.T) {
+	model := dispatchFixture(t)
+	next, _ := model.updateDispatch(tea.KeyMsg{Type: tea.KeyEnter})
+	model = next.(Model)
+	for _, key := range []string{"m", "j", "e", "g"} {
+		updated, _ := model.updateDispatch(runeKey(key))
+		model = updated.(Model)
+	}
+	if model.nameInput.Value() != "mjeg" {
+		t.Fatalf("name field value = %q", model.nameInput.Value())
+	}
+}
+
+func TestDispatchHintsNameTheNextField(t *testing.T) {
+	model := dispatchFixture(t)
+	model.mode = modeDispatch
+	if hints := model.commandHints(); !strings.Contains(hints, "Enter name") {
+		t.Fatalf("directory hints hide the name field: %q", hints)
+	}
+	selectCustomDirectory(t, &model)
+	next, _ := model.updateDispatch(tea.KeyMsg{Type: tea.KeyEnter})
+	model = next.(Model)
+	if hints := model.commandHints(); !strings.Contains(hints, "Tab name") {
+		t.Fatalf("picker hints hide the way out: %q", hints)
+	}
+}

--- a/internal/ui/input_test.go
+++ b/internal/ui/input_test.go
@@ -444,7 +444,13 @@ func TestDispatchWithoutANameLaunchesUnnamed(t *testing.T) {
 	updated, _ = model.beginDispatch(false)
 	model = updated.(Model)
 
-	// Enter on the provider skips straight past the optional name.
+	// Enter stops on the optional name; leaving it blank is what makes the
+	// launch unnamed.
+	updated, _ = model.Update(tea.KeyMsg{Type: tea.KeyEnter})
+	model = updated.(Model)
+	if model.formFocus != dispatchName {
+		t.Fatalf("Enter focus = %v, want the name field", model.formFocus)
+	}
 	updated, _ = model.Update(tea.KeyMsg{Type: tea.KeyEnter})
 	model = updated.(Model)
 	if model.formFocus != dispatchTask {

--- a/internal/ui/pathnav_test.go
+++ b/internal/ui/pathnav_test.go
@@ -105,7 +105,7 @@ func TestPathNavRerootsUpAndByTypedPath(t *testing.T) {
 	}
 }
 
-func TestDispatchPathNavPicksIntoTask(t *testing.T) {
+func TestDispatchPathNavPicksIntoTheNextField(t *testing.T) {
 	root := pathNavFixture(t)
 	model := NewModel(stubBackend{})
 	model.width = 100
@@ -119,8 +119,9 @@ func TestDispatchPathNavPicksIntoTask(t *testing.T) {
 	model = updated.(Model)
 	updated, _ = model.updateDispatch(tea.KeyMsg{Type: tea.KeyEnter})
 	model = updated.(Model)
-	if model.formFocus != dispatchTask {
-		t.Fatalf("enter did not confirm; focus = %v", model.formFocus)
+	if model.formFocus != dispatchName {
+		t.Fatalf("enter did not confirm into the name field; focus = %v",
+			model.formFocus)
 	}
 	if got := strings.TrimSpace(model.cwdInput.Value()); got != filepath.Join(root, "services/payments") {
 		t.Fatalf("confirmed path = %q", got)


### PR DESCRIPTION
The Name field in the new-agent form was drawn but unreachable going
forward. Every advancing key routed around it:

- Enter on the provider → location (or task)
- Enter on a location row → task
- Enter confirming a typed path → task
- Tab inside the path picker → swallowed by the picker's highlight

Shift-Tab back from the composer was the only way in, and the footer only
advertised that once focus was already on the task.

## Changes

- **Enter advances one step through `dispatchFocusOrder`**, so it can't skip
  a stop Tab would make.
- **The path picker releases Tab.** ↑/↓ and Ctrl-n/p still move its
  highlight; Tab now cycles fields, so the rows below the picker are
  reachable.
- **The focus order always contains the field holding focus**, so a move
  from it has an anchor instead of restarting at the top.
- **The hints quote the next stop** from that same order, so what the footer
  promises and where focus lands can't drift apart.

## Verified

`go test ./...` passes, plus four new tests in `flows_test.go` pinning the
reported behavior. Also driven end-to-end against a headless tmux client:
Enter from the location row lands on Name, Tab out of the open picker lands
on Name, typing reaches the field, and the picker's ↓/Enter still work.

Two existing tests encoded the old skip-past-name behavior and were updated
to the new intent.

Filed #44 for a separate bug found along the way: the form overflows its
modal when the picker is open and the *task composer* is what gets clipped.