### PR TITLE
Let Backspace leave an empty reply box

### DIFF
--- a/README.md
+++ b/README.md
@@ -170,7 +170,8 @@ IDs may be shortened as long as the prefix remains unambiguous.
 
 In Spanreed, press `i` or `s` to open the reply box — it wraps and grows
 with your message, and stays open between messages. Press `Enter` to send,
-`Ctrl-j` for a newline, and `Esc` to leave.
+`Ctrl-j` for a newline, and `Esc` — or `Backspace` once the box is empty —
+to leave.
 Press `/` to search the transcript (`n`/`N` between matches). Drag with the
 mouse to highlight transcript lines — releasing copies them to the tmux
 paste buffer and the system clipboard.

--- a/internal/ui/compose.go
+++ b/internal/ui/compose.go
@@ -17,10 +17,16 @@ import (
 func (m Model) updateCompose(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 	switch msg.String() {
 	case "esc", "ctrl+c", "ctrl+[":
-		m.mode = modeNormal
-		m.sendInput.Blur()
-		m.status = "Ready"
-		return m, nil
+		return m.closeComposer(), nil
+	case "backspace", "ctrl+h":
+		// Backspace deletes backwards until there is nothing left to
+		// delete, and then it deletes the composer: an empty reply box is
+		// the last thing standing between the cursor and the transcript.
+		// Held-down backspace therefore walks out of a reply the same way
+		// it walked into it, without the hand leaving for Esc.
+		if m.sendInput.Value() == "" {
+			return m.closeComposer(), nil
+		}
 	case "ctrl+j":
 		return m.insertComposerNewline()
 	case "ctrl+v":
@@ -69,6 +75,16 @@ func (m Model) updateCompose(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 	m.sendInput, cmd = m.sendInput.Update(msg)
 	m.syncComposerSize()
 	return m, cmd
+}
+
+// closeComposer leaves the reply box and hands the keyboard back to normal
+// mode. The value is left as it is: nothing that closes the composer discards
+// a draft, and re-entering with i finds the message where it was.
+func (m Model) closeComposer() Model {
+	m.mode = modeNormal
+	m.sendInput.Blur()
+	m.status = "Ready"
+	return m
 }
 
 // insertComposerNewline breaks the line under the cursor (ctrl+j).

--- a/internal/ui/flows_test.go
+++ b/internal/ui/flows_test.go
@@ -453,6 +453,38 @@ func TestComposerCtrlJInsertsNewline(t *testing.T) {
 	}
 }
 
+func TestComposerBackspaceLeavesOnlyWhenEmpty(t *testing.T) {
+	model := flowModelFixture(t, &flowBackend{})
+	updated, _ := model.updateNormal(runeKey("i"))
+	model = updated.(Model)
+	model.sendInput.SetValue("hi")
+
+	next, _ := model.updateCompose(tea.KeyMsg{Type: tea.KeyBackspace})
+	model = next.(Model)
+	if model.mode != modeCompose {
+		t.Fatalf("backspace over text left compose mode: %d", model.mode)
+	}
+	if model.sendInput.Value() != "h" {
+		t.Fatalf("backspace did not delete a rune: %q", model.sendInput.Value())
+	}
+
+	next, _ = model.updateCompose(tea.KeyMsg{Type: tea.KeyBackspace})
+	model = next.(Model)
+	if model.mode != modeCompose || model.sendInput.Value() != "" {
+		t.Fatalf("emptying the box left compose mode early: mode=%d value=%q",
+			model.mode, model.sendInput.Value())
+	}
+
+	next, _ = model.updateCompose(tea.KeyMsg{Type: tea.KeyBackspace})
+	model = next.(Model)
+	if model.mode != modeNormal {
+		t.Fatalf("backspace on an empty box stayed in mode %d", model.mode)
+	}
+	if model.sendInput.Focused() {
+		t.Fatal("reply box kept focus after leaving")
+	}
+}
+
 func TestComposerRuleAndVisibleRows(t *testing.T) {
 	if width := len([]rune(ansi.Strip(renderComposerRule(24)))); width != 24 {
 		t.Fatalf("composer rule width = %d", width)

--- a/internal/ui/modals.go
+++ b/internal/ui/modals.go
@@ -156,6 +156,7 @@ func (m Model) renderHelpModal(width, height int) string {
 			{"o", "new agent with directory picker"},
 			{"i / s", "write a reply in Spanreed"},
 			{"Ctrl-j", "newline in a reply or task"},
+			{"Backspace", "leave the reply box once it is empty"},
 			{"/ then n/N", "search the Spanreed transcript"},
 			{"drag", "select transcript lines; release copies"},
 			{"Ctrl-v", "paste clipboard image into the reply"},


### PR DESCRIPTION
In Spanreed, `Backspace` on an already-empty reply box now closes the composer and returns to normal mode, instead of doing nothing. A non-empty box behaves exactly as before — one rune per press — and the draft is left intact when the box closes, the same way `Esc` has always left it.

`Ctrl-h` gets the same treatment, since that is the other key the rest of the UI treats as backspace.

Help modal and README updated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)