### PR TITLE
Name the primary checkout in the Spanreed heading

### DIFF
--- a/internal/ui/input_test.go
+++ b/internal/ui/input_test.go
@@ -1741,7 +1741,7 @@ func TestInteractionHidesPreviousAgentTranscript(t *testing.T) {
 	}
 }
 
-func TestInteractionHeadingNamesTheWorktree(t *testing.T) {
+func TestInteractionHeadingNamesTheCheckout(t *testing.T) {
 	checkout := workspace.Context{
 		ID:            "git:/repo/.git",
 		Kind:          workspace.KindGit,
@@ -1751,9 +1751,10 @@ func TestInteractionHeadingNamesTheWorktree(t *testing.T) {
 	}
 	worktree := checkout
 	worktree.ExecutionRoot = "/repo/.claude/worktrees/fix-auth"
+	loose := workspace.DirectoryContext("/scratch")
 
 	model := NewModel(stubBackend{})
-	model.catalogWorkspaces = []workspace.Context{checkout}
+	model.catalogWorkspaces = []workspace.Context{checkout, loose}
 	model.agents = []agent.Agent{
 		{ID: "main", Name: "main", Cwd: "/repo", Workspace: checkout},
 		{
@@ -1762,45 +1763,121 @@ func TestInteractionHeadingNamesTheWorktree(t *testing.T) {
 			Cwd:       "/repo/.claude/worktrees/fix-auth",
 			Workspace: worktree,
 		},
+		{ID: "loose", Name: "loose", Cwd: "/scratch", Workspace: loose},
 	}
 
-	model.rebuildGroups(checkout.ID, "linked")
-	model.interactionID = "linked"
-	rendered := ansi.Strip(model.renderInteraction(80, 20))
-	if !strings.Contains(rendered, "worktree fix-auth") {
-		t.Fatalf("heading hides the worktree:\n%s", rendered)
+	for _, testCase := range []struct {
+		name      string
+		workspace string
+		agent     string
+		want      string
+		absent    []string
+	}{
+		{
+			name:      "linked worktree wears its own name",
+			workspace: checkout.ID,
+			agent:     "linked",
+			want:      "worktree fix-auth",
+			absent:    []string{"main checkout"},
+		},
+		{
+			name:      "primary checkout says so",
+			workspace: checkout.ID,
+			agent:     "main",
+			want:      "main checkout",
+			absent:    []string{"worktree"},
+		},
+		{
+			name:      "outside git names no checkout",
+			workspace: loose.ID,
+			agent:     "loose",
+			absent:    []string{"worktree", "main checkout"},
+		},
+	} {
+		t.Run(testCase.name, func(t *testing.T) {
+			model.rebuildGroups(testCase.workspace, testCase.agent)
+			model.interactionID = testCase.agent
+			rendered := ansi.Strip(model.renderInteraction(80, 20))
+			if testCase.want != "" && !strings.Contains(rendered, testCase.want) {
+				t.Fatalf("heading hides %q:\n%s", testCase.want, rendered)
+			}
+			for _, absent := range testCase.absent {
+				if strings.Contains(rendered, absent) {
+					t.Fatalf("heading claims %q:\n%s", absent, rendered)
+				}
+			}
+		})
 	}
+}
 
-	model.rebuildGroups(checkout.ID, "main")
-	model.interactionID = "main"
-	rendered = ansi.Strip(model.renderInteraction(80, 20))
-	if strings.Contains(rendered, "worktree") {
-		t.Fatalf("main checkout claims a worktree:\n%s", rendered)
+// The accent marks the checkout worth picking out of several; the primary one
+// is stated, not flagged, because in most repositories it is simply where the
+// work happens.
+func TestCheckoutBadgeColors(t *testing.T) {
+	linked := checkoutStyle(checkoutBadge{text: "worktree fix-auth"})
+	if linked.GetForeground() != colorAccent {
+		t.Fatalf("linked worktree lost its accent: %v", linked.GetForeground())
+	}
+	primary := checkoutStyle(checkoutBadge{text: "main checkout", primary: true})
+	if primary.GetForeground() != colorMuted {
+		t.Fatalf("primary checkout is not muted: %v", primary.GetForeground())
 	}
 }
 
 // A narrow pane drops the path before the badge: the path restates the
-// worktree, the badge is the only token that names it.
-func TestInteractionMetaKeepsWorktreeOverPath(t *testing.T) {
-	wide := ansi.Strip(interactionMeta(
-		"claude  working", "fix-auth", "~/repo/.claude/worktrees/fix-auth", 80,
-	))
-	if !strings.Contains(wide, "worktree fix-auth") ||
-		!strings.Contains(wide, "~/repo") {
-		t.Fatalf("wide meta line lost a token: %q", wide)
-	}
+// checkout, the badge is the only token that names it.
+func TestInteractionMetaKeepsCheckoutOverPath(t *testing.T) {
+	for _, testCase := range []struct {
+		name    string
+		badge   checkoutBadge
+		path    string
+		narrow  int
+		keeps   string
+		dropped string
+	}{
+		{
+			name:    "linked worktree",
+			badge:   checkoutBadge{text: "worktree fix-auth"},
+			path:    "~/repo/.claude/worktrees/fix-auth",
+			narrow:  34,
+			keeps:   "worktree fix-auth",
+			dropped: "~/repo",
+		},
+		{
+			name:    "primary checkout",
+			badge:   checkoutBadge{text: "main checkout", primary: true},
+			path:    "~/repos/stormlight",
+			narrow:  32,
+			keeps:   "main checkout",
+			dropped: "~/repos",
+		},
+	} {
+		t.Run(testCase.name, func(t *testing.T) {
+			wide := ansi.Strip(interactionMeta(
+				"claude  working", testCase.badge, testCase.path, 80,
+			))
+			if !strings.Contains(wide, testCase.keeps) ||
+				!strings.Contains(wide, testCase.dropped) {
+				t.Fatalf("wide meta line lost a token: %q", wide)
+			}
 
-	narrow := ansi.Strip(interactionMeta(
-		"claude  working", "fix-auth", "~/repo/.claude/worktrees/fix-auth", 34,
-	))
-	if !strings.Contains(narrow, "worktree fix-auth") {
-		t.Fatalf("narrow meta line dropped the worktree: %q", narrow)
-	}
-	if strings.Contains(narrow, "~/repo") {
-		t.Fatalf("narrow meta line kept the path: %q", narrow)
-	}
-	if width := ansi.StringWidth(narrow); width > 34 {
-		t.Fatalf("meta line overflows the pane: %d columns in %q", width, narrow)
+			narrow := ansi.Strip(interactionMeta(
+				"claude  working", testCase.badge, testCase.path, testCase.narrow,
+			))
+			if !strings.Contains(narrow, testCase.keeps) {
+				t.Fatalf("narrow meta line dropped the checkout: %q", narrow)
+			}
+			if strings.Contains(narrow, testCase.dropped) {
+				t.Fatalf("narrow meta line kept the path: %q", narrow)
+			}
+			if width := ansi.StringWidth(narrow); width > testCase.narrow {
+				t.Fatalf(
+					"meta line overflows the pane: %d columns in %q",
+					width,
+					narrow,
+				)
+			}
+		})
 	}
 }
 

--- a/internal/ui/spanreed.go
+++ b/internal/ui/spanreed.go
@@ -37,7 +37,7 @@ func (m Model) renderInteraction(width, height int) string {
 	}
 	meta := interactionMeta(
 		strings.Join(metaParts, "  "),
-		worktreeLabel(managedAgent),
+		agentCheckout(managedAgent),
 		shortPath(managedAgent.Cwd),
 		width,
 	)
@@ -131,32 +131,47 @@ func (m Model) renderInteraction(width, height int) string {
 	)
 }
 
-// interactionMeta renders the heading's subtitle. In the main checkout it is
-// one muted line — status tokens then path — truncated as a whole. In a
-// linked worktree the tree's name is set in accent between the two: a path
-// alone never says which of a workspace's checkouts an agent is editing, so
-// the badge is the last token to yield width, and the path — which merely
-// restates it — is the first.
-func interactionMeta(status, worktree, path string, width int) string {
-	if worktree == "" {
+// interactionMeta renders the heading's subtitle. Outside Git it is one muted
+// line — status tokens then path — truncated as a whole. In a Git workspace
+// the checkout is named between the two: a path alone never says which of a
+// workspace's checkouts an agent is editing, and saying nothing for the
+// primary one leaves the reader unable to tell an unbadged agent from a
+// dashboard that does not know. Either way the badge is the last token to
+// yield width, and the path — which merely restates it — is the first.
+func interactionMeta(status string, checkout checkoutBadge, path string, width int) string {
+	if checkout.text == "" {
 		return mutedStyle.Render(
 			truncate(strings.TrimSpace(status+"  "+path), width),
 		)
 	}
 	rendered := mutedStyle.Render(truncate(status, width))
 	badge := truncate(
-		"worktree "+worktree,
+		checkout.text,
 		max(0, width-lipgloss.Width(rendered)-2),
 	)
 	if badge == "" {
 		return rendered
 	}
-	rendered += "  " + accentStyle.Render(badge)
+	rendered += "  " + checkoutStyle(checkout).Render(badge)
 	remaining := width - lipgloss.Width(rendered) - 2
 	if path != "" && remaining > 0 {
 		rendered += "  " + mutedStyle.Render(truncate(path, remaining))
 	}
 	return rendered
+}
+
+// checkoutStyle picks the badge's color. A linked worktree is the tree worth
+// naming loudly, so it keeps the accent; the primary checkout is stated in
+// the muted tone the rest of the meta line uses, because in most repositories
+// working there is simply where the work happens. Only this repository asks
+// otherwise, and painting every workspace's normal case as a problem would be
+// the dashboard shouting a house rule at people who never agreed to it. The
+// alarm belongs to a per-workspace setting (#47); the fact belongs here.
+func checkoutStyle(checkout checkoutBadge) lipgloss.Style {
+	if checkout.primary {
+		return mutedStyle
+	}
+	return accentStyle
 }
 
 func cleanInteraction(content string, width int, providerID agent.Provider) string {

--- a/internal/ui/state.go
+++ b/internal/ui/state.go
@@ -227,20 +227,30 @@ func effectiveWorkspace(managedAgent agent.Agent) workspace.Context {
 	return value
 }
 
-// worktreeLabel names the linked Git worktree an agent runs in, and is empty
-// when the agent works the main checkout or isn't in Git at all. Linked
-// worktrees share a --git-common-dir with their checkout, so the resolver
-// files them under one workspace: Root is the checkout every worktree hangs
-// off, ExecutionRoot the tree this agent actually edits.
-func worktreeLabel(managedAgent agent.Agent) string {
+// checkoutBadge is the token naming the Git checkout an agent runs in, and
+// whether that checkout is the workspace's own rather than a worktree hanging
+// off it. An empty text means there is nothing to name.
+type checkoutBadge struct {
+	text    string
+	primary bool
+}
+
+// agentCheckout names the Git checkout an agent runs in. Linked worktrees
+// share a --git-common-dir with their checkout, so the resolver files them
+// under one workspace: Root is the checkout every worktree hangs off,
+// ExecutionRoot the tree this agent actually edits. A tree of its own is
+// named by that tree; landing on Root instead is the primary checkout, and it
+// is named too — every agent in a Git workspace gets a badge, so an absent
+// one means the agent is outside Git rather than merely unremarkable.
+func agentCheckout(managedAgent agent.Agent) checkoutBadge {
 	value := effectiveWorkspace(managedAgent)
 	if value.Kind != workspace.KindGit || value.ExecutionRoot == "" {
-		return ""
+		return checkoutBadge{}
 	}
 	if directoryKey(value.ExecutionRoot) == directoryKey(value.Root) {
-		return ""
+		return checkoutBadge{text: "main checkout", primary: true}
 	}
-	return filepath.Base(value.ExecutionRoot)
+	return checkoutBadge{text: "worktree " + filepath.Base(value.ExecutionRoot)}
 }
 
 func (m *Model) moveSelection(delta int) {


### PR DESCRIPTION
`worktreeLabel` said nothing when an agent's execution root was the
workspace root, so a blank meta line meant either "this agent is in the
main checkout" or "the dashboard has nothing to say about where it is."
Those are different facts and they rendered identically.

Every agent in a Git workspace now carries a checkout token: the tree's
name for a linked worktree, `main checkout` for the checkout those trees
hang off. An absent badge now means one thing only — the agent is outside
Git, or has no execution root.

The primary checkout's token is deliberately **muted, not warning-colored**.
Stormlight manages whatever repositories a user points it at, and in nearly
all of them working in the main checkout is normal; the rule against it is
this repository's own AGENTS.md, not a universal one. Painting every
workspace's ordinary case amber would flag a non-problem. Making it an
actual alarm is deferred to the per-workspace setting in #47 — for now the
badge reports a fact, not a verdict.

Width behavior is unchanged from b2f0eba: the badge is the last token to
yield and the path, which merely restates it, is the first.

`worktreeLabel` became `agentCheckout`, returning a `checkoutBadge`
(text plus a `primary` flag) so the renderer can pick the color; the color
choice itself lives in `checkoutStyle`, which is what the new color test
asserts against (lipgloss renders unstyled under a test's color profile,
so asserting on rendered bytes would have proved nothing).

Tests: the heading test is now a table over all three states (linked
worktree, primary checkout, non-Git), the width test is a table over both
badge kinds, and `TestCheckoutBadgeColors` pins accent vs muted.
`go build ./...` and `go test ./...` pass.

Fixes #48