### PR TITLE
Keep agent state visible under the cursor and harder to clear

### DIFF
--- a/README.md
+++ b/README.md
@@ -263,13 +263,19 @@ Attention has two tiers, and it always outranks the working glow:
 | waiting | finished with a result you haven't seen | soft amber `○` marker and count |
 | question / approval / auth | agent is blocked on an explicit decision | loud amber `!` — the whole row |
 
+Selecting a row never changes what it reports: the cursor row keeps its glow
+and its amber, painted onto the selection background rather than replaced by
+it, so moving through the list can't make a working agent read as idle.
+
 Every finished turn is classified from its final message (providers emit
 the same event for "done" and "asked you something", so the content is the
 discriminator): a closing question goes loud, anything else is an unseen
-result. Amber is an inbox — it clears when you engage: replying or opening
-the terminal clears any tier, viewing the result (a keypress while it's
-selected with its transcript on screen) clears unseen, and `M` marks the
+result. Amber is an inbox — it clears when you engage with the result:
+replying, interrupting, or opening the terminal clears any tier; paging
+through the transcript while it is on screen clears unseen; and `M` marks the
 selected agent — or every agent in the selected workspace — seen manually.
+Moving between panes and rows is not engagement — navigation is how you leave
+a result, so it leaves the amber where it is.
 
 Custom workspace types can override Git by installing executable resolvers in
 `~/.config/stormlight/resolvers`. The protocol is public and does not require

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -144,10 +144,13 @@ and "asked a question", so content is the only instant discriminator): a
 closing question is urgent, anything else is an unseen result. The
 provider's delayed idle notification is deliberately ignored — it would
 re-raise attention the human already cleared. Attention clears on
-engagement: a new prompt, opening the terminal, viewing the result while
-present, or an explicit mark-seen; the runtime refuses to let a soft
-signal downgrade an urgent state. Dead panes carry no attention — their
-exit status is the story.
+engagement: a new prompt, opening the terminal, replying, interrupting,
+paging through the result while it is on screen, or an explicit mark-seen.
+Navigating between panes and rows is deliberately not engagement — those
+are the keys a human presses on the way past a result, and counting them
+cleared the amber before it was ever read. The runtime refuses to let a
+soft signal downgrade an urgent state. Dead panes carry no attention —
+their exit status is the story.
 
 This prevents a resumable completed conversation from being conflated with a
 currently running process, and keeps "needs me now" distinct from "idle on

--- a/internal/ui/agents.go
+++ b/internal/ui/agents.go
@@ -80,7 +80,6 @@ func renderAgentRowWithDensity(
 	// One indicator column: the focused row's bar comes from the theme, a
 	// remembered selection shows the chevron, everything else shows its
 	// status glyph. Displaced state speaks through the title styling.
-	topContent := " " + displayTitle + strings.Repeat(" ", gap) + age
 
 	state := string(managedAgent.Activity)
 	if managedAgent.NeedsAttention() {
@@ -101,14 +100,18 @@ func renderAgentRowWithDensity(
 	// selection remembered in an inactive pane keeps just a faint marker,
 	// so exactly one row on screen is hot.
 	if focused || danger {
-		theme := rowThemeFor(danger)
-		if !expanded {
-			return theme.selectableRow(topContent, width, focused)
-		}
-		if focused {
-			return theme.focusedRow(topContent, bottomContent, width)
-		}
-		return theme.contextRow(topContent, bottomContent, width)
+		return renderSelectedAgentRow(
+			managedAgent,
+			displayTitle,
+			gap,
+			age,
+			bottomContent,
+			width,
+			focused,
+			expanded,
+			shimmerPhase,
+			rowThemeFor(danger),
+		)
 	}
 
 	renderedTitle := titleStyle.Render(displayTitle)
@@ -138,6 +141,84 @@ func renderAgentRowWithDensity(
 		return top
 	}
 	return lipgloss.JoinVertical(lipgloss.Left, top, bottom)
+}
+
+// renderSelectedAgentRow draws the cursor row over the selection background
+// without flattening the state the row is reporting: a working agent keeps
+// its cyan sweep and an urgent one keeps its amber, painted onto the row
+// background instead of replaced by it. Moving the cursor onto a row is not
+// news about the agent, so it must not change what the row says — the
+// workspace list has always rendered its selection this way, and an agent
+// that reads as idle the moment you select it is exactly the confusion this
+// avoids.
+func renderSelectedAgentRow(
+	managedAgent agent.Agent,
+	title string,
+	gap int,
+	age string,
+	bottom string,
+	width int,
+	focused bool,
+	expanded bool,
+	shimmerPhase int,
+	theme rowTheme,
+) string {
+	top := " " + title + strings.Repeat(" ", gap) + age
+	if width < 3 || lipgloss.Width(top) > max(0, width-2) {
+		if !expanded {
+			return theme.selectableRow(top, width, focused)
+		}
+		if focused {
+			return theme.focusedRow(top, bottom, width)
+		}
+		return theme.contextRow(top, bottom, width)
+	}
+
+	marker := "▏"
+	markerColor := theme.restMark
+	if focused {
+		marker = "▌"
+		markerColor = theme.focusMark
+	}
+	markerStyle := lipgloss.NewStyle().
+		Foreground(markerColor).
+		Background(theme.background).
+		Bold(focused)
+	baseStyle := lipgloss.NewStyle().
+		Foreground(theme.text).
+		Background(theme.background)
+	renderedTitle := baseStyle.Copy().Bold(true).Render(title)
+	switch {
+	case managedAgent.ProcessLive && managedAgent.Attention.Urgent():
+		// Same ranking as the quiet row: urgent attention outranks the
+		// working glow.
+		renderedTitle = baseStyle.Copy().
+			Foreground(colorWaiting).
+			Bold(true).
+			Render(title)
+	case managedAgent.Activity == agent.ActivityWorking,
+		managedAgent.Activity == agent.ActivityStarting:
+		renderedTitle = shimmerText(title, shimmerPhase, theme.background)
+	}
+
+	contentWidth := width - 1
+	tailWidth := max(0, contentWidth-1-lipgloss.Width(title))
+	topLine := markerStyle.Render(marker) +
+		baseStyle.Render(" ") +
+		renderedTitle +
+		baseStyle.Copy().
+			Width(tailWidth).
+			MaxWidth(tailWidth).
+			Render(strings.Repeat(" ", gap)+age)
+	if !expanded {
+		return topLine
+	}
+	bottomLine := markerStyle.Render(marker) +
+		baseStyle.Copy().
+			Width(contentWidth).
+			MaxWidth(contentWidth).
+			Render(ansi.Truncate(bottom, contentWidth, ""))
+	return lipgloss.JoinVertical(lipgloss.Left, topLine, bottomLine)
 }
 
 func listRowCapacity(height int, expanded bool) int {

--- a/internal/ui/input_test.go
+++ b/internal/ui/input_test.go
@@ -14,6 +14,7 @@ import (
 	tea "github.com/charmbracelet/bubbletea"
 	"github.com/charmbracelet/lipgloss"
 	"github.com/charmbracelet/x/ansi"
+	"github.com/muesli/termenv"
 	"github.com/trentkm/stormlight/internal/agent"
 	"github.com/trentkm/stormlight/internal/app"
 	"github.com/trentkm/stormlight/internal/provider"
@@ -1604,6 +1605,61 @@ func TestFocusedAgentRowUsesTaskFirstTitleAndSelectionRail(t *testing.T) {
 	}
 }
 
+// Selecting a row must not change what it reports. The selection background
+// used to repaint the title flat, so putting the cursor on a working agent
+// made it read exactly like an idle one — which is what "the blue pulse
+// clears as soon as I navigate left" describes. See #63.
+func TestSelectedAgentRowKeepsWorkingAndUrgentState(t *testing.T) {
+	previous := lipgloss.ColorProfile()
+	lipgloss.SetColorProfile(termenv.TrueColor)
+	defer lipgloss.SetColorProfile(previous)
+
+	base := agent.Agent{
+		Provider:    agent.ProviderCodex,
+		Name:        "cx-fix-parser",
+		Task:        "Fix parser behavior",
+		ProcessLive: true,
+	}
+	withState := func(activity agent.Activity, attention agent.Attention) agent.Agent {
+		value := base
+		value.Activity = activity
+		value.Attention = attention
+		return value
+	}
+	render := func(value agent.Agent, phase int) string {
+		return renderAgentRowWithDensity(value, true, true, 52, true, false, phase)
+	}
+	// The subtitle spells the state out in words either way; the claim here
+	// is about the title line, which is what carries the color.
+	titleLine := func(rendered string) string {
+		return strings.SplitN(rendered, "\n", 2)[0]
+	}
+
+	idle := render(withState(agent.ActivityIdle, agent.AttentionNone), 4)
+	working := render(withState(agent.ActivityWorking, agent.AttentionNone), 4)
+	urgent := render(withState(agent.ActivityIdle, agent.AttentionQuestion), 4)
+	if titleLine(working) == titleLine(idle) {
+		t.Fatal("selected working title renders identically to an idle one")
+	}
+	if titleLine(urgent) == titleLine(idle) {
+		t.Fatal("selected urgent title renders identically to an idle one")
+	}
+
+	// The sweep has to keep moving under the cursor, not freeze at a shade.
+	late := render(withState(agent.ActivityWorking, agent.AttentionNone), 7)
+	if titleLine(late) == titleLine(working) {
+		t.Fatal("selected working title does not shimmer between phases")
+	}
+
+	for _, rendered := range []string{idle, working, urgent, late} {
+		for index, line := range strings.Split(ansi.Strip(rendered), "\n") {
+			if width := lipgloss.Width(line); width != 52 {
+				t.Fatalf("line %d width = %d, want 52: %q", index+1, width, line)
+			}
+		}
+	}
+}
+
 func TestContextualNewAction(t *testing.T) {
 	workspaceContext := workspace.DirectoryContext(t.TempDir())
 	model := NewModel(stubBackend{})
@@ -2070,7 +2126,7 @@ func (b *recordingBackend) Attach(
 	return app.AttachResult{}, nil
 }
 
-func TestSeenClearingMarksSelectedAgentOnPresence(t *testing.T) {
+func unreadAgentModel(active pane) Model {
 	ws := workspace.DirectoryContext("/workspace/project")
 	model := NewModel(stubBackend{})
 	model.width = 120
@@ -2086,13 +2142,56 @@ func TestSeenClearingMarksSelectedAgentOnPresence(t *testing.T) {
 		Workspace:   ws,
 	}}
 	model.rebuildGroups(ws.ID, "unread")
-	model.activePane = paneAgents
+	model.activePane = active
 	model.interactionID = "unread"
+	return model
+}
 
-	updated, _ := model.Update(runeKey("k"))
-	model = updated.(Model)
-	if model.agents[0].Attention != agent.AttentionNone {
-		t.Fatalf("attention = %q, want cleared on presence", model.agents[0].Attention)
+func TestSeenClearingMarksSelectedAgentOnEngagement(t *testing.T) {
+	cases := []struct {
+		label  string
+		key    tea.KeyMsg
+		active pane
+	}{
+		{"scroll the transcript", runeKey("k"), paneInteraction},
+		{"jump to its end", runeKey("G"), paneInteraction},
+		{"reply", runeKey("i"), paneAgents},
+		{"open its terminal", tea.KeyMsg{Type: tea.KeyEnter}, paneAgents},
+	}
+	for _, testCase := range cases {
+		model := unreadAgentModel(testCase.active)
+		updated, _ := model.Update(testCase.key)
+		model = updated.(Model)
+		if model.agents[0].Attention != agent.AttentionNone {
+			t.Fatalf("%s: attention = %q, want cleared on engagement",
+				testCase.label, model.agents[0].Attention)
+		}
+	}
+}
+
+// Navigating past an unseen result is not reading it: the amber has to
+// survive the keys a human presses on the way out of the transcript, or it
+// clears before they ever look. See #63.
+func TestSeenClearingSurvivesNavigation(t *testing.T) {
+	cases := []struct {
+		label  string
+		key    tea.KeyMsg
+		active pane
+	}{
+		{"left, out of the transcript", runeKey("h"), paneInteraction},
+		{"right, into the transcript", runeKey("l"), paneAgents},
+		{"cycling panes", tea.KeyMsg{Type: tea.KeyTab}, paneAgents},
+		{"up the agent list", runeKey("k"), paneAgents},
+		{"down the workspace list", runeKey("j"), paneWorkspaces},
+	}
+	for _, testCase := range cases {
+		model := unreadAgentModel(testCase.active)
+		updated, _ := model.Update(testCase.key)
+		model = updated.(Model)
+		if model.agents[0].Attention != agent.AttentionWaiting {
+			t.Fatalf("%s: attention = %q, want the unseen result kept",
+				testCase.label, model.agents[0].Attention)
+		}
 	}
 }
 

--- a/internal/ui/model.go
+++ b/internal/ui/model.go
@@ -543,14 +543,15 @@ func (m Model) Update(message tea.Msg) (tea.Model, tea.Cmd) {
 			m.status = "Ready"
 			return m, nil
 		default:
-			// The keypress is the presence proof: if an unseen result is
-			// on screen right now (selected, transcript loaded) and the
-			// human acts, it has been seen.
+			// Reading the result is the presence proof: if an unseen result
+			// is on screen right now (selected, transcript loaded) and the
+			// human engages with it, it has been seen.
 			seenID := ""
 			if selected, ok := m.selectedAgent(); ok &&
 				selected.ProcessLive &&
 				selected.Attention == agent.AttentionWaiting &&
-				m.interactionID == selected.ID {
+				m.interactionID == selected.ID &&
+				marksResultSeen(msg.String(), m.activePane) {
 				seenID = selected.ID
 			}
 			updated, cmd := m.updateNormal(msg)
@@ -785,6 +786,37 @@ func (m Model) updateNormal(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 	var cmd tea.Cmd
 	m.interaction, cmd = m.interaction.Update(msg)
 	return m, cmd
+}
+
+// marksResultSeen reports whether a keypress engages with the unseen result
+// rather than merely happening near it. Acting on the agent counts from
+// anywhere; paging through the transcript counts only while the transcript
+// pane holds focus, because that is the one place those keys are reading
+// rather than moving the cursor.
+//
+// Bare navigation is deliberately absent. `h` back out of the transcript,
+// `l` into it, tab between panes, `j`/`k` down the agent list — every one of
+// those is how a human leaves a result, and treating them as proof made
+// amber clear on the way past. Nothing here is lost by waiting: `M` marks
+// seen outright, and the amber costs nothing while it waits.
+func marksResultSeen(key string, active pane) bool {
+	switch key {
+	case "enter", "i", "s", "x":
+		// Opening the terminal, replying, and interrupting all act on the
+		// result itself, wherever the cursor happens to be.
+		return true
+	}
+	if active != paneInteraction {
+		return false
+	}
+	switch key {
+	case "j", "k", "up", "down",
+		"ctrl+d", "ctrl+u", "ctrl+f", "ctrl+b", "pgup", "pgdown",
+		"g", "G",
+		"/", "n", "N":
+		return true
+	}
+	return false
 }
 
 func (m Model) anyAgentsActive() bool {


### PR DESCRIPTION
Selecting an agent row repainted its title flat over the selection
background, so the cyan working sweep, the urgent amber, and the status
glyph all vanished the moment the cursor landed on it. Navigating left out
of the transcript makes the agents pane active, which focuses the row you
were just reading — a running agent went from pulsing to indistinguishable
from an idle one on a single keypress. The workspace list has always
painted its selection the other way, keeping the sweep over the row
background; agent rows now do the same, and the state ranking (urgent
outranks working) matches the quiet row exactly.

The same keypress also cleared the unseen-result amber. Treating any key as
presence proof meant h, l, tab, and j/k all counted, and those are the keys
a human presses on the way past a result rather than into it. Engagement is
now what it claims to be: replying, interrupting, or opening the terminal
from anywhere, or paging through the transcript while that pane holds
focus. Bare navigation leaves the amber alone, and M still marks seen
outright.

Fixes #63