### PR TITLE
Ship a Homebrew cask instead of a formula

### DIFF
--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -40,26 +40,37 @@ release:
 changelog:
   use: github
 
-brews:
+# Casks, not formulae. `brews` is soft-deprecated as of goreleaser v2.10 and
+# removed outright in v2.16; the formula it generated was a workaround from
+# when Linuxbrew had no cask support. It does now — Homebrew's cask code is
+# cross-platform, with macOS layered on top as overrides under
+# extend/os/mac/cask — so the generated cask carries on_linux URLs and Linux
+# keeps its `brew install` path.
+homebrew_casks:
   - repository:
       owner: trentkm
       name: homebrew-stormlight
       token: "{{ .Env.HOMEBREW_TAP_GITHUB_TOKEN }}"
     homepage: https://github.com/trentkm/stormlight
     description: Workspace-native control surface for coding agents
-    license: MIT
     # tmux >= 3.7 is required for popup overlays (older display-popup
     # crashes the server on DECRQM, tmux/tmux#4942); Homebrew ships 3.7+.
     # yazi is the directory picker for workspaces and dispatch — core to
     # the intended experience, so it installs alongside. Neovim stays
     # optional: most people already have an editor opinion.
     dependencies:
-      - name: tmux
-      - name: yazi
-    directory: Formula
-    install: |
-      bin.install "stormlight"
+      - formula: tmux
+      - formula: yazi
     caveats: |
       Optional: install neovim to edit agent tasks in a popup (brew install neovim).
-    test: |
-      assert_match version.to_s, shell_output("#{bin}/stormlight --version")
+    # Homebrew quarantines cask downloads, and an unsigned binary then trips
+    # Gatekeeper on first run. Stripping the attribute keeps `stormlight`
+    # launchable; the guard matches Homebrew's own split, where quarantine is
+    # a macOS override and the generic implementation reports it unavailable.
+    # Without it this would shell out to a path Linux does not have.
+    hooks:
+      post:
+        install: |
+          if OS.mac?
+            system_command "/usr/bin/xattr", args: ["-dr", "com.apple.quarantine", "#{staged_path}/stormlight"]
+          end


### PR DESCRIPTION
Closes #54.

goreleaser soft-deprecated `brews` in v2.10 and **removes it in v2.16**. `release.yml` pins nothing, so it resolves the latest goreleaser every run, and local is already 2.14.3 — this breaks roughly two minor versions out, with nothing in this repo having changed.

## Linux is not affected

I initially thought casks were macOS-only. That was true historically and is now wrong: Homebrew's cask implementation is cross-platform, with macOS layered on as overrides under `extend/os/mac/cask/`, and `cask/dsl.rb` handles `arm64_linux` / `x86_64_linux` arch conditionals. There is no macOS-only guard anywhere in `Library/Homebrew`.

The generated cask carries `on_linux` URLs for both architectures. Linux keeps `brew install`. goreleaser's own note explains why the formula existed: it "was the only way to do it for Linuxbrew at the time, but this is no longer true."

## Changes

- `brews:` → `homebrew_casks:`, `dependencies` switch from `name:` to `formula:`
- `directory: Formula` dropped — casks default to `Casks/`
- `license` and `test` dropped — no cask equivalent
- `install: bin.install` replaced by the cask `binary` artifact, which goreleaser emits automatically
- **postflight quarantine strip**, gated on `OS.mac?`. Casks quarantine what they download, which trips Gatekeeper on an unsigned binary's first run. The gate mirrors Homebrew's own split — quarantine is a macOS override, the generic implementation reports it unavailable — and ungated it would shell out to `/usr/bin/xattr`, which Linux does not have.

## Verification

- `goreleaser check` — clean, deprecation warning gone
- `goreleaser release --snapshot --clean` — builds all four platforms, writes `Casks/stormlight.rb`
- `ruby -c` — syntax OK
- Loaded into a scratch tap and evaluated by Homebrew itself: `brew info --cask` resolves dependencies (tmux, yazi), recognizes `stormlight (Binary)`, renders caveats
- `brew audit --cask` — exit 0, no warnings

Not verifiable before publishing: an actual `brew install`, since the cask's URLs point at release assets that only exist once a tag is pushed.

## Follow-up, after the next release

The tap will then hold both `Casks/stormlight.rb` and the stale `Formula/stormlight.rb`. Anyone on the formula needs `tap_migrations.json` in the tap to be carried across by `brew upgrade`; adding it before a cask exists would just break formula users. Tracked separately — it is a change to the tap repo, not this one.