### PR TITLE
Give the task box a newline key and the rows to show it

### DIFF
--- a/README.md
+++ b/README.md
@@ -198,8 +198,10 @@ Pressing `n` in Agents or Spanreed inherits the current workspace context.
 The centered form contains a vertical `Coding agent` picker, an optional name,
 and a wrapping task composer. Use `j` / `k` to choose Codex, Claude, or another
 configured coding agent, then press `Enter` to compose and `Enter` again to
-launch. Shell remains available through `stormlight dispatch --provider shell`,
-but is not presented as a conversational coding agent.
+launch. Since `Enter` launches, `Ctrl-j` is what breaks a line inside the task
+composer — the same key the Spanreed reply box uses. Shell remains available
+through `stormlight dispatch --provider shell`, but is not presented as a
+conversational coding agent.
 
 `Tab` reaches the name field, which `Enter` on the picker skips past. Leave it
 empty and the agent is named after its task; fill it in and that name is what

--- a/internal/ui/chrome.go
+++ b/internal/ui/chrome.go
@@ -149,12 +149,13 @@ func (m Model) commandHints() string {
 			return "name this agent  Enter " + m.nextDispatchField() +
 				"  Tab fields  Esc cancel"
 		default:
-			hints := "Enter launch"
+			// Enter launches, so the newline key has to be spelled out
+			// here — it is the one affordance in this field with nothing
+			// on screen to suggest it. The name row keeps its own label
+			// and cursor, and the line is only so wide.
+			hints := "Enter launch  Ctrl-j newline"
 			if m.nvimPath != "" {
 				hints += "  Ctrl-o Neovim"
-			}
-			if m.dispatchNameVisible() {
-				hints += "  Shift-Tab name"
 			}
 			return hints + "  Esc cancel"
 		}

--- a/internal/ui/compose.go
+++ b/internal/ui/compose.go
@@ -9,6 +9,7 @@ import (
 	"strings"
 	"unicode"
 
+	"github.com/charmbracelet/bubbles/textarea"
 	tea "github.com/charmbracelet/bubbletea"
 	"github.com/charmbracelet/lipgloss"
 )
@@ -75,9 +76,18 @@ func (m Model) updateCompose(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 // terminal→tmux→pane to hold, and it silently submits instead of inserting
 // a newline anywhere it doesn't. Ctrl+j works everywhere.
 func (m Model) insertComposerNewline() (tea.Model, tea.Cmd) {
-	m.sendInput.InsertString("\n")
+	insertTextareaNewline(&m.sendInput)
 	m.syncComposerSize()
 	return m, nil
+}
+
+// insertTextareaNewline breaks the line under the cursor. The newline is
+// handed to the textarea as the Enter it binds internally rather than
+// written in behind its back: only its own Update repositions the scroll
+// viewport, so an inserted rune leaves the view a row behind the cursor
+// until the next keystroke drags it along.
+func insertTextareaNewline(input *textarea.Model) {
+	*input, _ = input.Update(tea.KeyMsg{Type: tea.KeyEnter})
 }
 
 // syncComposerSize keeps the persisted reply textarea sized to the Spanreed
@@ -94,20 +104,25 @@ func (m *Model) syncComposerSize() {
 	height := composerHeight(m.sendInput.Value(), inner)
 	m.sendInput.SetHeight(height)
 	if height > previous {
-		// The keystroke that grew the content was processed while the box
-		// was still one row short, which scrolled the textarea's viewport —
-		// and nothing scrolls it back once the box catches up (its
-		// repositioning only ever chases the cursor). Rebuilding the value
-		// resets the scroll; the cursor is put back where it was.
-		row := m.sendInput.Line()
-		info := m.sendInput.LineInfo()
-		column := info.StartColumn + info.ColumnOffset
-		m.sendInput.SetValue(m.sendInput.Value())
-		for m.sendInput.Line() > row {
-			m.sendInput.CursorUp()
-		}
-		m.sendInput.SetCursor(column)
+		resetTextareaScroll(&m.sendInput)
 	}
+}
+
+// resetTextareaScroll clears a scroll offset a grown box no longer needs.
+// The keystroke that grew the content was processed while the box was still
+// a row short, which scrolled the textarea's viewport — and nothing scrolls
+// it back once the box catches up, since its repositioning only ever chases
+// the cursor. Rebuilding the value resets the scroll; the cursor is put back
+// where it was.
+func resetTextareaScroll(input *textarea.Model) {
+	row := input.Line()
+	info := input.LineInfo()
+	column := info.StartColumn + info.ColumnOffset
+	input.SetValue(input.Value())
+	for input.Line() > row {
+		input.CursorUp()
+	}
+	input.SetCursor(column)
 }
 
 // insertComposerToken inserts text into the reply at the cursor, padded

--- a/internal/ui/dispatch.go
+++ b/internal/ui/dispatch.go
@@ -17,7 +17,22 @@ import (
 	"github.com/trentkm/stormlight/internal/workspace"
 )
 
+// updateDispatch handles a key in the new-agent form and then re-sizes the
+// task textarea. Nearly every key can change the box the composer is drawn
+// in — a keystroke rewraps it, a directory choice pushes it down the form —
+// and the textarea has to be told, so the sync wraps the key handling
+// instead of trailing every branch of it.
 func (m Model) updateDispatch(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
+	next, cmd := m.dispatchKey(msg)
+	updated, ok := next.(Model)
+	if !ok {
+		return next, cmd
+	}
+	updated.syncTaskComposerSize()
+	return updated, cmd
+}
+
+func (m Model) dispatchKey(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 	key := msg.String()
 	if m.formFocus == dispatchDirectory {
 		switch {
@@ -64,6 +79,13 @@ func (m Model) updateDispatch(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 	case "ctrl+o":
 		if m.formFocus == dispatchTask {
 			return m.openTaskEditor()
+		}
+	case "ctrl+j":
+		// Enter launches the agent, so the task box needs its own newline
+		// key — the same one the Spanreed composer uses.
+		if m.formFocus == dispatchTask {
+			insertTextareaNewline(&m.taskInput)
+			return m, nil
 		}
 	case "h", "left":
 		if m.formFocus == dispatchProvider && len(m.providers) > 0 {
@@ -164,10 +186,10 @@ func (m Model) updateDispatch(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 
 func (m Model) dispatchModalDimensions(width, height int) (int, int) {
 	preferredWidth := 62
-	preferredHeight := 21
+	preferredHeight := 24
 	if m.chooseDispatchDirectory {
 		preferredWidth = 78
-		preferredHeight = 27
+		preferredHeight = 29
 	}
 	return modalDimensions(width, height, preferredWidth, preferredHeight)
 }
@@ -192,10 +214,6 @@ func (m Model) renderAddWorkspaceModal(width, height int) string {
 		modalWidth,
 		modalHeight,
 	)
-}
-
-func (m Model) renderAddWorkspace(width int) string {
-	return m.renderAddWorkspaceAt(width, max(12, m.height-5))
 }
 
 func (m Model) renderAddWorkspaceAt(width, height int) string {
@@ -240,26 +258,104 @@ func (m Model) renderAddWorkspaceAt(width, height int) string {
 	return strings.Join(lines, "\n")
 }
 
-func (m Model) renderDispatch(width int) string {
-	return m.renderDispatchAt(width, max(12, m.height-5))
+// The task composer's floor and ceiling. Under three rows a wrapped task
+// stops being editable — most of what you typed is scrolled out of sight —
+// and past six the box crowds the rest of the form.
+const (
+	minTaskHeight = 3
+	maxTaskHeight = 6
+)
+
+// dispatchFormLayout is the new-agent form's shape inside a given box: the
+// rows above the task composer, how tall the composer gets, and whether the
+// roomy form survived. Drawing the form and sizing the persisted textarea
+// have to agree on all three, so both ask for a layout rather than each
+// deriving its own.
+type dispatchFormLayout struct {
+	head       []string
+	taskHeight int
+	roomy      bool
 }
 
-// roomyForm reports whether the new-agent form has height to spare. A tight
-// form drops its breathing room and the optional name row; the task
-// composer is never what gets cut.
-func roomyForm(height int) bool {
-	return height >= 15
+// dispatchLayout lays the form out at the given content box. The roomy form
+// keeps its breathing room and the optional name row, and gives them up when
+// they would starve the task composer — the composer is the field the form
+// exists to fill, so it is never what gets cut.
+func (m Model) dispatchLayout(width, height int) dispatchFormLayout {
+	roomy := dispatchFormLayout{roomy: true}
+	roomy.head = m.dispatchHeadLines(width, height, true)
+	roomy.taskHeight = dispatchTaskHeight(height, renderedRows(roomy.head), true)
+	if roomy.taskHeight >= minTaskHeight {
+		return roomy
+	}
+	tight := dispatchFormLayout{}
+	tight.head = m.dispatchHeadLines(width, height, false)
+	tight.taskHeight = dispatchTaskHeight(height, renderedRows(tight.head), false)
+	if tight.taskHeight < roomy.taskHeight {
+		return roomy
+	}
+	// A tie goes to the tight form: neither shape can give the composer its
+	// minimum, and the shorter one at least fits more of itself on screen.
+	return tight
 }
 
-// dispatchNameVisible answers the same question against the modal the
-// current terminal actually produces, so focus can skip a field that isn't
-// drawn — a cursor in an invisible input is worse than no field at all.
+// dispatchTaskHeight is what the head rows leave once the composer's border
+// and the hint row have taken their share — plus, in the roomy form, the
+// blank line that separates them.
+func dispatchTaskHeight(height, headRows int, roomy bool) int {
+	reserved := 3
+	if roomy {
+		reserved = 4
+	}
+	return clamp(height-headRows-reserved, 1, maxTaskHeight)
+}
+
+// renderedRows counts the rows a slice of form lines draws. Entries are not
+// all one row: the directory picker arrives as a block of its own, and
+// measuring the composer's share against the slice length hands it rows the
+// modal has already spent — which pushes the hint line, and then the box
+// itself, off the bottom.
+func renderedRows(lines []string) int {
+	rows := 0
+	for _, line := range lines {
+		rows += strings.Count(line, "\n") + 1
+	}
+	return rows
+}
+
+// dispatchNameVisible answers whether the modal the current terminal
+// produces draws the optional name row, so focus can skip a field that isn't
+// there — a cursor in an invisible input is worse than no field at all.
 func (m Model) dispatchNameVisible() bool {
-	_, modalHeight := m.dispatchModalDimensions(m.bodyDimensions())
-	return roomyForm(max(1, modalHeight-2))
+	return m.dispatchLayout(m.dispatchContentDimensions()).roomy
+}
+
+// dispatchContentDimensions is the modal's interior for the terminal as it
+// stands, matching what renderBody hands renderDispatchModal.
+func (m Model) dispatchContentDimensions() (int, int) {
+	modalWidth, modalHeight := m.dispatchModalDimensions(m.bodyDimensions())
+	return max(1, modalWidth-2), max(1, modalHeight-2)
 }
 
 func (m Model) renderDispatchAt(width, height int) string {
+	contentWidth := max(1, width-4)
+	layout := m.dispatchLayout(width, height)
+	lines := append(
+		layout.head,
+		indentLines(m.renderTaskComposer(contentWidth, layout.taskHeight), "  "),
+	)
+	if layout.roomy {
+		lines = append(lines, "")
+	}
+	lines = append(lines,
+		"  "+mutedStyle.Render(truncate(m.commandHints(), contentWidth)),
+	)
+	return strings.Join(lines, "\n")
+}
+
+// dispatchHeadLines renders every row above the task composer. It stops
+// there because how much room is left is the caller's question.
+func (m Model) dispatchHeadLines(width, height int, roomy bool) []string {
 	providerStyle := titleStyle
 	if m.formFocus == dispatchProvider {
 		providerStyle = accentStyle
@@ -306,7 +402,7 @@ func (m Model) renderDispatchAt(width, height int) string {
 			customPathLines = 8
 		}
 		directoryRows := clamp(
-			height-len(lines)-customPathLines-6,
+			height-renderedRows(lines)-customPathLines-6,
 			1,
 			4,
 		)
@@ -323,7 +419,6 @@ func (m Model) renderDispatchAt(width, height int) string {
 		}
 	}
 
-	roomy := roomyForm(height)
 	if roomy {
 		lines = append(lines, "")
 	}
@@ -349,7 +444,7 @@ func (m Model) renderDispatchAt(width, height int) string {
 	if roomy {
 		lines = append(lines, "")
 	}
-	lines = append(lines,
+	return append(lines,
 		"  "+m.renderDispatchSectionTitle(
 			taskStyle,
 			"Task",
@@ -357,13 +452,6 @@ func (m Model) renderDispatchAt(width, height int) string {
 			contentWidth,
 		),
 	)
-	taskHeight := clamp(height-len(lines)-4, 1, 6)
-	lines = append(lines,
-		indentLines(m.renderTaskComposer(contentWidth, taskHeight), "  "),
-		"",
-		"  "+mutedStyle.Render(truncate(m.commandHints(), contentWidth)),
-	)
-	return strings.Join(lines, "\n")
 }
 
 func indentLines(block, prefix string) string {
@@ -384,9 +472,8 @@ func (m Model) renderNameField(width int) string {
 }
 
 func (m Model) renderTaskComposer(width, height int) string {
-	width = max(3, width)
 	height = max(1, height)
-	innerWidth := max(1, width-2)
+	innerWidth := taskComposerWidth(width)
 	input := m.taskInput
 	input.SetWidth(innerWidth)
 	input.SetHeight(height)
@@ -400,6 +487,28 @@ func (m Model) renderTaskComposer(width, height int) string {
 		style = style.BorderForeground(colorAccent)
 	}
 	return style.Render(input.View())
+}
+
+// taskComposerWidth is the textarea's width inside the composer's border.
+func taskComposerWidth(width int) int {
+	return max(1, max(3, width)-2)
+}
+
+// syncTaskComposerSize keeps the persisted task textarea at the size the form
+// draws it. The textarea wraps and scrolls against its own width and height,
+// and that state lives on the model between keystrokes — sizing only the
+// render-time copy leaves the persisted one wrapping at its default width,
+// counting more rows than the box has, and scrolling the viewport the two
+// copies share past the top of what was typed. Nothing scrolls it back.
+func (m *Model) syncTaskComposerSize() {
+	width, height := m.dispatchContentDimensions()
+	layout := m.dispatchLayout(width, height)
+	previous := m.taskInput.Height()
+	m.taskInput.SetWidth(taskComposerWidth(max(1, width-4)))
+	m.taskInput.SetHeight(layout.taskHeight)
+	if layout.taskHeight > previous {
+		resetTextareaScroll(&m.taskInput)
+	}
 }
 
 func nextDispatchMode(mode agent.PermissionMode) agent.PermissionMode {
@@ -1026,6 +1135,7 @@ func (m Model) beginDispatch(chooseDirectory bool) (tea.Model, tea.Cmd) {
 	m.mode = modeDispatch
 	m.dispatchPrefix = ""
 	m.focusForm()
+	m.syncTaskComposerSize()
 	m.err = nil
 	m.status = "New agent"
 	return m, nil

--- a/internal/ui/input_test.go
+++ b/internal/ui/input_test.go
@@ -3,6 +3,7 @@ package ui
 import (
 	"context"
 	"errors"
+	"fmt"
 	"os"
 	"os/exec"
 	"path/filepath"
@@ -465,6 +466,126 @@ func TestDispatchWithoutANameLaunchesUnnamed(t *testing.T) {
 	}
 	if backend.request.Name != "" {
 		t.Fatalf("unnamed dispatch carried name %q", backend.request.Name)
+	}
+}
+
+// dispatchTaskFixture opens the new-agent form on a terminal of the given
+// size with the cursor in the task box.
+func dispatchTaskFixture(t *testing.T, width, height int) Model {
+	t.Helper()
+	backend := &recordingBackend{
+		providers: []provider.Info{
+			{ID: agent.ProviderCodex, Label: "Codex", Available: true},
+			{ID: agent.ProviderClaude, Label: "Claude", Available: true},
+		},
+	}
+	model := NewModel(backend)
+	model.yaziPath = "/opt/homebrew/bin/yazi"
+	sized, _ := model.Update(tea.WindowSizeMsg{Width: width, Height: height})
+	model = sized.(Model)
+	opened, _ := model.beginDispatch(true)
+	model = opened.(Model)
+	model.formFocus = dispatchTask
+	model.focusForm()
+	return model
+}
+
+// taskComposerRows returns the rows the task box draws, border stripped.
+func taskComposerRows(t *testing.T, model Model) []string {
+	t.Helper()
+	width, height := model.dispatchContentDimensions()
+	layout := model.dispatchLayout(width, height)
+	box := strings.Split(
+		ansi.Strip(model.renderTaskComposer(max(1, width-4), layout.taskHeight)),
+		"\n",
+	)
+	if len(box) != layout.taskHeight+2 {
+		t.Fatalf("box drew %d rows, want %d plus its border:\n%s",
+			len(box), layout.taskHeight, strings.Join(box, "\n"))
+	}
+	return box[1 : len(box)-1]
+}
+
+// typeTask types into the task box the way the event loop does, drawing
+// after every key — the textarea scrolls against what was last drawn.
+func typeTask(t *testing.T, model Model, keys ...tea.KeyMsg) Model {
+	t.Helper()
+	for _, key := range keys {
+		updated, _ := model.updateDispatch(key)
+		model = updated.(Model)
+		model.View()
+	}
+	return model
+}
+
+// Enter launches the agent, so the task box needs its own newline key.
+func TestDispatchTaskCtrlJInsertsNewline(t *testing.T) {
+	model := dispatchTaskFixture(t, 120, 40)
+	model = typeTask(t, model,
+		runeKey("first"),
+		tea.KeyMsg{Type: tea.KeyCtrlJ},
+		runeKey("second"),
+	)
+	if got := model.taskInput.Value(); got != "first\nsecond" {
+		t.Fatalf("task = %q, want both lines", got)
+	}
+	if rows := taskComposerRows(t, model); !strings.Contains(rows[0], "first") ||
+		!strings.Contains(rows[1], "second") {
+		t.Fatalf("the box does not show both lines:\n%s", strings.Join(rows, "\n"))
+	}
+}
+
+// Typing past the bottom of the box must keep the cursor's line in view.
+// The textarea wraps and scrolls against its own width and height, so a
+// persisted size that disagrees with the drawn box parks the scroll above
+// what is being typed and nothing brings it back.
+func TestDispatchTaskComposerKeepsTypingInView(t *testing.T) {
+	for _, size := range [][2]int{{80, 24}, {100, 30}, {160, 50}} {
+		model := dispatchTaskFixture(t, size[0], size[1])
+		for index := range 40 {
+			model = typeTask(t, model, runeKey(fmt.Sprintf("word%02d ", index)))
+		}
+		rows := taskComposerRows(t, model)
+		if !strings.Contains(strings.Join(rows, " "), "word39") {
+			t.Fatalf("%dx%d: the last word typed is out of view:\n%s",
+				size[0], size[1], strings.Join(rows, "\n"))
+		}
+		if strings.TrimSpace(rows[0]) == "" {
+			t.Fatalf("%dx%d: the box opens on a blank row:\n%s",
+				size[0], size[1], strings.Join(rows, "\n"))
+		}
+	}
+}
+
+// The form's rows are a fixed budget: the composer takes what is left, and
+// the hint line below it is the first thing a miscount pushes off the
+// bottom of the modal. The path picker is the case that miscounted — it
+// arrives as a block of rows rather than as one line.
+func TestDispatchFormFitsItsModal(t *testing.T) {
+	for _, size := range [][2]int{{80, 24}, {100, 30}, {120, 34}, {160, 50}} {
+		for _, picker := range []bool{false, true} {
+			// A 24-row terminal cannot hold the picker and the form both;
+			// every other combination has to fit whole.
+			if picker && size[1] < 30 {
+				continue
+			}
+			model := dispatchTaskFixture(t, size[0], size[1])
+			if picker {
+				selectCustomDirectory(t, &model)
+				model.startPathNav()
+			}
+			model = typeTask(t, model, runeKey(strings.Repeat("task ", 40)))
+			modal := ansi.Strip(model.renderDispatchModal(model.bodyDimensions()))
+			if !strings.Contains(modal, "Esc cancel") {
+				t.Fatalf("%dx%d picker=%v: the hint line was clipped:\n%s",
+					size[0], size[1], picker, modal)
+			}
+			if !strings.Contains(modal, "task task") {
+				t.Fatalf("%dx%d picker=%v: the task box was clipped:\n%s",
+					size[0], size[1], picker, modal)
+			}
+			assertViewFitsPane(t, model, size[0]-1, size[1]-1)
+		}
 	}
 }
 
@@ -934,6 +1055,8 @@ func TestNewAgentUsesSelectedWorkspaceWithoutDirectoryStep(t *testing.T) {
 	}}
 	model.rebuildGroups(workspaceContext.ID, "feature-agent")
 	model.activePane = paneAgents
+	sized, _ := model.Update(tea.WindowSizeMsg{Width: 120, Height: 40})
+	model = sized.(Model)
 
 	updated, _ := model.updateNormal(runeKey("n"))
 	model = updated.(Model)
@@ -949,7 +1072,7 @@ func TestNewAgentUsesSelectedWorkspaceWithoutDirectoryStep(t *testing.T) {
 	if got := model.cwdInput.Value(); got != executionRoot {
 		t.Fatalf("working directory = %q", got)
 	}
-	rendered := ansi.Strip(model.renderDispatch(80))
+	rendered := ansi.Strip(model.renderDispatchModal(model.bodyDimensions()))
 	if !strings.Contains(rendered, "Coding agent") ||
 		!strings.Contains(rendered, "Task") ||
 		strings.Contains(rendered, "Working directory") ||
@@ -957,10 +1080,15 @@ func TestNewAgentUsesSelectedWorkspaceWithoutDirectoryStep(t *testing.T) {
 		t.Fatalf("unexpected contextual new-agent form:\n%s", rendered)
 	}
 
-	updated, _ = model.updateDispatch(tea.KeyMsg{Type: tea.KeyEnter})
-	model = updated.(Model)
+	for range len(model.dispatchFocusOrder()) {
+		if model.formFocus == dispatchTask {
+			break
+		}
+		updated, _ = model.updateDispatch(tea.KeyMsg{Type: tea.KeyEnter})
+		model = updated.(Model)
+	}
 	if model.formFocus != dispatchTask {
-		t.Fatalf("Enter from coding agent focused %v, want input", model.formFocus)
+		t.Fatalf("Enter never reached the task field: %v", model.formFocus)
 	}
 	model.taskInput.SetValue("review this workspace")
 	updated, cmd := model.updateDispatch(tea.KeyMsg{Type: tea.KeyEnter})

--- a/internal/ui/modals.go
+++ b/internal/ui/modals.go
@@ -155,6 +155,7 @@ func (m Model) renderHelpModal(width, height int) string {
 			{"n", "new agent (or add workspace)"},
 			{"o", "new agent with directory picker"},
 			{"i / s", "write a reply in Spanreed"},
+			{"Ctrl-j", "newline in a reply or task"},
 			{"/ then n/N", "search the Spanreed transcript"},
 			{"drag", "select transcript lines; release copies"},
 			{"Ctrl-v", "paste clipboard image into the reply"},

--- a/internal/ui/model.go
+++ b/internal/ui/model.go
@@ -328,6 +328,7 @@ func (m Model) Update(message tea.Msg) (tea.Model, tea.Cmd) {
 			m.formFocus = dispatchTask
 			m.focusForm()
 		}
+		m.syncTaskComposerSize()
 		return m, tea.Batch(m.loadInteractionCmd(), m.syncAgentWindowsCmd())
 
 	case tickMsg:
@@ -486,6 +487,7 @@ func (m Model) Update(message tea.Msg) (tea.Model, tea.Cmd) {
 		m.cwdInput.SetValue(msg.path)
 		m.formFocus = dispatchTask
 		m.focusForm()
+		m.syncTaskComposerSize()
 		m.status = "Directory selected"
 		return m, tea.EnableMouseCellMotion
 
@@ -499,6 +501,7 @@ func (m Model) Update(message tea.Msg) (tea.Model, tea.Cmd) {
 		m.taskInput.SetValue(msg.task)
 		m.formFocus = dispatchTask
 		m.focusForm()
+		m.syncTaskComposerSize()
 		m.err = nil
 		m.status = "Task updated"
 		return m, tea.EnableMouseCellMotion


### PR DESCRIPTION
Writing a task in the new-agent form went wrong two ways. Enter launches
the agent, so nothing broke a line — the Spanreed composer's Ctrl-j did
nothing here — and once a task wrapped past the box, the text scrolled
out of sight and stayed there.

The scroll was the persisted textarea never being sized. Only the
render-time copy got SetWidth and SetHeight, so between keystrokes the
model's own textarea wrapped at its 40-column default, counted rows the
drawn box did not have, and scrolled the viewport the two copies share
past the top of what was typed. Nothing scrolls it back: the textarea's
repositioning only chases the cursor. syncTaskComposerSize now keeps the
persisted box at the size the form draws, and updateDispatch wraps the
key handling so every key that reflows the form re-sizes it.

The form's rows were miscounted too. The composer took what was left of
the modal measured in slice entries, but the path picker arrives as a
block of six or seven rows counted as one — so with the picker open, the
composer was handed rows the modal had already spent and the hint line,
then the box itself, fell off the bottom. Count rendered rows instead.

What was left over was rarely enough regardless. The optional name row
yielded on a height threshold that had nothing to do with the composer,
so an 80x24 pane drew the name field and gave the task one row. The form
now lays itself out against what the composer needs: the roomy shape
keeps its breathing room and the name row while the composer still gets
three rows, and gives them up when it does not. With the modal two rows
taller, an ordinary terminal draws the full six.

Ctrl-j inserts the newline, routed through the textarea's own Update
rather than InsertString, since only Update repositions the view — the
Spanreed composer had the same one-row lag and now shares the helper.

Fixes #69