### PR TITLE
Name the agent, not the session, on the tmux status bar

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,12 +35,15 @@ preserving the checkout or worktree each agent is using.
 An outside-tmux launch transparently hosts the dashboard in a temporary
 session on the Stormlight server; a launch from inside your own tmux uses the
 current pane directly and reaches agents through a nested client. Selecting an
-agent switches to its window. Press the tmux prefix followed by `Q` to return
-to the dashboard. Stormlight installs this binding only when `Q` is unbound or
-already owned by Stormlight. While the prefix is active, the managed session
-highlights the tmux status bar and shows `Q` for return and `?` for the full
-tmux key list. Closing the dashboard removes only its temporary session;
-agents keep running on the Stormlight server.
+agent switches to its window, and that window's status bar names where you
+are — `workspace › worktree › agent` — rather than listing the session's other
+agents, which the dashboard is already for. A narrow terminal drops the outer
+segments first; the agent's own name always stays. Press the tmux prefix
+followed by `Q` to return to the dashboard. Stormlight installs this binding
+only when `Q` is unbound or already owned by Stormlight. While the prefix is
+active, the managed session highlights the tmux status bar and shows `Q` for
+return and `?` for the full tmux key list. Closing the dashboard removes only
+its temporary session; agents keep running on the Stormlight server.
 
 ## Requirements
 

--- a/internal/tmux/runtime.go
+++ b/internal/tmux/runtime.go
@@ -34,20 +34,60 @@ const (
 	statusStylePrefixOption = "@stormlight_status_style_prefix"
 	statusLeftBaseOption    = "@stormlight_status_left_base"
 	statusLeftPrefixOption  = "@stormlight_status_left_prefix"
-	prefixFeedbackOption    = "@stormlight_prefix_feedback"
-	prefixFeedbackVersion   = "2"
+	statusVersionOption     = "@stormlight_status_version"
+	statusVersion           = "3"
 	prefixStatusStyle       = "bg=#e5c07b,fg=#1f2328,bold"
 	prefixStatusLeft        = " PREFIX  [Q] return  [?] all keys "
 	// The agents session lives on the Stormlight-owned server, so its
 	// status bar carries the dashboard's identity: a deep sapphire band
 	// with the glint-and-wordmark status-left, echoing the header.
-	baseStatusStyle      = "bg=#1B2740,fg=#C8D6F2"
-	baseStatusLeft       = " #[fg=#7DCFFF,bold]✦ #[fg=#E8EEF9,bold]#{session_name}#[default] "
-	baseStatusLeftLength = 40
+	baseStatusStyle = "bg=#1B2740,fg=#C8D6F2"
+	// A window inside an agent is a place, and the bar names it the way the
+	// dashboard does: workspace › worktree › agent. Only the runtime's own
+	// windows carry @stormlight_id; anything else on the band (the dashboard's
+	// own host session, a stray shell) falls back to the session name.
+	//
+	// Commas inside #[...] have to be escaped as #, — an unescaped one ends
+	// the surrounding #{?...} branch and swallows the rest of the format.
+	agentStatusLineage = `#{?#{@stormlight_workspace_name},` +
+		statusWorkspaceSegment + statusTailSegment + `,}` +
+		`#[fg=#E8EEF9#,bold]#{window_name}`
+	// Each segment is capped so a verbose workspace name cannot crowd out the
+	// agent, and each is dropped outright once the client is too narrow to
+	// hold it: the worktree below 90 columns, the workspace below 60. The
+	// agent's own name never drops — it is the answer the bar exists to give.
+	statusWorkspaceSegment = `#{?#{e|>=:#{client_width},60},` +
+		`#[fg=#8FA6CC]#{=/16/…:@stormlight_workspace_name}#[fg=#55698F] › ,}`
+	statusTailSegment = `#{?#{e|>=:#{client_width},90},` +
+		`#{?#{@stormlight_workspace_tail},` +
+		`#[fg=#8FA6CC]#{=/16/…:@stormlight_workspace_tail}#[fg=#55698F] › ,},}`
+	// The glint drops back to #[default] immediately: tmux attributes latch
+	// until something clears them, so a bold that stayed on would make the
+	// whole band bold and flatten the lineage into one weight.
+	baseStatusLeft = ` #[fg=#7DCFFF#,bold]✦#[default] #{?#{@stormlight_id},` +
+		agentStatusLineage + `,#[fg=#E8EEF9#,bold]#{session_name}} `
+	// status-left is the whole bar now, so its own length cap stays out of the
+	// way; what keeps it off the return hint is the render-time truncation in
+	// dynamicStatusLeft, which subtracts the hint's width from the client's.
+	baseStatusLeftLength = 400
 	dynamicStatusStyle   = `#{?client_prefix,#{E:@stormlight_status_style_prefix},#{E:@stormlight_status_style_base}}`
-	dynamicStatusLeft    = `#{?client_prefix,#{E:@stormlight_status_left_prefix},#{E:@stormlight_status_left_base}}`
-	basePaneFieldCount   = 10
-	metadataFieldCount   = 20
+	dynamicStatusLeft    = `#{?client_prefix,#{E:@stormlight_status_left_prefix},` +
+		`#{T;=/#{e|-:#{client_width},#{status-right-length}}:@stormlight_status_left_base}}`
+	// Stormlight's windows are its agents, and the dashboard is where you
+	// choose between them — listing them again on every agent's status bar
+	// only pushes the lineage of the one you are actually in off the band. So
+	// the bar is left and right sections with no window list between them.
+	// status-format is a session option, which is what makes this safe: the
+	// managed session may share a server with the user's own sessions, and
+	// they keep tmux's default bar.
+	statusFormat = `#[align=left range=left #{E:status-left-style}]#[push-default]` +
+		`#{T;=/#{status-left-length}:status-left}` +
+		`#[pop-default]#[norange default]` +
+		`#[align=right range=right #{E:status-right-style}]#[push-default]` +
+		`#{T;=/#{status-right-length}:status-right}` +
+		`#[pop-default]#[norange default]`
+	basePaneFieldCount = 10
+	metadataFieldCount = 20
 )
 
 var agentMetadataFields = [metadataFieldCount]string{
@@ -401,8 +441,8 @@ func (r *Runtime) configureReturn(ctx context.Context, sessionName, windowID, ta
 		return fmt.Errorf("install tmux return binding: %w", err)
 	}
 	r.configureRootReturn(ctx)
-	if err := r.configurePrefixFeedback(ctx, sessionName); err != nil {
-		diagnostic.Logger().Warn("tmux prefix feedback unavailable", "error", err)
+	if err := r.configureStatusBar(ctx, sessionName); err != nil {
+		diagnostic.Logger().Warn("tmux status bar unavailable", "error", err)
 	}
 	if _, err := r.runner.Run(ctx, nil,
 		"set-option", "-w", "-t", windowID, returnTargetOption, target,
@@ -453,14 +493,19 @@ func (r *Runtime) configureRootReturn(ctx context.Context) {
 	}
 }
 
-func (r *Runtime) configurePrefixFeedback(ctx context.Context, sessionName string) error {
+// configureStatusBar dresses the managed session's status bar: the sapphire
+// band, the agent's lineage on the left, the return hint on the right, and the
+// amber prefix state that replaces the left while the prefix is held. The
+// whole thing is versioned by one option so a session configured by an older
+// binary is re-dressed rather than left half-current.
+func (r *Runtime) configureStatusBar(ctx context.Context, sessionName string) error {
 	version, err := r.runner.Run(ctx, nil,
-		"show-options", "-qv", "-t", sessionName, prefixFeedbackOption,
+		"show-options", "-qv", "-t", sessionName, statusVersionOption,
 	)
 	if err != nil {
-		return fmt.Errorf("read prefix feedback version: %w", err)
+		return fmt.Errorf("read status bar version: %w", err)
 	}
-	if version == prefixFeedbackVersion {
+	if version == statusVersion {
 		return nil
 	}
 
@@ -472,13 +517,14 @@ func (r *Runtime) configurePrefixFeedback(ctx context.Context, sessionName strin
 		{statusLeftBaseOption, baseStatusLeft},
 		{statusStylePrefixOption, prefixStatusStyle},
 		{statusLeftPrefixOption, prefixStatusLeft},
-		{prefixFeedbackOption, prefixFeedbackVersion},
+		{statusVersionOption, statusVersion},
 		{"status-style", dynamicStatusStyle},
 		{"status-left", dynamicStatusLeft},
 		{"status-left-length", strconv.Itoa(
 			max(baseStatusLeftLength, len(prefixStatusLeft)))},
 		{"status-right", r.statusRightHint()},
 		{"status-right-length", strconv.Itoa(len(r.statusRightHint()))},
+		{"status-format[0]", statusFormat},
 	}
 	for _, option := range options {
 		if _, err := r.runner.Run(ctx, nil,
@@ -942,13 +988,18 @@ func encodeWorkspaceOptions(value workspace.Context) (map[string]string, error) 
 		metadata = base64.RawURLEncoding.EncodeToString(encoded)
 	}
 	return map[string]string{
-		"@stormlight_workspace_id":       value.ID,
-		"@stormlight_workspace_kind":     value.Kind,
-		"@stormlight_workspace_name":     value.Name,
-		"@stormlight_workspace_root":     value.Root,
-		"@stormlight_execution_root":     value.ExecutionRoot,
-		"@stormlight_component_name":     value.ComponentName,
-		"@stormlight_component_root":     value.ComponentRoot,
+		"@stormlight_workspace_id":   value.ID,
+		"@stormlight_workspace_kind": value.Kind,
+		"@stormlight_workspace_name": value.Name,
+		"@stormlight_workspace_root": value.Root,
+		"@stormlight_execution_root": value.ExecutionRoot,
+		"@stormlight_component_name": value.ComponentName,
+		"@stormlight_component_root": value.ComponentRoot,
+		// The lineage tail is derived, not stored: the status bar needs it as
+		// one value because tmux formats cannot pick between a component and
+		// a worktree basename. It is written here, alongside the fields it is
+		// derived from, so the two can never drift.
+		"@stormlight_workspace_tail":     value.Tail(),
 		"@stormlight_workspace_metadata": metadata,
 	}, nil
 }

--- a/internal/tmux/runtime_test.go
+++ b/internal/tmux/runtime_test.go
@@ -291,7 +291,7 @@ func TestAttachOutsideTmuxReturnsInteractiveCommand(t *testing.T) {
 			"run-shell", "-C", returnBindingFormat},
 	}
 	wantCalls = append(wantCalls, rootReturnCalls()...)
-	wantCalls = append(wantCalls, prefixFeedbackCalls("stormlight-agents")...)
+	wantCalls = append(wantCalls, statusBarCalls("stormlight-agents")...)
 	wantCalls = append(wantCalls,
 		[]string{"set-option", "-w", "-t", "@1", "@stormlight_return_target", ""},
 	)
@@ -343,7 +343,7 @@ func TestAttachInsideTmuxSwitchesCurrentClient(t *testing.T) {
 					"run-shell", "-C", returnBindingFormat},
 			}
 			wantCalls = append(wantCalls, rootReturnCalls()...)
-			wantCalls = append(wantCalls, prefixFeedbackCalls("stormlight-agents")...)
+			wantCalls = append(wantCalls, statusBarCalls("stormlight-agents")...)
 			wantCalls = append(wantCalls,
 				[]string{"set-option", "-w", "-t", "@1", "@stormlight_return_target", "$7"},
 			)
@@ -409,7 +409,7 @@ func TestAttachRefreshesStormlightOwnedReturnBinding(t *testing.T) {
 			"run-shell", "-C", returnBindingFormat},
 	}
 	wantCalls = append(wantCalls, rootReturnCalls()...)
-	wantCalls = append(wantCalls, prefixFeedbackCalls("stormlight-agents")...)
+	wantCalls = append(wantCalls, statusBarCalls("stormlight-agents")...)
 	wantCalls = append(wantCalls,
 		[]string{"set-option", "-w", "-t", "@1", "@stormlight_return_target", ""},
 	)
@@ -444,15 +444,56 @@ func TestAttachSkipsForeignRootBindingsWithoutFailing(t *testing.T) {
 	}
 }
 
-func TestConfigurePrefixFeedbackSkipsCurrentVersion(t *testing.T) {
-	runner := &captureRunner{feedbackVersion: prefixFeedbackVersion}
+// tmux ends a #{?...} branch at the first unescaped comma, and a comma inside
+// a #[...] style tag counts: leave one raw and the branch stops mid-style,
+// taking the rest of the status bar with it. The failure is silent — tmux
+// renders a truncated bar rather than complaining — so the rule is enforced
+// here instead of being discovered on someone's screen.
+func TestStatusFormatsEscapeStyleCommas(t *testing.T) {
+	for name, format := range map[string]string{
+		"agentStatusLineage":     agentStatusLineage,
+		"statusWorkspaceSegment": statusWorkspaceSegment,
+		"statusTailSegment":      statusTailSegment,
+		"baseStatusLeft":         baseStatusLeft,
+		"dynamicStatusLeft":      dynamicStatusLeft,
+		"dynamicStatusStyle":     dynamicStatusStyle,
+		"statusFormat":           statusFormat,
+	} {
+		for _, tag := range styleTags(format) {
+			for index, char := range tag {
+				if char == ',' && (index == 0 || tag[index-1] != '#') {
+					t.Fatalf("%s: unescaped comma in style tag %q", name, tag)
+				}
+			}
+		}
+	}
+}
+
+// styleTags returns every #[...] span in a tmux format.
+func styleTags(format string) []string {
+	var tags []string
+	for index := 0; index+1 < len(format); index++ {
+		if format[index] != '#' || format[index+1] != '[' {
+			continue
+		}
+		end := strings.IndexByte(format[index:], ']')
+		if end < 0 {
+			continue
+		}
+		tags = append(tags, format[index:index+end+1])
+	}
+	return tags
+}
+
+func TestConfigureStatusBarSkipsCurrentVersion(t *testing.T) {
+	runner := &captureRunner{feedbackVersion: statusVersion}
 	runtime := &Runtime{runner: runner}
 
-	if err := runtime.configurePrefixFeedback(context.Background(), "custom-agents"); err != nil {
+	if err := runtime.configureStatusBar(context.Background(), "custom-agents"); err != nil {
 		t.Fatal(err)
 	}
 	assertCalls(t, runner.calls, [][]string{
-		{"show-options", "-qv", "-t", "custom-agents", "@stormlight_prefix_feedback"},
+		{"show-options", "-qv", "-t", "custom-agents", statusVersionOption},
 	})
 }
 
@@ -472,8 +513,13 @@ func TestUpdateRestoresMissingStormlightWindowMetadata(t *testing.T) {
 			written[call[4]] = call[5]
 		}
 	}
-	if len(written) != metadataFieldCount {
-		t.Fatalf("wrote %d metadata options: %#v", len(written), written)
+	// Every field the pane listing reads back has to be restored; the record
+	// is only whole if the window carries all of them. Options written for
+	// display alone — the status bar's lineage tail — may ride along.
+	for _, field := range agentMetadataFields {
+		if _, ok := written["@stormlight_"+field]; !ok {
+			t.Fatalf("metadata option %q was not restored: %#v", field, written)
+		}
 	}
 	if written["@stormlight_id"] != "capture-id" {
 		t.Fatalf("stormlight id = %q", written["@stormlight_id"])
@@ -615,7 +661,7 @@ func (r *captureRunner) Run(_ context.Context, _ []byte, args ...string) (string
 		return r.clientLine, nil
 	case "show-options":
 		switch args[len(args)-1] {
-		case prefixFeedbackOption:
+		case statusVersionOption:
 			return r.feedbackVersion, nil
 		case "@stormlight_id":
 			return r.stormlightID, nil
@@ -625,9 +671,9 @@ func (r *captureRunner) Run(_ context.Context, _ []byte, args ...string) (string
 	return "pane output", nil
 }
 
-func prefixFeedbackCalls(sessionName string) [][]string {
+func statusBarCalls(sessionName string) [][]string {
 	return [][]string{
-		{"show-options", "-qv", "-t", sessionName, "@stormlight_prefix_feedback"},
+		{"show-options", "-qv", "-t", sessionName, statusVersionOption},
 		{"set-option", "-t", sessionName, "@stormlight_status_style_base",
 			baseStatusStyle},
 		{"set-option", "-t", sessionName, "@stormlight_status_left_base",
@@ -636,14 +682,15 @@ func prefixFeedbackCalls(sessionName string) [][]string {
 			"bg=#e5c07b,fg=#1f2328,bold"},
 		{"set-option", "-t", sessionName, "@stormlight_status_left_prefix",
 			" PREFIX  [Q] return  [?] all keys "},
-		{"set-option", "-t", sessionName, "@stormlight_prefix_feedback",
-			prefixFeedbackVersion},
+		{"set-option", "-t", sessionName, statusVersionOption, statusVersion},
 		{"set-option", "-t", sessionName, "status-style", dynamicStatusStyle},
 		{"set-option", "-t", sessionName, "status-left", dynamicStatusLeft},
-		{"set-option", "-t", sessionName, "status-left-length", "40"},
+		{"set-option", "-t", sessionName, "status-left-length",
+			strconv.Itoa(baseStatusLeftLength)},
 		{"set-option", "-t", sessionName, "status-right", (&Runtime{}).statusRightHint()},
 		{"set-option", "-t", sessionName, "status-right-length",
 			strconv.Itoa(len((&Runtime{}).statusRightHint()))},
+		{"set-option", "-t", sessionName, "status-format[0]", statusFormat},
 	}
 }
 

--- a/internal/ui/workspaces.go
+++ b/internal/ui/workspaces.go
@@ -338,7 +338,7 @@ func workspaceDetail(value workspace.Context, width int) string {
 		if pathToken != "" {
 			parts = append(parts, pathToken)
 		}
-		if tail := workspaceDetailTail(value); tail != "" {
+		if tail := value.Tail(); tail != "" {
 			parts = append(parts, tail)
 		}
 		return strings.Join(parts, " · ")
@@ -354,20 +354,6 @@ func workspaceDetail(value workspace.Context, width int) string {
 		detail = join(truncatePathTail(path, max(1, width-overhead)))
 	}
 	return ansi.Truncate(detail, width, "…")
-}
-
-// workspaceDetailTail is the subtitle's final token: a resolver-supplied
-// component, or the worktree directory when the agent runs outside the main
-// checkout. Empty when neither adds information beyond the workspace name.
-func workspaceDetailTail(value workspace.Context) string {
-	tail := value.ComponentName
-	if tail == "" && value.ExecutionRoot != "" && value.ExecutionRoot != value.Root {
-		tail = filepath.Base(value.ExecutionRoot)
-	}
-	if tail == value.Name {
-		return ""
-	}
-	return tail
 }
 
 // abbreviatePath shortens every segment but the last to its first rune,

--- a/internal/workspace/context.go
+++ b/internal/workspace/context.go
@@ -29,6 +29,23 @@ func (c Context) IsZero() bool {
 	return c.ID == ""
 }
 
+// Tail is the lineage segment that follows the workspace name: a
+// resolver-supplied component, or the worktree directory when the agent runs
+// outside the main checkout. It is empty when neither says anything the
+// workspace name does not already say. The dashboard's workspace subtitle and
+// the managed session's tmux status bar both read it, so the rule lives here
+// rather than in either renderer.
+func (c Context) Tail() string {
+	tail := c.ComponentName
+	if tail == "" && c.ExecutionRoot != "" && c.ExecutionRoot != c.Root {
+		tail = pathName(c.ExecutionRoot)
+	}
+	if tail == c.Name {
+		return ""
+	}
+	return tail
+}
+
 func (c Context) IsComplete() bool {
 	return c.ID != "" &&
 		c.Kind != "" &&

--- a/internal/workspace/context_test.go
+++ b/internal/workspace/context_test.go
@@ -1,0 +1,54 @@
+package workspace
+
+import "testing"
+
+func TestContextTail(t *testing.T) {
+	for _, testCase := range []struct {
+		name  string
+		value Context
+		want  string
+	}{
+		{
+			name: "component wins",
+			value: Context{
+				Name:          "monorepo",
+				Root:          "/repos/monorepo",
+				ExecutionRoot: "/repos/monorepo/services/api",
+				ComponentName: "api",
+			},
+			want: "api",
+		},
+		{
+			name: "worktree stands in for a missing component",
+			value: Context{
+				Name:          "stormlight",
+				Root:          "/repos/stormlight",
+				ExecutionRoot: "/repos/stormlight/.claude/worktrees/status-bar",
+			},
+			want: "status-bar",
+		},
+		{
+			name: "main checkout has no tail",
+			value: Context{
+				Name:          "stormlight",
+				Root:          "/repos/stormlight",
+				ExecutionRoot: "/repos/stormlight",
+			},
+			want: "",
+		},
+		{
+			name: "a tail that repeats the name says nothing",
+			value: Context{
+				Name:          "api",
+				Root:          "/repos/monorepo",
+				ExecutionRoot: "/repos/monorepo/api",
+				ComponentName: "api",
+			},
+			want: "",
+		},
+	} {
+		if got := testCase.value.Tail(); got != testCase.want {
+			t.Fatalf("%s: tail = %q, want %q", testCase.name, got, testCase.want)
+		}
+	}
+}


### PR DESCRIPTION
Inside an agent, the tmux status bar read `✦ stormlight-agents 0:Brew 1:Refactor 2:Test Task- 3:Status Bar*` — the session name plus every other agent's window. Neither half says which agent you are in.

It now shows that window's lineage, the same one the dashboard's workspace subtitle uses:

```
 ✦ stormlight › status-bar-lineage › Status Bar Lineage          C-6 ⏎ dashboard
```

- The window list is gone. Choosing between agents is the dashboard's job, and the list crowded out the one thing the bar is positioned to say. `status-format` is a session option, so any other session on the server — including your own — keeps tmux's default bar.
- The tail rule (component, else the worktree directory when it differs from the main checkout) moved to `workspace.Context.Tail`, so the dashboard subtitle and the status bar read it from one place. `Dispatch`/`SetWorkspace` write it as a window option beside the fields it derives from.
- Sizing happens in the tmux format, because only tmux knows the client width at render time: segments are capped, the worktree drops below 90 columns and the workspace below 60, and the left side is truncated to the client width less the return hint so it can never overrun it. The agent's own name never drops.

Verified against a real tmux server at 55–120 columns — an agent in a worktree, an agent without one, a window with no workspace, and a plain window falling back to the session name — plus the prefix state still taking over the left side.

The three `internal/ui` dispatch-focus failures on this branch are #73, already red on `origin/main`.

Fixes #74