### PR TITLE
Say what 0.x means and what 1.0.0 would cost

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -173,6 +173,19 @@ minor, fixes bump the patch. Cutting one is cheap, but each is a thing users
 see and re-download, so releases follow completed work rather than individual
 merges.
 
+The minor number has no ceiling and is not a countdown. `0.x` means exactly
+what semver says it means — no stability promise, anything may change at any
+time — so v0.9.0 and v0.27.0 are ordinary places to be, and moving from 0.2
+to 0.3 costs nothing. Staying in `0.x` is what buys the freedom the
+Philosophy section above assumes: breaking refactors stay welcome precisely
+because no version has promised otherwise.
+
+1.0.0 is therefore a decision, not a milestone reached by incrementing. It
+declares that the interface — the dashboard's keys, the workspace catalog
+format, the state files — is stable enough that breaking it costs a major
+bump. Cut it when that promise is one worth keeping, not when the minor
+number looks large.
+
 ## Headless TUI testing
 
 The dashboard and agent lifecycle can be exercised without a real terminal:


### PR DESCRIPTION
The Releasing section landed the bump rules but not the frame around them, which leaves the minor number reading as a countdown — as though v0.3.0 were progress toward a v1.0.0 that arrives on its own.

Two paragraphs: `0.x` has no ceiling and promises nothing (which is what makes Philosophy's "breaking refactors are welcome" actually free), and 1.0.0 is a deliberate declaration about interface stability rather than a milestone reached by incrementing.

Docs only.