### PR TITLE
Let the human mark an agent's state

### DIFF
--- a/README.md
+++ b/README.md
@@ -125,6 +125,7 @@ stormlight list --json
 stormlight attach <id>
 stormlight send <id> "Run the focused test before wrapping up"
 stormlight rename <id> "focused test fixer"
+stormlight mark <id> attention
 stormlight stop <id>
 stormlight delete <id>
 stormlight logs
@@ -160,6 +161,7 @@ IDs may be shortened as long as the prefix remains unambiguous.
 | `Ctrl-x`, then `X` | Delete a workspace **and all of its agents** |
 | `R` | Rename the selected workspace or agent |
 | `,` then `a` / `n` / `c` | Sort by attention, name, or newest (applies to both lists) |
+| `m` | Mark the selected agent in progress or needs-attention (your own reading, overriding Stormlight's) |
 | `M` | Mark the selected agent — or workspace — seen |
 | `K` | Workspace info popup (resolver, roots, metadata) |
 | `?` | Full keybinding reference |
@@ -276,6 +278,41 @@ through the transcript while it is on screen clears unseen; and `M` marks the
 selected agent — or every agent in the selected workspace — seen manually.
 Moving between panes and rows is not engagement — navigation is how you leave
 a result, so it leaves the amber where it is.
+
+### Marking an agent yourself
+
+Stormlight infers all of this from provider hooks and pane state, and it is
+sometimes wrong: an agent grinding through a long tool call reads as idle, and
+a result you want to revisit reads as nothing at all. Press `m` on an agent to
+say otherwise. The picker offers two marks and a way out:
+
+| Mark | Says | Look |
+|---|---|---|
+| `w` in progress | still going; nothing is pending on you | cyan `●` and the working glow, any attention stood down |
+| `a` needs attention | come back to this one | amber `◆` in the waiting tier |
+| `c` clear | hand the row back to Stormlight's reading | whatever Stormlight infers |
+
+A mark outranks everything Stormlight inferred — in the row, in the workspace
+counts, and in the header — and rows say `marked in progress` or
+`marked needs attention` outright, so a corrected row never passes for an
+inference. The `◆` is deliberately not the inferred tiers' `○` or `!`: at a
+glance you can tell your own amber from Stormlight's.
+
+The two marks retire differently, because different parties can answer them.
+In-progress claims the agent is still running, which the agent settles the
+moment it reports anything — its next hook event retires the mark. Needs-
+attention claims *you* have something to come back to, which no provider event
+can answer, so only you take it down: `M`, or engaging with the row the same
+way engagement clears amber. A mark also stops applying when the pane dies,
+because an exit status is the whole story of a finished agent.
+
+The same override is available outside the dashboard:
+
+```bash
+stormlight mark 0123abcd working
+stormlight mark 0123abcd attention
+stormlight mark 0123abcd none
+```
 
 Custom workspace types can override Git by installing executable resolvers in
 `~/.config/stormlight/resolvers`. The protocol is public and does not require

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -83,6 +83,7 @@ the durable metadata:
 | `@stormlight_created_at` | Unix creation timestamp |
 | `@stormlight_activity` | Normalized activity state |
 | `@stormlight_attention` | Pending human-attention type |
+| `@stormlight_mark` | Human's manual override of the derived state |
 | `@stormlight_pane` | Original agent pane |
 | `@stormlight_workspace_id` | Stable workspace group identifier |
 | `@stormlight_workspace_kind` | Resolver-defined workspace type |
@@ -130,11 +131,12 @@ available return and help keys.
 ## State model
 
 The public agent record keeps process lifetime, activity, and attention
-separate:
+separate, with a fourth axis for the human's own reading:
 
 - Process: live or exited, with an optional exit code.
 - Activity: starting, working, idle, completed, failed, or stopped.
 - Attention: question, approval, authentication, waiting, or none.
+- Mark: working, attention, or none — set by a human, never derived.
 
 Attention is tiered. Question, approval, and authentication are urgent — the
 agent is blocked on an explicit human decision. Waiting is soft — the turn
@@ -155,6 +157,17 @@ their exit status is the story.
 This prevents a resumable completed conversation from being conflated with a
 currently running process, and keeps "needs me now" distinct from "idle on
 me" and from "just idle".
+
+A mark is the one signal nothing derives. Everything above is inference, and
+inference is sometimes wrong, so a human can say otherwise (`m` in the
+dashboard, `stormlight mark` outside it) and the mark outranks the derived
+reading everywhere it is displayed or counted. The two marks retire
+differently, because different parties can answer them: a working mark claims
+the agent is still running, which the agent settles as soon as it reports
+anything, so the next state-bearing update retires it; an attention mark
+claims the human has something to return to, which no provider event can
+answer, so only an explicit clear or the same engagement that clears amber
+takes it down. Like attention, a mark stops applying once the pane is dead.
 
 ## Persistence
 

--- a/internal/agent/agent.go
+++ b/internal/agent/agent.go
@@ -72,6 +72,52 @@ func (a Attention) Rank() int {
 	}
 }
 
+// Mark is the human's own reading of an agent, set from the dashboard when
+// Stormlight's inference is wrong or when a row wants revisiting. Stormlight
+// derives activity and attention from provider hooks and pane state, and it
+// gets that wrong often enough that the human needs a way to say otherwise —
+// a mark is that word, and it outranks everything Stormlight inferred.
+//
+// The two marks retire differently, because different parties can answer
+// them. MarkWorking claims the agent is still going, which the agent itself
+// settles the moment it reports anything: its next self-report retires the
+// mark. MarkAttention claims the human has something to come back to, which
+// no provider event can answer, so only the human takes it down — with M or
+// by engaging with the row, exactly like the amber inbox it joins.
+type Mark string
+
+const (
+	MarkNone Mark = ""
+	// MarkWorking says the agent is still going, whatever the dashboard
+	// reads: the row glows working and any attention on it stands down.
+	MarkWorking Mark = "working"
+	// MarkAttention says the human wants this row back, whatever the
+	// dashboard reads: it joins the waiting tier of the amber inbox.
+	MarkAttention Mark = "attention"
+)
+
+func ParseMark(value string) (Mark, error) {
+	if value == "none" || value == "clear" {
+		return MarkNone, nil
+	}
+	switch Mark(value) {
+	case MarkNone, MarkWorking, MarkAttention:
+		return Mark(value), nil
+	}
+	return "", fmt.Errorf("invalid mark %q (working, attention, or none)", value)
+}
+
+// Label is how a mark reads in the dashboard and in status lines.
+func (m Mark) Label() string {
+	switch m {
+	case MarkWorking:
+		return "in progress"
+	case MarkAttention:
+		return "needs attention"
+	}
+	return ""
+}
+
 // PermissionMode controls how much a dispatched agent may do without asking.
 // The names are provider-neutral; each provider adapter maps them to its own
 // flags.
@@ -114,6 +160,7 @@ type Agent struct {
 	CreatedAt   time.Time      `json:"created_at"`
 	Activity    Activity       `json:"activity"`
 	Attention   Attention      `json:"attention,omitempty"`
+	Mark        Mark           `json:"mark,omitempty"`
 	TmuxSession string         `json:"tmux_session"`
 	WindowID    string         `json:"window_id"`
 	WindowIndex int            `json:"window_index"`
@@ -129,8 +176,38 @@ type Agent struct {
 	Workspace      workspace.Context `json:"workspace"`
 }
 
+// EffectiveMark is the mark the dashboard honors. A dead pane has an exit
+// status of its own to report and no live state left to correct, so a mark
+// stops applying the moment the process is gone.
+func (a Agent) EffectiveMark() Mark {
+	if !a.ProcessLive {
+		return MarkNone
+	}
+	return a.Mark
+}
+
 func (a Agent) NeedsAttention() bool {
+	switch a.EffectiveMark() {
+	case MarkAttention:
+		return true
+	case MarkWorking:
+		// The human said this agent is still going, so it is not waiting on
+		// anyone — that is the whole point of the mark.
+		return false
+	}
 	return a.Attention != AttentionNone
+}
+
+// TriageRank orders agents for attention sorting. A mark speaks with the tier
+// it names; everything else defers to the derived attention.
+func (a Agent) TriageRank() int {
+	switch a.EffectiveMark() {
+	case MarkAttention:
+		return AttentionWaiting.Rank()
+	case MarkWorking:
+		return AttentionNone.Rank()
+	}
+	return a.Attention.Rank()
 }
 
 func (a Agent) DisplaySummary() string {
@@ -155,6 +232,9 @@ func Sort(agents []Agent) {
 func priority(a Agent) int {
 	if a.NeedsAttention() {
 		return 0
+	}
+	if a.EffectiveMark() == MarkWorking {
+		return 1
 	}
 	switch a.Activity {
 	case ActivityWorking, ActivityStarting:

--- a/internal/agent/agent_test.go
+++ b/internal/agent/agent_test.go
@@ -59,6 +59,127 @@ func TestAttentionTiersDriveUrgencyOwnershipAndRank(t *testing.T) {
 	}
 }
 
+func TestMarkOverridesDerivedTriage(t *testing.T) {
+	for _, testCase := range []struct {
+		name   string
+		agent  Agent
+		needs  bool
+		rank   int
+		effect Mark
+	}{
+		{
+			name: "in progress stands down a stale question",
+			agent: Agent{
+				ProcessLive: true,
+				Attention:   AttentionQuestion,
+				Mark:        MarkWorking,
+			},
+			needs:  false,
+			rank:   AttentionNone.Rank(),
+			effect: MarkWorking,
+		},
+		{
+			name: "needs attention flags a quiet agent",
+			agent: Agent{
+				ProcessLive: true,
+				Activity:    ActivityIdle,
+				Mark:        MarkAttention,
+			},
+			needs:  true,
+			rank:   AttentionWaiting.Rank(),
+			effect: MarkAttention,
+		},
+		{
+			name: "a dead pane reports its exit, not a mark",
+			agent: Agent{
+				Activity: ActivityCompleted,
+				Mark:     MarkWorking,
+			},
+			needs:  false,
+			rank:   AttentionNone.Rank(),
+			effect: MarkNone,
+		},
+		{
+			name:   "unmarked agents defer to attention",
+			agent:  Agent{ProcessLive: true, Attention: AttentionWaiting},
+			needs:  true,
+			rank:   AttentionWaiting.Rank(),
+			effect: MarkNone,
+		},
+	} {
+		t.Run(testCase.name, func(t *testing.T) {
+			if got := testCase.agent.EffectiveMark(); got != testCase.effect {
+				t.Fatalf("EffectiveMark() = %q, want %q", got, testCase.effect)
+			}
+			if got := testCase.agent.NeedsAttention(); got != testCase.needs {
+				t.Fatalf("NeedsAttention() = %v, want %v", got, testCase.needs)
+			}
+			if got := testCase.agent.TriageRank(); got != testCase.rank {
+				t.Fatalf("TriageRank() = %d, want %d", got, testCase.rank)
+			}
+		})
+	}
+}
+
+func TestSortLiftsMarkedAgentsOverDerivedState(t *testing.T) {
+	now := time.Now()
+	agents := []Agent{
+		{ID: "completed", Activity: ActivityCompleted, CreatedAt: now},
+		{
+			ID:          "marked-working",
+			Activity:    ActivityIdle,
+			ProcessLive: true,
+			Mark:        MarkWorking,
+			CreatedAt:   now,
+		},
+		{
+			ID:          "marked-attention",
+			Activity:    ActivityIdle,
+			ProcessLive: true,
+			Mark:        MarkAttention,
+			CreatedAt:   now,
+		},
+		{ID: "idle", Activity: ActivityIdle, CreatedAt: now},
+	}
+
+	Sort(agents)
+
+	want := []string{"marked-attention", "marked-working", "idle", "completed"}
+	for index := range want {
+		if agents[index].ID != want[index] {
+			t.Fatalf("position %d = %q, want %q", index, agents[index].ID, want[index])
+		}
+	}
+}
+
+func TestParseMarkAcceptsNamesAndRejectsUnknown(t *testing.T) {
+	for value, want := range map[string]Mark{
+		"":          MarkNone,
+		"none":      MarkNone,
+		"clear":     MarkNone,
+		"working":   MarkWorking,
+		"attention": MarkAttention,
+	} {
+		mark, err := ParseMark(value)
+		if err != nil {
+			t.Fatalf("ParseMark(%q) = %v", value, err)
+		}
+		if mark != want {
+			t.Fatalf("ParseMark(%q) = %q, want %q", value, mark, want)
+		}
+	}
+	for _, value := range []string{"Working", "in-progress", "attn"} {
+		if _, err := ParseMark(value); err == nil {
+			t.Fatalf("ParseMark(%q) was accepted", value)
+		}
+	}
+	if MarkWorking.Label() != "in progress" ||
+		MarkAttention.Label() != "needs attention" ||
+		MarkNone.Label() != "" {
+		t.Fatal("mark labels changed")
+	}
+}
+
 func TestParseModeDefaultsWhenUnsetAndRejectsUnknown(t *testing.T) {
 	mode, err := ParseMode("")
 	if err != nil || mode != DefaultMode {

--- a/internal/app/service.go
+++ b/internal/app/service.go
@@ -308,9 +308,19 @@ func (s *Service) Interrupt(ctx context.Context, id string) error {
 	return s.runtime.Interrupt(ctx, id)
 }
 
-// ClearAttention marks an agent's notification as seen.
+// ClearAttention marks an agent's notification as seen, taking down a
+// manual attention mark with it — both mean the same thing to the human.
 func (s *Service) ClearAttention(ctx context.Context, id string) error {
 	return s.runtime.Update(ctx, id, session.Update{ClearAttention: true})
+}
+
+// SetMark records the human's own reading of an agent's state, overriding
+// what Stormlight inferred. agent.MarkNone removes an existing mark.
+func (s *Service) SetMark(ctx context.Context, id string, mark agent.Mark) error {
+	return s.runtime.Update(ctx, id, session.Update{
+		Mark:      mark,
+		ClearMark: mark == agent.MarkNone,
+	})
 }
 
 func (s *Service) Delete(ctx context.Context, id string) error {

--- a/internal/session/runtime.go
+++ b/internal/session/runtime.go
@@ -53,6 +53,11 @@ type Update struct {
 	// ClearAttention removes any attention state without touching the
 	// rest of the record; an empty Attention alone means "leave as is".
 	ClearAttention bool
+	// Mark records the human's own reading of the agent; empty means
+	// "leave as is", so removing one takes ClearMark.
+	Mark agent.Mark
+	// ClearMark removes any mark without touching the rest of the record.
+	ClearMark bool
 }
 
 type AttachResult struct {

--- a/internal/tmux/runtime.go
+++ b/internal/tmux/runtime.go
@@ -47,7 +47,7 @@ const (
 	dynamicStatusStyle   = `#{?client_prefix,#{E:@stormlight_status_style_prefix},#{E:@stormlight_status_style_base}}`
 	dynamicStatusLeft    = `#{?client_prefix,#{E:@stormlight_status_left_prefix},#{E:@stormlight_status_left_base}}`
 	basePaneFieldCount   = 10
-	metadataFieldCount   = 19
+	metadataFieldCount   = 20
 )
 
 var agentMetadataFields = [metadataFieldCount]string{
@@ -70,6 +70,7 @@ var agentMetadataFields = [metadataFieldCount]string{
 	"workspace_metadata",
 	"mode",
 	"transcript_path",
+	"mark",
 }
 
 type Runtime struct {
@@ -205,6 +206,7 @@ func (r *Runtime) Dispatch(ctx context.Context, req session.DispatchRequest) (ag
 		"@stormlight_created_at": strconv.FormatInt(createdAt.Unix(), 10),
 		"@stormlight_activity":   string(agent.ActivityStarting),
 		"@stormlight_attention":  "",
+		"@stormlight_mark":       "",
 		"@stormlight_pane":       target.paneID,
 		"@stormlight_mode":       string(req.Mode),
 	}
@@ -632,6 +634,24 @@ func (r *Runtime) Update(ctx context.Context, id string, update session.Update) 
 		}
 		values["@stormlight_attention"] = string(attention)
 	}
+	switch {
+	case update.ClearMark:
+		values["@stormlight_mark"] = ""
+	case update.Mark != "":
+		values["@stormlight_mark"] = string(update.Mark)
+	case update.ClearAttention && managedAgent.Mark == agent.MarkAttention:
+		// Clearing attention takes the attention mark down with it: both say
+		// "this row wants me", and seen is seen.
+		values["@stormlight_mark"] = ""
+	case (update.Activity != "" || update.Attention != "") &&
+		managedAgent.Mark == agent.MarkWorking:
+		// An in-progress mark corrects a stale reading of what the agent is
+		// doing, and the agent is the authority on that: its next
+		// self-report is a fresh reading, so the correction retires. An
+		// attention mark is about what the human must do, which no provider
+		// event can answer, so it survives every update but an explicit one.
+		values["@stormlight_mark"] = ""
+	}
 	if strings.TrimSpace(update.Summary) != "" {
 		values["@stormlight_summary"] = metadataValue(update.Summary)
 	}
@@ -869,6 +889,7 @@ func parseAgent(line string) (agent.Agent, bool) {
 		ExitCode:       exitCode,
 		Mode:           agent.PermissionMode(core[17]),
 		TranscriptPath: core[18],
+		Mark:           agent.Mark(core[19]),
 		Workspace: workspace.Context{
 			ID:            core[9],
 			Kind:          core[10],
@@ -899,6 +920,7 @@ func encodeAgentOptions(managedAgent agent.Agent) (map[string]string, error) {
 		"@stormlight_pane":            managedAgent.PaneID,
 		"@stormlight_mode":            string(managedAgent.Mode),
 		"@stormlight_transcript_path": managedAgent.TranscriptPath,
+		"@stormlight_mark":            string(managedAgent.Mark),
 	}
 	workspaceOptions, err := encodeWorkspaceOptions(managedAgent.Workspace)
 	if err != nil {

--- a/internal/tmux/runtime_test.go
+++ b/internal/tmux/runtime_test.go
@@ -44,6 +44,7 @@ func TestParseAgent(t *testing.T) {
 		"eyJicmFuY2giOiJtYWluIn0",
 		"auto",
 		"/tmp/claude/session.jsonl",
+		"attention",
 	}
 	line := strings.Join(parts, fieldSeparator)
 
@@ -72,6 +73,9 @@ func TestParseAgent(t *testing.T) {
 	}
 	if managedAgent.TranscriptPath != "/tmp/claude/session.jsonl" {
 		t.Fatalf("transcript path = %q", managedAgent.TranscriptPath)
+	}
+	if managedAgent.Mark != agent.MarkAttention {
+		t.Fatalf("mark = %q", managedAgent.Mark)
 	}
 }
 
@@ -569,7 +573,10 @@ func releaseWindowSizeCalls() [][]string {
 }
 
 type captureRunner struct {
-	agentLine       string
+	agentLine string
+	// stormlightID is what show-options reports for @stormlight_id; empty
+	// means the window has lost its metadata and Update restores the record.
+	stormlightID    string
 	sourceSessionID string
 	binding         string
 	rootBinding     string
@@ -607,8 +614,11 @@ func (r *captureRunner) Run(_ context.Context, _ []byte, args ...string) (string
 	case "list-clients":
 		return r.clientLine, nil
 	case "show-options":
-		if args[len(args)-1] == prefixFeedbackOption {
+		switch args[len(args)-1] {
+		case prefixFeedbackOption:
 			return r.feedbackVersion, nil
+		case "@stormlight_id":
+			return r.stormlightID, nil
 		}
 		return "", nil
 	}
@@ -840,4 +850,109 @@ func TestUpdateTurnEndDowngradesResolvedApproval(t *testing.T) {
 		}
 	}
 	t.Fatal("attention was never written")
+}
+
+// markWrites collects the @stormlight_mark values an Update wrote.
+func markWrites(calls [][]string) []string {
+	var values []string
+	for _, call := range calls {
+		if len(call) >= 2 && call[0] == "set-option" &&
+			call[len(call)-2] == "@stormlight_mark" {
+			values = append(values, call[len(call)-1])
+		}
+	}
+	return values
+}
+
+// markedAgentRunner answers for a window that still has its metadata, so an
+// Update writes only what its policy decided rather than restoring the record.
+func markedAgentRunner(mark agent.Mark) *captureRunner {
+	parts := strings.Split(captureAgentLine(false), fieldSeparator)
+	parts[basePaneFieldCount+19] = string(mark)
+	return &captureRunner{
+		agentLine:    strings.Join(parts, fieldSeparator),
+		stormlightID: "capture-id",
+	}
+}
+
+func TestUpdateStoresAndClearsMarks(t *testing.T) {
+	runner := markedAgentRunner(agent.MarkNone)
+	runtime := &Runtime{runner: runner}
+
+	if err := runtime.Update(context.Background(), "capture-id", session.Update{
+		Mark: agent.MarkAttention,
+	}); err != nil {
+		t.Fatal(err)
+	}
+	if got := markWrites(runner.calls); len(got) != 1 || got[0] != "attention" {
+		t.Fatalf("mark writes = %v", got)
+	}
+
+	runner = markedAgentRunner(agent.MarkAttention)
+	runtime = &Runtime{runner: runner}
+	if err := runtime.Update(context.Background(), "capture-id", session.Update{
+		ClearMark: true,
+	}); err != nil {
+		t.Fatal(err)
+	}
+	if got := markWrites(runner.calls); len(got) != 1 || got[0] != "" {
+		t.Fatalf("clear writes = %v", got)
+	}
+}
+
+func TestUpdateRetiresWorkingMarkOnProviderSignal(t *testing.T) {
+	runner := markedAgentRunner(agent.MarkWorking)
+	runtime := &Runtime{runner: runner}
+
+	err := runtime.Update(context.Background(), "capture-id", session.Update{
+		Activity:  agent.ActivityIdle,
+		Attention: agent.AttentionWaiting,
+		TurnEnded: true,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got := markWrites(runner.calls); len(got) != 1 || got[0] != "" {
+		t.Fatalf("mark writes = %v, want the in-progress mark retired", got)
+	}
+}
+
+func TestUpdateKeepsAttentionMarkThroughProviderSignals(t *testing.T) {
+	runner := markedAgentRunner(agent.MarkAttention)
+	runtime := &Runtime{runner: runner}
+
+	err := runtime.Update(context.Background(), "capture-id", session.Update{
+		Activity:  agent.ActivityWorking,
+		Attention: agent.AttentionNone,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got := markWrites(runner.calls); len(got) != 0 {
+		t.Fatalf("mark writes = %v, want the human's mark untouched", got)
+	}
+}
+
+func TestClearAttentionTakesDownTheAttentionMarkOnly(t *testing.T) {
+	runner := markedAgentRunner(agent.MarkAttention)
+	runtime := &Runtime{runner: runner}
+	if err := runtime.Update(context.Background(), "capture-id", session.Update{
+		ClearAttention: true,
+	}); err != nil {
+		t.Fatal(err)
+	}
+	if got := markWrites(runner.calls); len(got) != 1 || got[0] != "" {
+		t.Fatalf("mark writes = %v, want the attention mark cleared", got)
+	}
+
+	runner = markedAgentRunner(agent.MarkWorking)
+	runtime = &Runtime{runner: runner}
+	if err := runtime.Update(context.Background(), "capture-id", session.Update{
+		ClearAttention: true,
+	}); err != nil {
+		t.Fatal(err)
+	}
+	if got := markWrites(runner.calls); len(got) != 0 {
+		t.Fatalf("mark writes = %v, want the in-progress mark kept", got)
+	}
 }

--- a/internal/ui/agents.go
+++ b/internal/ui/agents.go
@@ -81,11 +81,7 @@ func renderAgentRowWithDensity(
 	// remembered selection shows the chevron, everything else shows its
 	// status glyph. Displaced state speaks through the title styling.
 
-	state := string(managedAgent.Activity)
-	if managedAgent.NeedsAttention() {
-		state = "needs " + string(managedAgent.Attention)
-	}
-	details := []string{providerName, state}
+	details := []string{providerName, agentStateLabel(managedAgent)}
 	if badge := modeBadge(managedAgent.Mode); badge != "" {
 		details = append(details, badge)
 	}
@@ -116,16 +112,15 @@ func renderAgentRowWithDensity(
 
 	renderedTitle := titleStyle.Render(displayTitle)
 	detailStyle := mutedStyle
-	switch {
-	case managedAgent.ProcessLive && managedAgent.Attention.Urgent():
+	switch rowEmphasisFor(managedAgent) {
+	case emphasisUrgent:
 		// Urgent attention outranks the working glow: the row goes loud
 		// amber. The waiting tier keeps its calm row and speaks through
 		// the amber status symbol alone.
 		attentionStyle := lipgloss.NewStyle().Foreground(colorWaiting).Bold(true)
 		renderedTitle = attentionStyle.Render(displayTitle)
 		detailStyle = attentionStyle
-	case managedAgent.Activity == agent.ActivityWorking,
-		managedAgent.Activity == agent.ActivityStarting:
+	case emphasisWorking:
 		renderedTitle = shimmerText(displayTitle, shimmerPhase, nil)
 	}
 	indicator := statusStyle.Render(symbol)
@@ -188,16 +183,15 @@ func renderSelectedAgentRow(
 		Foreground(theme.text).
 		Background(theme.background)
 	renderedTitle := baseStyle.Copy().Bold(true).Render(title)
-	switch {
-	case managedAgent.ProcessLive && managedAgent.Attention.Urgent():
+	switch rowEmphasisFor(managedAgent) {
+	case emphasisUrgent:
 		// Same ranking as the quiet row: urgent attention outranks the
 		// working glow.
 		renderedTitle = baseStyle.Copy().
 			Foreground(colorWaiting).
 			Bold(true).
 			Render(title)
-	case managedAgent.Activity == agent.ActivityWorking,
-		managedAgent.Activity == agent.ActivityStarting:
+	case emphasisWorking:
 		renderedTitle = shimmerText(title, shimmerPhase, theme.background)
 	}
 
@@ -357,15 +351,25 @@ func attentionTierOf(urgent, waiting int) attentionTier {
 	}
 }
 
+// workspaceStats counts a workspace's agents into the same triage buckets the
+// rows use, marks included: a corrected row is corrected in the counters too,
+// or the summary would keep reporting the reading the human overruled.
 func workspaceStats(agents []agent.Agent) (active, urgent, waiting int) {
 	for _, managedAgent := range agents {
-		if managedAgent.Activity == agent.ActivityWorking ||
-			managedAgent.Activity == agent.ActivityStarting {
+		if agentCountsActive(managedAgent) {
 			active++
 		}
 		if !managedAgent.ProcessLive {
 			// A dead pane can't be waiting on anyone; its exit status is
 			// the story.
+			continue
+		}
+		switch managedAgent.EffectiveMark() {
+		case agent.MarkWorking:
+			// The human said it is still going; nothing is pending on them.
+			continue
+		case agent.MarkAttention:
+			waiting++
 			continue
 		}
 		switch {
@@ -376,6 +380,16 @@ func workspaceStats(agents []agent.Agent) (active, urgent, waiting int) {
 		}
 	}
 	return active, urgent, waiting
+}
+
+// agentCountsActive reports whether an agent belongs in the "active" tally —
+// running by Stormlight's reading, or by the human's.
+func agentCountsActive(managedAgent agent.Agent) bool {
+	if managedAgent.EffectiveMark() == agent.MarkWorking {
+		return true
+	}
+	return managedAgent.Activity == agent.ActivityWorking ||
+		managedAgent.Activity == agent.ActivityStarting
 }
 
 func agentLocation(managedAgent agent.Agent) string {
@@ -392,7 +406,57 @@ func agentLocation(managedAgent agent.Agent) string {
 	return ""
 }
 
+// rowEmphasis says how a row's title should read. A manual mark comes first:
+// it exists precisely because the derived state was wrong, so nothing derived
+// may outrank it.
+type rowEmphasis int
+
+const (
+	emphasisNone rowEmphasis = iota
+	emphasisUrgent
+	emphasisWorking
+)
+
+func rowEmphasisFor(managedAgent agent.Agent) rowEmphasis {
+	switch managedAgent.EffectiveMark() {
+	case agent.MarkWorking:
+		return emphasisWorking
+	case agent.MarkAttention:
+		// A mark is the human's own note, not a blocked provider prompt, so
+		// it joins the calm waiting tier and speaks through its glyph.
+		return emphasisNone
+	}
+	if managedAgent.ProcessLive && managedAgent.Attention.Urgent() {
+		return emphasisUrgent
+	}
+	switch managedAgent.Activity {
+	case agent.ActivityWorking, agent.ActivityStarting:
+		return emphasisWorking
+	}
+	return emphasisNone
+}
+
+// agentStateLabel is the row's state token: a mark says so in words, so a
+// corrected row never looks like an inference.
+func agentStateLabel(managedAgent agent.Agent) string {
+	if mark := managedAgent.EffectiveMark(); mark != agent.MarkNone {
+		return "marked " + mark.Label()
+	}
+	if managedAgent.NeedsAttention() {
+		return "needs " + string(managedAgent.Attention)
+	}
+	return string(managedAgent.Activity)
+}
+
 func statusVisual(managedAgent agent.Agent) (string, lipgloss.Style) {
+	switch managedAgent.EffectiveMark() {
+	case agent.MarkWorking:
+		return "●", lipgloss.NewStyle().Foreground(colorWorking)
+	case agent.MarkAttention:
+		// A diamond rather than the inferred tiers' ○ and !: a glance should
+		// tell you whether the amber is Stormlight's reading or your own.
+		return "◆", lipgloss.NewStyle().Foreground(colorWaiting)
+	}
 	if managedAgent.ProcessLive && managedAgent.Attention.Urgent() {
 		return "!", lipgloss.NewStyle().Foreground(colorWaiting).Bold(true)
 	}

--- a/internal/ui/chrome.go
+++ b/internal/ui/chrome.go
@@ -162,6 +162,8 @@ func (m Model) commandHints() string {
 		return "j/k select  Enter add  e edit path  Esc cancel"
 	case modeRename:
 		return "Enter apply  Esc cancel"
+	case modeMark:
+		return "w in progress  a needs attention  c clear  Esc cancel"
 	}
 	rowMode := "z expand rows"
 	if m.rowsExpanded {
@@ -179,7 +181,8 @@ func (m Model) commandHints() string {
 	switch m.activePane {
 	case paneAgents:
 		return strings.TrimSpace(
-			"h/l panes  j/k select  n new  M seen  , sort  " + rowMode + "  Enter open",
+			"h/l panes  j/k select  n new  m mark  M seen  , sort  " +
+				rowMode + "  Enter open",
 		)
 	case paneInteraction:
 		if m.search.query != "" {

--- a/internal/ui/flows_test.go
+++ b/internal/ui/flows_test.go
@@ -19,6 +19,16 @@ type flowBackend struct {
 	renamedID        string
 	renamedName      string
 	renamedWorkspace string
+	markedID         string
+	mark             agent.Mark
+	markCalls        int
+}
+
+func (b *flowBackend) SetMark(_ context.Context, id string, mark agent.Mark) error {
+	b.markedID = id
+	b.mark = mark
+	b.markCalls++
+	return nil
 }
 
 func (b *flowBackend) Delete(_ context.Context, id string) error {
@@ -529,5 +539,166 @@ func TestDispatchHintsNameTheNextField(t *testing.T) {
 	model = next.(Model)
 	if hints := model.commandHints(); !strings.Contains(hints, "Tab name") {
 		t.Fatalf("picker hints hide the way out: %q", hints)
+	}
+}
+
+func TestMarkFlowRecordsTheHumansReading(t *testing.T) {
+	backend := &flowBackend{}
+	model := flowModelFixture(t, backend)
+	model.activePane = paneAgents
+
+	updated, _ := model.updateNormal(runeKey("m"))
+	model = updated.(Model)
+	if model.mode != modeMark || model.markAgentID != "agent-1" {
+		t.Fatalf("m state: mode=%d agent=%q", model.mode, model.markAgentID)
+	}
+	rendered := ansi.Strip(model.renderMarkModal(80, 24))
+	for _, want := range []string{"Mark", "In progress", "Needs attention"} {
+		if !strings.Contains(rendered, want) {
+			t.Fatalf("mark modal lacks %q:\n%s", want, rendered)
+		}
+	}
+
+	next, _ := model.updateMark(tea.KeyMsg{Type: tea.KeyEscape})
+	model = next.(Model)
+	if model.mode != modeNormal || backend.markCalls != 0 {
+		t.Fatalf("esc did not cancel: mode=%d calls=%d", model.mode, backend.markCalls)
+	}
+
+	model.mode = modeMark
+	next, cmd := model.updateMark(runeKey("a"))
+	model = next.(Model)
+	if cmd == nil {
+		t.Fatal("a did not submit a mark")
+	}
+	// The row reports the human's reading before the backend write lands.
+	if model.agents[0].Mark != agent.MarkAttention ||
+		model.groups[0].agents[0].Mark != agent.MarkAttention {
+		t.Fatalf("mark not applied locally: %#v", model.agents[0].Mark)
+	}
+	cmd()
+	if backend.markedID != "agent-1" || backend.mark != agent.MarkAttention {
+		t.Fatalf("marked %q as %q", backend.markedID, backend.mark)
+	}
+
+	// Reopening lands on the mark already set, and clearing hands the row
+	// back to Stormlight's own reading.
+	updated, _ = model.updateNormal(runeKey("m"))
+	model = updated.(Model)
+	if markChoices[model.markIndex].mark != agent.MarkAttention {
+		t.Fatalf("picker opened on %q", markChoices[model.markIndex].mark)
+	}
+	next, cmd = model.updateMark(runeKey("c"))
+	model = next.(Model)
+	cmd()
+	if backend.mark != agent.MarkNone || model.agents[0].Mark != agent.MarkNone {
+		t.Fatalf("clear left mark %q (backend %q)", model.agents[0].Mark, backend.mark)
+	}
+}
+
+func TestMarkedRowsReportTheMarkAndClearWhenSeen(t *testing.T) {
+	working := agent.Agent{
+		ID:          "one",
+		Name:        "one",
+		ProcessLive: true,
+		Activity:    agent.ActivityIdle,
+		Attention:   agent.AttentionQuestion,
+		Mark:        agent.MarkWorking,
+	}
+	attention := agent.Agent{
+		ID:          "two",
+		Name:        "two",
+		ProcessLive: true,
+		Activity:    agent.ActivityIdle,
+		Mark:        agent.MarkAttention,
+	}
+
+	row := ansi.Strip(renderAgentRow(working, false, false, 60))
+	if !strings.Contains(row, "marked in progress") {
+		t.Fatalf("in-progress row = %q", row)
+	}
+	row = ansi.Strip(renderAgentRow(attention, false, false, 60))
+	if !strings.Contains(row, "marked needs attention") ||
+		!strings.Contains(row, "◆") {
+		t.Fatalf("attention row = %q", row)
+	}
+
+	active, urgent, waiting := workspaceStats([]agent.Agent{working, attention})
+	if active != 1 || urgent != 0 || waiting != 1 {
+		t.Fatalf("stats: active=%d urgent=%d waiting=%d", active, urgent, waiting)
+	}
+
+	ws := workspace.DirectoryContext("/workspace/marks")
+	model := NewModel(stubBackend{})
+	model.width = 120
+	model.catalogWorkspaces = []workspace.Context{ws}
+	attention.Workspace = ws
+	model.agents = []agent.Agent{attention}
+	model.rebuildGroups(ws.ID, "")
+	model.activePane = paneWorkspaces
+
+	updated, cmd := model.updateNormal(runeKey("M"))
+	model = updated.(Model)
+	if cmd == nil {
+		t.Fatal("M did not clear the manual mark")
+	}
+	if model.agents[0].Mark != agent.MarkNone {
+		t.Fatalf("mark after M = %q", model.agents[0].Mark)
+	}
+}
+
+func TestSpanreedHeadingHonorsMarksOverDerivedState(t *testing.T) {
+	ws := workspace.DirectoryContext("/workspace/marks")
+	model := NewModel(stubBackend{})
+	model.width = 120
+	model.catalogWorkspaces = []workspace.Context{ws}
+	base := agent.Agent{
+		ID:          "one",
+		Name:        "one",
+		Provider:    agent.ProviderClaude,
+		ProcessLive: true,
+		Activity:    agent.ActivityIdle,
+		Attention:   agent.AttentionWaiting,
+		Workspace:   ws,
+	}
+
+	for _, testCase := range []struct {
+		name   string
+		mark   agent.Mark
+		want   string
+		absent string
+	}{
+		{
+			name:   "unmarked keeps the derived reading",
+			want:   "Unseen result",
+			absent: "marked",
+		},
+		{
+			name:   "in progress stands the unseen result down",
+			mark:   agent.MarkWorking,
+			want:   "marked in progress",
+			absent: "Unseen result",
+		},
+		{
+			name:   "needs attention says whose flag it is",
+			mark:   agent.MarkAttention,
+			want:   "Marked needs attention",
+			absent: "Unseen result",
+		},
+	} {
+		t.Run(testCase.name, func(t *testing.T) {
+			marked := base
+			marked.Mark = testCase.mark
+			model.agents = []agent.Agent{marked}
+			model.rebuildGroups(ws.ID, marked.ID)
+			model.interactionID = marked.ID
+			rendered := ansi.Strip(model.renderInteraction(80, 20))
+			if !strings.Contains(rendered, testCase.want) {
+				t.Fatalf("heading hides %q:\n%s", testCase.want, rendered)
+			}
+			if strings.Contains(rendered, testCase.absent) {
+				t.Fatalf("heading still claims %q:\n%s", testCase.absent, rendered)
+			}
+		})
 	}
 }

--- a/internal/ui/input_test.go
+++ b/internal/ui/input_test.go
@@ -2066,6 +2066,10 @@ func (stubBackend) ClearAttention(context.Context, string) error {
 	return nil
 }
 
+func (stubBackend) SetMark(context.Context, string, agent.Mark) error {
+	return nil
+}
+
 func (stubBackend) RenameWorkspace(context.Context, workspace.Context, string) error {
 	return nil
 }

--- a/internal/ui/layout.go
+++ b/internal/ui/layout.go
@@ -11,29 +11,11 @@ import (
 	tea "github.com/charmbracelet/bubbletea"
 	"github.com/charmbracelet/lipgloss"
 	"github.com/charmbracelet/x/ansi"
-	"github.com/trentkm/stormlight/internal/agent"
 )
 
 func (m Model) renderHeader() string {
 	width := max(1, m.width-1)
-	working := 0
-	urgent := 0
-	waiting := 0
-	for _, managedAgent := range m.agents {
-		if managedAgent.Activity == agent.ActivityWorking ||
-			managedAgent.Activity == agent.ActivityStarting {
-			working++
-		}
-		if !managedAgent.ProcessLive {
-			continue
-		}
-		switch {
-		case managedAgent.Attention.Urgent():
-			urgent++
-		case managedAgent.Attention == agent.AttentionWaiting:
-			waiting++
-		}
-	}
+	working, urgent, waiting := workspaceStats(m.agents)
 	// No chrome: the wordmark's own gradient is the identity, floating on
 	// the terminal background with the counters at the far edge.
 	left := renderWordmark(m.shimmerPhaseOrRest())
@@ -82,6 +64,13 @@ func (m Model) renderBody() string {
 		return overlayCentered(
 			dashboard,
 			m.renderRenameModal(width, contentHeight),
+			width,
+			contentHeight,
+		)
+	case modeMark:
+		return overlayCentered(
+			dashboard,
+			m.renderMarkModal(width, contentHeight),
 			width,
 			contentHeight,
 		)

--- a/internal/ui/marks.go
+++ b/internal/ui/marks.go
@@ -1,0 +1,184 @@
+package ui
+
+// The manual mark picker: the human's own reading of an agent, overriding
+// what Stormlight inferred. See issue #67.
+
+import (
+	"context"
+	"strings"
+
+	tea "github.com/charmbracelet/bubbletea"
+	"github.com/charmbracelet/lipgloss"
+	"github.com/trentkm/stormlight/internal/agent"
+)
+
+// markChoice is one row of the picker: the mark it sets, the key that picks
+// it directly, and how it reads.
+type markChoice struct {
+	mark   agent.Mark
+	key    string
+	label  string
+	detail string
+}
+
+// markChoices are ordered as the picker draws them. Clearing sits last
+// because it is the exit, not a state.
+var markChoices = []markChoice{
+	{
+		mark:   agent.MarkWorking,
+		key:    "w",
+		label:  "In progress",
+		detail: "still going; nothing pending",
+	},
+	{
+		mark:   agent.MarkAttention,
+		key:    "a",
+		label:  "Needs attention",
+		detail: "come back to this one",
+	},
+	{
+		mark:   agent.MarkNone,
+		key:    "c",
+		label:  "Clear mark",
+		detail: "back to Stormlight's own reading",
+	},
+}
+
+func markChoiceIndex(mark agent.Mark) int {
+	for index, choice := range markChoices {
+		if choice.mark == mark {
+			return index
+		}
+	}
+	return 0
+}
+
+// beginMark opens the picker on the selected agent. Marking is per-agent
+// wherever the cursor is, like interrupting: a workspace has no state of its
+// own to correct.
+func (m Model) beginMark() (tea.Model, tea.Cmd) {
+	selected, ok := m.selectedAgent()
+	if !ok {
+		return m, nil
+	}
+	m.markAgentID = selected.ID
+	m.markIndex = markChoiceIndex(selected.EffectiveMark())
+	m.mode = modeMark
+	m.err = nil
+	m.status = "Mark " + agentDisplayTitle(selected)
+	return m, nil
+}
+
+func (m Model) updateMark(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
+	key := msg.String()
+	switch key {
+	case "esc", "ctrl+c", "ctrl+[":
+		m.mode = modeNormal
+		m.status = "Ready"
+		return m, nil
+	case "j", "down":
+		m.markIndex = clamp(m.markIndex+1, 0, len(markChoices)-1)
+		return m, nil
+	case "k", "up":
+		m.markIndex = clamp(m.markIndex-1, 0, len(markChoices)-1)
+		return m, nil
+	case "enter":
+		return m.submitMark(markChoices[m.markIndex].mark)
+	}
+	for _, choice := range markChoices {
+		if key == choice.key {
+			return m.submitMark(choice.mark)
+		}
+	}
+	return m, nil
+}
+
+func (m Model) submitMark(mark agent.Mark) (tea.Model, tea.Cmd) {
+	m.mode = modeNormal
+	id := m.markAgentID
+	if id == "" {
+		m.status = "Ready"
+		return m, nil
+	}
+	// Apply locally first so the row reports the human's reading on the very
+	// next frame; the backend write follows.
+	m.applyMark(id, mark)
+	status := "Marked in progress"
+	switch mark {
+	case agent.MarkAttention:
+		status = "Marked needs attention"
+	case agent.MarkNone:
+		status = "Mark cleared"
+	}
+	m.status = status
+	backend := m.backend
+	return m, actionCmd(status, func(ctx context.Context) error {
+		return backend.SetMark(ctx, id, mark)
+	})
+}
+
+// applyMark writes the mark into the loaded agents so the dashboard reflects
+// it before the next refresh lands.
+func (m *Model) applyMark(id string, mark agent.Mark) {
+	for index := range m.agents {
+		if m.agents[index].ID == id {
+			m.agents[index].Mark = mark
+		}
+	}
+	for group := range m.groups {
+		for index := range m.groups[group].agents {
+			if m.groups[group].agents[index].ID == id {
+				m.groups[group].agents[index].Mark = mark
+			}
+		}
+	}
+}
+
+func (m Model) renderMarkModal(width, height int) string {
+	// Title, blank, the choices, blank, hints — plus the border.
+	modalWidth, modalHeight := modalDimensions(
+		width,
+		height,
+		64,
+		len(markChoices)+6,
+	)
+	innerWidth := max(1, modalWidth-2)
+	contentWidth := max(1, innerWidth-4)
+
+	title := "Mark agent"
+	if selected, ok := m.selectedAgent(); ok && selected.ID == m.markAgentID {
+		title = "Mark · " + truncate(agentDisplayTitle(selected), contentWidth-8)
+	}
+	lines := []string{
+		"  " + titleStyle.Render(title),
+		"",
+	}
+	for index, choice := range markChoices {
+		labelWidth := max(1, min(18, contentWidth-4))
+		label := lipgloss.NewStyle().
+			Width(labelWidth).
+			Render(truncate(choice.label, labelWidth))
+		detail := truncate(choice.detail, max(1, contentWidth-labelWidth-6))
+		if index == m.markIndex {
+			lines = append(lines, "  "+renderSelectableRow(
+				choice.key+"  "+label+"  "+detail,
+				contentWidth,
+				true,
+			))
+			continue
+		}
+		// One leading space matches the selectable row's marker column, so
+		// moving the cursor never shifts the text sideways.
+		lines = append(lines, "  "+lipgloss.NewStyle().
+			Width(contentWidth).
+			MaxWidth(contentWidth).
+			Render(" "+accentStyle.Render(choice.key)+"  "+
+				titleStyle.Render(label)+"  "+
+				mutedStyle.Render(detail)))
+	}
+	lines = append(lines,
+		"",
+		"  "+mutedStyle.Render("j/k choose  Enter apply  Esc cancel"),
+	)
+	return renderModal(strings.Join(lines, "\n"), modalWidth, modalHeight)
+}

--- a/internal/ui/modals.go
+++ b/internal/ui/modals.go
@@ -161,6 +161,7 @@ func (m Model) renderHelpModal(width, height int) string {
 			{"x", "interrupt the selected agent"},
 			{"Ctrl-x then x/X", "delete agent / workspace (+agents)"},
 			{"R", "rename workspace or agent"},
+			{"m", "mark agent in progress / needs attention"},
 			{"M", "mark agent or workspace seen"},
 			{"K", "workspace info"},
 		}},

--- a/internal/ui/model.go
+++ b/internal/ui/model.go
@@ -30,6 +30,7 @@ type Backend interface {
 	Send(context.Context, string, string) error
 	Interrupt(context.Context, string) error
 	ClearAttention(context.Context, string) error
+	SetMark(context.Context, string, agent.Mark) error
 	Delete(context.Context, string) error
 	Rename(context.Context, string, string) error
 	RenameWorkspace(context.Context, workspace.Context, string) error
@@ -47,6 +48,7 @@ const (
 	modeDelete
 	modeAddWorkspace
 	modeRename
+	modeMark
 	modeInfo
 	modeHelp
 )
@@ -153,6 +155,8 @@ type Model struct {
 	renameInput             lineInput
 	renameAgentID           string
 	renameWorkspace         workspace.Context
+	markAgentID             string
+	markIndex               int
 	pathNav                 pathNav
 	pickerStart             string
 	chooseDispatchDirectory bool
@@ -537,6 +541,8 @@ func (m Model) Update(message tea.Msg) (tea.Model, tea.Cmd) {
 			return m.updateAddWorkspace(msg)
 		case modeRename:
 			return m.updateRename(msg)
+		case modeMark:
+			return m.updateMark(msg)
 		case modeInfo, modeHelp:
 			// Any key dismisses an informational overlay.
 			m.mode = modeNormal
@@ -549,7 +555,8 @@ func (m Model) Update(message tea.Msg) (tea.Model, tea.Cmd) {
 			seenID := ""
 			if selected, ok := m.selectedAgent(); ok &&
 				selected.ProcessLive &&
-				selected.Attention == agent.AttentionWaiting &&
+				(selected.Attention == agent.AttentionWaiting ||
+					selected.EffectiveMark() == agent.MarkAttention) &&
 				m.interactionID == selected.ID &&
 				marksResultSeen(msg.String(), m.activePane) {
 				seenID = selected.ID
@@ -764,6 +771,8 @@ func (m Model) updateNormal(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 		return m, tea.Batch(m.refreshCmd(), m.loadInteractionCmd())
 	case "R":
 		return m.beginRename()
+	case "m":
+		return m.beginMark()
 	case "M":
 		return m.clearAttention()
 	case "K":
@@ -821,8 +830,7 @@ func marksResultSeen(key string, active pane) bool {
 
 func (m Model) anyAgentsActive() bool {
 	for _, managedAgent := range m.agents {
-		if managedAgent.Activity == agent.ActivityWorking ||
-			managedAgent.Activity == agent.ActivityStarting {
+		if agentCountsActive(managedAgent) {
 			return true
 		}
 	}

--- a/internal/ui/spanreed.go
+++ b/internal/ui/spanreed.go
@@ -20,8 +20,7 @@ func (m Model) renderInteraction(width, height int) string {
 		return mutedStyle.Render(truncate("No agent selected", width))
 	}
 	title := titleStyle.Render(truncate(agentDisplayTitle(managedAgent), width))
-	if managedAgent.Activity == agent.ActivityWorking ||
-		managedAgent.Activity == agent.ActivityStarting {
+	if rowEmphasisFor(managedAgent) == emphasisWorking {
 		title = shimmerText(
 			truncate(agentDisplayTitle(managedAgent), width),
 			m.shimmerPhaseOrRest(),
@@ -30,7 +29,7 @@ func (m Model) renderInteraction(width, height int) string {
 	}
 	metaParts := []string{
 		string(managedAgent.Provider),
-		string(managedAgent.Activity),
+		agentStateLabel(managedAgent),
 	}
 	if badge := modeBadge(managedAgent.Mode); badge != "" {
 		metaParts = append(metaParts, badge)
@@ -41,7 +40,14 @@ func (m Model) renderInteraction(width, height int) string {
 		shortPath(managedAgent.Cwd),
 		width,
 	)
-	if managedAgent.ProcessLive && managedAgent.Attention.Urgent() {
+	switch {
+	case managedAgent.EffectiveMark() == agent.MarkAttention:
+		meta = lipgloss.NewStyle().Foreground(colorWaiting).
+			Render(truncate("Marked needs attention", width))
+	case managedAgent.EffectiveMark() == agent.MarkWorking:
+		// The human said it is still going, and the meta line already reads
+		// "marked in progress"; nothing derived may talk over that.
+	case managedAgent.ProcessLive && managedAgent.Attention.Urgent():
 		// Prompts are answered in the agent's own terminal; the dashboard's
 		// job is pointing at the pane, loudly.
 		hint := " — i to reply"
@@ -53,8 +59,8 @@ func (m Model) renderInteraction(width, height int) string {
 				"Needs "+string(managedAgent.Attention)+hint,
 				width,
 			))
-	} else if managedAgent.ProcessLive &&
-		managedAgent.Attention == agent.AttentionWaiting {
+	case managedAgent.ProcessLive &&
+		managedAgent.Attention == agent.AttentionWaiting:
 		meta = lipgloss.NewStyle().Foreground(colorWaiting).
 			Render(truncate("Unseen result", width))
 	}
@@ -67,6 +73,11 @@ func (m Model) renderInteraction(width, height int) string {
 		// The heading line is easy to slide past; the band above the
 		// composer row is not. It replaces the input affordances entirely
 		// when the agent's own terminal holds the prompt.
+		//
+		// A mark never suppresses this band. Marks are triage — how loudly a
+		// row asks to be looked at — while the band says where text has to go
+		// to reach the agent, which is a fact about the running prompt that
+		// no reading of the state changes.
 		guidance := " ⚠ Agent asked a question — i to reply, Enter for its terminal"
 		if managedAgent.Attention.TerminalOwned() {
 			guidance = " ⚠ Needs " + string(managedAgent.Attention) +

--- a/internal/ui/state.go
+++ b/internal/ui/state.go
@@ -138,7 +138,7 @@ func sortAgentList(agents []agent.Agent, mode sortMode) {
 		})
 	case sortByAttention:
 		slices.SortStableFunc(agents, func(a, b agent.Agent) int {
-			if d := a.Attention.Rank() - b.Attention.Rank(); d != 0 {
+			if d := a.TriageRank() - b.TriageRank(); d != 0 {
 				return d
 			}
 			return newestFirst(a, b)
@@ -310,21 +310,28 @@ func (m *Model) moveSelectionToEnd() {
 }
 
 // markAttentionSeen clears attention locally so the amber drops on the very
-// next frame; the backend write follows asynchronously.
+// next frame; the backend write follows asynchronously. A manual attention
+// mark goes with it — seen is seen, whoever raised the flag.
 func (m *Model) markAttentionSeen(ids ...string) {
 	member := make(map[string]bool, len(ids))
 	for _, id := range ids {
 		member[id] = true
 	}
+	clear := func(managedAgent *agent.Agent) {
+		managedAgent.Attention = agent.AttentionNone
+		if managedAgent.Mark == agent.MarkAttention {
+			managedAgent.Mark = agent.MarkNone
+		}
+	}
 	for index := range m.agents {
 		if member[m.agents[index].ID] {
-			m.agents[index].Attention = agent.AttentionNone
+			clear(&m.agents[index])
 		}
 	}
 	for g := range m.groups {
 		for index := range m.groups[g].agents {
 			if member[m.groups[g].agents[index].ID] {
-				m.groups[g].agents[index].Attention = agent.AttentionNone
+				clear(&m.groups[g].agents[index])
 			}
 		}
 	}
@@ -352,16 +359,19 @@ func clearAttentionCmd(backend Backend, ids ...string) tea.Cmd {
 // clearAttention handles the M hotkey: mark the selected agent — or every
 // agent in the selected workspace — as seen, regardless of tier.
 func (m Model) clearAttention() (tea.Model, tea.Cmd) {
+	flagged := func(managedAgent agent.Agent) bool {
+		return managedAgent.ProcessLive &&
+			(managedAgent.Attention != agent.AttentionNone ||
+				managedAgent.EffectiveMark() == agent.MarkAttention)
+	}
 	ids := []string{}
 	if m.activePane == paneWorkspaces {
 		for _, managedAgent := range m.agentsForSelectedWorkspace() {
-			if managedAgent.ProcessLive &&
-				managedAgent.Attention != agent.AttentionNone {
+			if flagged(managedAgent) {
 				ids = append(ids, managedAgent.ID)
 			}
 		}
-	} else if selected, ok := m.selectedAgent(); ok &&
-		selected.ProcessLive && selected.Attention != agent.AttentionNone {
+	} else if selected, ok := m.selectedAgent(); ok && flagged(selected) {
 		ids = append(ids, selected.ID)
 	}
 	if len(ids) == 0 {

--- a/main.go
+++ b/main.go
@@ -129,6 +129,7 @@ func newRootCommand() *cobra.Command {
 		newRenameCommand(&socket, &sessionName, cfg),
 		newStopCommand(&socket, &sessionName, cfg),
 		newDeleteCommand(&socket, &sessionName, cfg),
+		newMarkCommand(&socket, &sessionName, cfg),
 		newEventCommand(&socket, &sessionName, cfg),
 		newProviderEventCommand(&socket, &sessionName, cfg),
 		newLogsCommand(&logFile),
@@ -682,6 +683,28 @@ func newDeleteCommand(socket, sessionName *string, cfg config.Config) *cobra.Com
 				return err
 			}
 			return service.Delete(cmd.Context(), args[0])
+		},
+	}
+}
+
+func newMarkCommand(socket, sessionName *string, cfg config.Config) *cobra.Command {
+	return &cobra.Command{
+		Use:   "mark <id> <working|attention|none>",
+		Short: "Record your own reading of an agent's state",
+		Long: "Override what Stormlight infers about an agent: working says " +
+			"it is still going, attention flags it to come back to, and none " +
+			"hands the row back to Stormlight's own reading.",
+		Args: cobra.ExactArgs(2),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			mark, err := agent.ParseMark(args[1])
+			if err != nil {
+				return err
+			}
+			service, err := newService(*socket, *sessionName, cfg)
+			if err != nil {
+				return err
+			}
+			return service.SetMark(cmd.Context(), args[0], mark)
 		},
 	}
 }


### PR DESCRIPTION
Stormlight infers activity and attention from provider hooks and pane
state, and it is sometimes wrong: an agent grinding through a long tool
call reads as idle, and a result worth revisiting reads as nothing at
all. Add a mark — the human's own reading — that outranks everything
derived, in the row, the workspace counts, the header, and the Spanreed
heading. Press m on an agent for the picker (w in progress, a needs
attention, c clear), or use stormlight mark <id> <mark> outside the
dashboard.

The two marks retire differently, because different parties can answer
them. In-progress claims the agent is still running, which the agent
settles the moment it reports anything, so its next state-bearing update
retires the mark. Needs-attention claims the human has something to come
back to, which no provider event can answer, so only an explicit clear or
the same engagement that clears amber takes it down. Both stop applying
once the pane is dead, where the exit status is the whole story.

Marked rows say "marked in progress" or "marked needs attention" outright
and an attention mark wears a diamond rather than the inferred tiers' ○
and !, so a corrected row never passes for an inference. The Spanreed
attention band is deliberately left alone: it says where text must go to
reach a live prompt, which is routing rather than triage.

Fixes #67