### PR TITLE
Give the dashboard's chrome a hierarchy

### DIFF
--- a/internal/ui/chrome.go
+++ b/internal/ui/chrome.go
@@ -58,24 +58,51 @@ func renderComposerRule(width int) string {
 	return out.String()
 }
 
-// renderFooterRule tints the divider with the wordmark's sapphire→ice
-// gradient, dimmed toward the border grey — the footer's quiet echo of the
-// header identity.
-func renderFooterRule(width int) string {
+// The dashboard is framed by one band of light: the wordmark's sapphire→ice
+// gradient, run across the full terminal width and held back toward the
+// border grey. The pane headers ride the top of it and the footer rule the
+// bottom, so the frame reads as a single drawn material rather than three
+// decorations that happen to share a screen. The segment the cursor is in
+// rises to full strength — focus is where the band brightens, not a color
+// swapped out for another.
+//
+// bandColor is that gradient sampled at t, the fraction of the way across
+// the dashboard.
+func bandColor(t float64, lit bool) lipgloss.AdaptiveColor {
+	fade := 0.55
+	if lit {
+		fade = 0
+	}
+	return lipgloss.AdaptiveColor{
+		Light: lerpHex(gradientStop(wordmarkStopsLight, t), colorBorder.Light, fade),
+		Dark:  lerpHex(gradientStop(wordmarkStopsDark, t), colorBorder.Dark, fade),
+	}
+}
+
+// renderBandRun draws count cells of the band. The run knows where it sits in
+// the dashboard (start of total columns) rather than restarting the gradient
+// per pane, which is what keeps the header rules and the footer rule reading
+// as one continuous sweep. The header draws its band as underlined blanks so
+// it can share a row with the labels; the footer, having a row to itself,
+// draws glyphs.
+func renderBandRun(glyph string, start, count, total int, lit, underlined bool) string {
 	var out strings.Builder
-	for index := 0; index < width; index++ {
+	for index := 0; index < count; index++ {
 		t := 0.0
-		if width > 1 {
-			t = float64(index) / float64(width-1)
+		if total > 1 {
+			t = float64(clamp(start+index, 0, total-1)) / float64(total-1)
 		}
-		out.WriteString(lipgloss.NewStyle().
-			Foreground(lipgloss.AdaptiveColor{
-				Light: lerpHex(gradientStop(wordmarkStopsLight, t), "#AAB3B9", 0.55),
-				Dark:  lerpHex(gradientStop(wordmarkStopsDark, t), "#59636B", 0.55),
-			}).
-			Render("─"))
+		style := lipgloss.NewStyle().Foreground(bandColor(t, lit))
+		if underlined {
+			style = style.Underline(true)
+		}
+		out.WriteString(style.Render(glyph))
 	}
 	return out.String()
+}
+
+func renderFooterRule(width int) string {
+	return renderBandRun("─", 0, width, width, false, false)
 }
 
 func (m Model) chordHints() string {

--- a/internal/ui/input_test.go
+++ b/internal/ui/input_test.go
@@ -761,10 +761,11 @@ func TestWideDashboardRendersThreePaneHierarchy(t *testing.T) {
 	assertViewFitsPane(t, model, 119, 29)
 }
 
-// One rule crosses the dashboard body, and it is the one that matters: the
-// heavy seam between the catalog and the Spanreed, capped under the header
-// band and trailed by a column of air. The catalog's own columns are divided
-// by nothing at all.
+// The dashboard's two seams divide different kinds of thing, so they are not
+// drawn alike: a hairline in the header band's own faded gradient splits the
+// catalog's columns, while a heavy accent rule trailed by a column of air
+// splits the whole catalog from the Spanreed. Both hang from caps under the
+// band, and both keep air on either side.
 func TestWideDashboardSeamsSeparateCatalogFromControlPlane(t *testing.T) {
 	model := NewModel(stubBackend{})
 	model.width = 120
@@ -784,34 +785,35 @@ func TestWideDashboardSeamsSeparateCatalogFromControlPlane(t *testing.T) {
 	if header < 0 {
 		t.Fatalf("pane header row not found:\n%s", body)
 	}
-	// The header row carries the seam's cap, not the seam: a half-stroke
-	// that begins at the band and descends out of it.
+	// The header row carries the seams' caps, not the seams: half-strokes
+	// that begin at the band and descend out of it.
+	hairline := strings.Index(lines[header], "╷")
 	plane := strings.Index(lines[header], "╻")
-	if plane < 0 {
-		t.Fatalf("plane seam is not capped under the band: %q", lines[header])
+	if hairline < 0 || plane < 0 || plane < hairline {
+		t.Fatalf("seams are not capped under the band: %q", lines[header])
 	}
-	if strings.ContainsAny(lines[header], "│┃╷") {
+	if strings.ContainsAny(lines[header], "│┃") {
 		t.Fatalf("uncapped seam collides with the header band: %q", lines[header])
 	}
 
 	firstRow := lines[header+1]
-	if strings.Index(firstRow, "┃") != plane {
-		t.Fatalf("seam does not hang from its cap:\n%q\n%q",
+	if strings.Index(firstRow, "│") != hairline ||
+		strings.Index(firstRow, "┃") != plane {
+		t.Fatalf("seams do not hang from their caps:\n%q\n%q",
 			lines[header], firstRow)
 	}
 
 	for _, line := range lines[header+1:] {
-		if strings.Contains(line, "│") {
-			t.Fatalf("a rule still divides the catalog's columns: %q", line)
-		}
 		runes := []rune(line)
-		column := -1
-		for index, glyph := range runes {
-			if glyph == '┃' {
-				column = index
-				break
+		if column := runeIndex(runes, '│'); column >= 0 {
+			if column+1 < len(runes) && runes[column+1] != ' ' {
+				t.Fatalf("catalog rule has no air behind it: %q", line)
+			}
+			if column > 0 && runes[column-1] != ' ' {
+				t.Fatalf("catalog rule has no air before it: %q", line)
 			}
 		}
+		column := runeIndex(runes, '┃')
 		if column < 0 {
 			t.Fatalf("body row has no plane seam: %q", line)
 		}
@@ -821,7 +823,12 @@ func TestWideDashboardSeamsSeparateCatalogFromControlPlane(t *testing.T) {
 	}
 }
 
-func TestAgentPaneHeaderShowsSelectedWorkspace(t *testing.T) {
+// The wide layout already says which workspace is selected four ways — the ›
+// marker, the undimmed row, the connector arc, and the agent list's contents —
+// so the header does not spell it out a fifth time. The narrow layout shows
+// one pane at a time, where none of those four are on screen, and there the
+// context label is the only thing naming the workspace.
+func TestAgentPaneHeaderNamesWorkspaceOnlyWhenNarrow(t *testing.T) {
 	workspaceContext := workspace.DirectoryContext("/workspace/meshclaw")
 	model := NewModel(stubBackend{})
 	model.width = 120
@@ -831,10 +838,18 @@ func TestAgentPaneHeaderShowsSelectedWorkspace(t *testing.T) {
 	model.rebuildGroups(workspaceContext.ID, "")
 
 	header := strings.Split(ansi.Strip(model.renderBody()), "\n")[0]
-	if !strings.Contains(header, "Agents") ||
-		!strings.Contains(header, "meshclaw") ||
-		strings.Index(header, "meshclaw") < strings.Index(header, "Agents") {
-		t.Fatalf("agent header lacks right-aligned workspace context: %q", header)
+	if !strings.Contains(header, "Agents") {
+		t.Fatalf("agent header is missing its label: %q", header)
+	}
+	if strings.Contains(header, "meshclaw") {
+		t.Fatalf("wide agent header repeats the workspace: %q", header)
+	}
+
+	model.width = 60
+	narrow := strings.Split(ansi.Strip(model.renderBody()), "\n")[0]
+	if !strings.Contains(narrow, "meshclaw") ||
+		strings.Index(narrow, "meshclaw") < strings.Index(narrow, "Agents") {
+		t.Fatalf("narrow agent header lacks its workspace context: %q", narrow)
 	}
 
 	rendered := ansi.Strip(renderPaneHeader("Agents", "a-very-long-workspace-name", 24, true, headerBand{total: 24}))
@@ -846,8 +861,10 @@ func TestAgentPaneHeaderShowsSelectedWorkspace(t *testing.T) {
 func TestPaneHeaderKeepsLabelAlignmentAcrossFocusStates(t *testing.T) {
 	active := ansi.Strip(renderPaneHeader("Workspaces", "", 24, true, headerBand{total: 24}))
 	inactive := ansi.Strip(renderPaneHeader("Workspaces", "", 24, false, headerBand{total: 24}))
-	if !strings.HasPrefix(active, "Workspaces") ||
-		!strings.HasPrefix(inactive, "Workspaces") {
+	// The label is set into the band with a column of padding on each side,
+	// and that padding must not move when focus does.
+	if !strings.HasPrefix(active, " Workspaces ") ||
+		!strings.HasPrefix(inactive, " Workspaces ") {
 		t.Fatalf("labels shifted between focus states:\nactive:   %q\ninactive: %q",
 			active, inactive)
 	}
@@ -1661,17 +1678,17 @@ func TestSortChordChangesMode(t *testing.T) {
 
 func TestHierarchyConnectorBridgesDifferentRows(t *testing.T) {
 	pane := strings.Join([]string{
-		"header  ",
-		"one     ",
-		"two     ",
-		"three   ",
+		"header │",
+		"one    │",
+		"two    │",
+		"three  │",
 	}, "\n")
 	rendered := ansi.Strip(paintHierarchyConnector(pane, 8, 1, 3))
 	lines := strings.Split(rendered, "\n")
-	if !strings.HasSuffix(lines[0], "  ") ||
-		!strings.HasSuffix(lines[1], " ╮") ||
-		!strings.HasSuffix(lines[2], " │") ||
-		!strings.HasSuffix(lines[3], " ╰") {
+	if lines[0] != "header │" ||
+		!strings.HasSuffix(lines[1], "╮ │") ||
+		!strings.HasSuffix(lines[2], "│ │") ||
+		!strings.HasSuffix(lines[3], "╰ │") {
 		t.Fatalf("hierarchy path is incomplete:\n%s", rendered)
 	}
 	for index, line := range lines {
@@ -1696,15 +1713,26 @@ func TestHierarchyKeepsParentRowsSelected(t *testing.T) {
 
 	workspaces := ansi.Strip(model.renderWorkspaces(30, 12))
 	agents := ansi.Strip(model.renderAgents(40, 12))
-	if !strings.Contains(workspaces, "›") ||
-		!strings.Contains(agents, "›") ||
-		strings.Contains(workspaces, "▌") ||
-		strings.Contains(agents, "▌") {
+	// The focus bar belongs to the pane holding the cursor, and the cursor is
+	// in the Spanreed, so neither list claims it.
+	if strings.Contains(workspaces, "▌") || strings.Contains(agents, "▌") {
 		t.Fatalf(
-			"hierarchy selection is unclear:\nworkspaces:\n%s\nagents:\n%s",
+			"a list claimed the focus bar it does not hold:\nworkspaces:\n%s\nagents:\n%s",
 			workspaces,
 			agents,
 		)
+	}
+	if !strings.Contains(agents, "›") {
+		t.Fatalf("selected agent is unmarked:\n%s", agents)
+	}
+	// The workspace row marks nothing: the pane keeps it undimmed while its
+	// neighbours recede, which is signal enough without an arrow.
+	if strings.Contains(workspaces, "›") {
+		t.Fatalf("workspace row still carries a selection arrow:\n%s", workspaces)
+	}
+	lit := model.selectedRowRange(len(model.groups), model.workspaceCursor, 11)
+	if lit.count == 0 {
+		t.Fatalf("no workspace row is held at full strength to mark selection")
 	}
 }
 
@@ -2053,57 +2081,64 @@ func TestCheckoutBadgeColors(t *testing.T) {
 }
 
 // A narrow pane drops the path before the badge: the path restates the
-// checkout, the badge is the only token that names it.
+// checkout, the badge is the only token that names it. Tokens fall from the
+// tail, so the state and the provider outlive both.
 func TestInteractionMetaKeepsCheckoutOverPath(t *testing.T) {
+	agentIn := func(root, executionRoot string) agent.Agent {
+		return agent.Agent{
+			Provider:    agent.ProviderClaude,
+			Activity:    agent.ActivityWorking,
+			ProcessLive: true,
+			Cwd:         "~/repos/stormlight",
+			Workspace: workspace.Context{
+				ID:            "w",
+				Name:          "stormlight",
+				Kind:          workspace.KindGit,
+				Root:          root,
+				ExecutionRoot: executionRoot,
+			},
+		}
+	}
 	for _, testCase := range []struct {
-		name    string
-		badge   checkoutBadge
-		path    string
-		narrow  int
-		keeps   string
-		dropped string
+		name   string
+		agent  agent.Agent
+		narrow int
+		keeps  string
 	}{
 		{
-			name:    "linked worktree",
-			badge:   checkoutBadge{text: "worktree fix-auth"},
-			path:    "~/repo/.claude/worktrees/fix-auth",
-			narrow:  34,
-			keeps:   "worktree fix-auth",
-			dropped: "~/repo",
+			name:   "linked worktree",
+			agent:  agentIn("/repo", "/repo/.claude/worktrees/fix-auth"),
+			narrow: 40,
+			keeps:  "worktree fix-auth",
 		},
 		{
-			name:    "primary checkout",
-			badge:   checkoutBadge{text: "main checkout", primary: true},
-			path:    "~/repos/stormlight",
-			narrow:  32,
-			keeps:   "main checkout",
-			dropped: "~/repos",
+			name:   "primary checkout",
+			agent:  agentIn("/repo", "/repo"),
+			narrow: 36,
+			keeps:  "main checkout",
 		},
 	} {
 		t.Run(testCase.name, func(t *testing.T) {
-			wide := ansi.Strip(interactionMeta(
-				"claude  working", testCase.badge, testCase.path, 80,
-			))
+			wide := ansi.Strip(interactionMeta(testCase.agent, 90))
 			if !strings.Contains(wide, testCase.keeps) ||
-				!strings.Contains(wide, testCase.dropped) {
+				!strings.Contains(wide, "stormlight") {
 				t.Fatalf("wide meta line lost a token: %q", wide)
 			}
+			if !strings.Contains(wide, "working") ||
+				!strings.Contains(wide, "claude") {
+				t.Fatalf("wide meta line lost its state or provider: %q", wide)
+			}
 
-			narrow := ansi.Strip(interactionMeta(
-				"claude  working", testCase.badge, testCase.path, testCase.narrow,
-			))
+			narrow := ansi.Strip(interactionMeta(testCase.agent, testCase.narrow))
 			if !strings.Contains(narrow, testCase.keeps) {
 				t.Fatalf("narrow meta line dropped the checkout: %q", narrow)
 			}
-			if strings.Contains(narrow, testCase.dropped) {
+			if strings.Contains(narrow, "stormlight") {
 				t.Fatalf("narrow meta line kept the path: %q", narrow)
 			}
 			if width := ansi.StringWidth(narrow); width > testCase.narrow {
-				t.Fatalf(
-					"meta line overflows the pane: %d columns in %q",
-					width,
-					narrow,
-				)
+				t.Fatalf("narrow meta line is %d wide, limit %d: %q",
+					width, testCase.narrow, narrow)
 			}
 		})
 	}
@@ -2393,4 +2428,13 @@ func TestClearAttentionHotkeyClearsWholeWorkspace(t *testing.T) {
 			t.Fatalf("agent %s attention = %q", managedAgent.ID, managedAgent.Attention)
 		}
 	}
+}
+
+func runeIndex(runes []rune, want rune) int {
+	for index, glyph := range runes {
+		if glyph == want {
+			return index
+		}
+	}
+	return -1
 }

--- a/internal/ui/input_test.go
+++ b/internal/ui/input_test.go
@@ -1558,7 +1558,7 @@ func TestWorkspaceShimmerSweepsWithStableWidth(t *testing.T) {
 		t.Fatalf("focus bar missing:\n%s", ansi.Strip(early))
 	}
 	quiet := ansi.Strip(model.renderWorkspaceRow(group, false, false, 30, false))
-	if !strings.Contains(quiet, "●1") {
+	if !strings.Contains(quiet, "● 1") {
 		t.Fatalf("active count chip missing on quiet row:\n%s", quiet)
 	}
 	if strings.HasPrefix(strings.TrimSpace(quiet), "●") {

--- a/internal/ui/input_test.go
+++ b/internal/ui/input_test.go
@@ -761,23 +761,53 @@ func TestWideDashboardRendersThreePaneHierarchy(t *testing.T) {
 	assertViewFitsPane(t, model, 119, 29)
 }
 
-func TestWideDashboardRendersPhysicalPaneDividers(t *testing.T) {
+// The dashboard's two seams divide different kinds of thing, so they are not
+// drawn alike: a hairline splits the catalog's own columns, while a heavy rule
+// followed by a column of air splits the whole catalog from the Spanreed.
+func TestWideDashboardSeamsSeparateCatalogFromControlPlane(t *testing.T) {
 	model := NewModel(stubBackend{})
 	model.width = 120
 	model.height = 30
 
 	body := ansi.Strip(model.renderBody())
-	for _, line := range strings.Split(body, "\n") {
+	lines := strings.Split(body, "\n")
+	header := -1
+	for index, line := range lines {
 		if strings.Contains(line, "Workspaces") &&
 			strings.Contains(line, "Agents") &&
 			strings.Contains(line, "Spanreed") {
-			if strings.Count(line, "│") < 2 {
-				t.Fatalf("pane headers have no physical dividers: %q", line)
-			}
-			return
+			header = index
+			break
 		}
 	}
-	t.Fatalf("pane header row not found:\n%s", body)
+	if header < 0 {
+		t.Fatalf("pane header row not found:\n%s", body)
+	}
+	hairline := strings.Index(lines[header], "│")
+	plane := strings.Index(lines[header], "┃")
+	if hairline < 0 || plane < 0 || plane < hairline {
+		t.Fatalf("seams are not a hairline then a heavy rule: %q", lines[header])
+	}
+	if strings.Count(lines[header], "┃") != 1 {
+		t.Fatalf("more than one plane seam: %q", lines[header])
+	}
+
+	for _, line := range lines[header+1:] {
+		runes := []rune(line)
+		column := -1
+		for index, glyph := range runes {
+			if glyph == '┃' {
+				column = index
+				break
+			}
+		}
+		if column < 0 {
+			t.Fatalf("body row has no plane seam: %q", line)
+		}
+		if column+1 < len(runes) && runes[column+1] != ' ' {
+			t.Fatalf("plane seam has no gutter behind it: %q", line)
+		}
+	}
 }
 
 func TestAgentPaneHeaderShowsSelectedWorkspace(t *testing.T) {

--- a/internal/ui/input_test.go
+++ b/internal/ui/input_test.go
@@ -761,9 +761,10 @@ func TestWideDashboardRendersThreePaneHierarchy(t *testing.T) {
 	assertViewFitsPane(t, model, 119, 29)
 }
 
-// The dashboard's two seams divide different kinds of thing, so they are not
-// drawn alike: a hairline splits the catalog's own columns, while a heavy rule
-// followed by a column of air splits the whole catalog from the Spanreed.
+// One rule crosses the dashboard body, and it is the one that matters: the
+// heavy seam between the catalog and the Spanreed, capped under the header
+// band and trailed by a column of air. The catalog's own columns are divided
+// by nothing at all.
 func TestWideDashboardSeamsSeparateCatalogFromControlPlane(t *testing.T) {
 	model := NewModel(stubBackend{})
 	model.width = 120
@@ -783,25 +784,26 @@ func TestWideDashboardSeamsSeparateCatalogFromControlPlane(t *testing.T) {
 	if header < 0 {
 		t.Fatalf("pane header row not found:\n%s", body)
 	}
-	// The header row carries the seams' caps, not the seams: half-strokes
-	// that begin at the band and descend out of it.
-	hairline := strings.Index(lines[header], "╷")
+	// The header row carries the seam's cap, not the seam: a half-stroke
+	// that begins at the band and descends out of it.
 	plane := strings.Index(lines[header], "╻")
-	if hairline < 0 || plane < 0 || plane < hairline {
-		t.Fatalf("seams are not capped under the band: %q", lines[header])
+	if plane < 0 {
+		t.Fatalf("plane seam is not capped under the band: %q", lines[header])
 	}
-	if strings.ContainsAny(lines[header], "│┃") {
+	if strings.ContainsAny(lines[header], "│┃╷") {
 		t.Fatalf("uncapped seam collides with the header band: %q", lines[header])
 	}
 
 	firstRow := lines[header+1]
-	if strings.Index(firstRow, "│") != hairline ||
-		strings.Index(firstRow, "┃") != plane {
-		t.Fatalf("seams do not hang from their caps:\n%q\n%q",
+	if strings.Index(firstRow, "┃") != plane {
+		t.Fatalf("seam does not hang from its cap:\n%q\n%q",
 			lines[header], firstRow)
 	}
 
 	for _, line := range lines[header+1:] {
+		if strings.Contains(line, "│") {
+			t.Fatalf("a rule still divides the catalog's columns: %q", line)
+		}
 		runes := []rune(line)
 		column := -1
 		for index, glyph := range runes {
@@ -1556,8 +1558,11 @@ func TestWorkspaceShimmerSweepsWithStableWidth(t *testing.T) {
 		t.Fatalf("focus bar missing:\n%s", ansi.Strip(early))
 	}
 	quiet := ansi.Strip(model.renderWorkspaceRow(group, false, false, 30, false))
-	if !strings.HasPrefix(quiet, "●") {
-		t.Fatalf("active glyph missing on quiet row:\n%s", quiet)
+	if !strings.Contains(quiet, "●1") {
+		t.Fatalf("active count chip missing on quiet row:\n%s", quiet)
+	}
+	if strings.HasPrefix(strings.TrimSpace(quiet), "●") {
+		t.Fatalf("state glyph is still doubled in the left column:\n%s", quiet)
 	}
 	// Colors are unavailable under the test color profile, so the sweep
 	// itself is asserted via the band math.
@@ -1597,7 +1602,7 @@ func TestHierarchyConnectorRowsFollowDensity(t *testing.T) {
 	model.agentCursor = 2
 
 	workspaceRow, agentRow, ok := model.hierarchyConnectorRows(20)
-	if !ok || workspaceRow != 2 || agentRow != 3 {
+	if !ok || workspaceRow != 3 || agentRow != 4 {
 		t.Fatalf(
 			"compact connector rows = %d -> %d, ok=%v",
 			workspaceRow,
@@ -1608,7 +1613,7 @@ func TestHierarchyConnectorRowsFollowDensity(t *testing.T) {
 
 	model.rowsExpanded = true
 	workspaceRow, agentRow, ok = model.hierarchyConnectorRows(20)
-	if !ok || workspaceRow != 4 || agentRow != 7 {
+	if !ok || workspaceRow != 5 || agentRow != 8 {
 		t.Fatalf(
 			"expanded connector rows = %d -> %d, ok=%v",
 			workspaceRow,
@@ -1656,17 +1661,17 @@ func TestSortChordChangesMode(t *testing.T) {
 
 func TestHierarchyConnectorBridgesDifferentRows(t *testing.T) {
 	pane := strings.Join([]string{
-		"header │",
-		"one    │",
-		"two    │",
-		"three  │",
+		"header  ",
+		"one     ",
+		"two     ",
+		"three   ",
 	}, "\n")
 	rendered := ansi.Strip(paintHierarchyConnector(pane, 8, 1, 3))
 	lines := strings.Split(rendered, "\n")
-	if !strings.HasSuffix(lines[0], " │") ||
-		!strings.HasSuffix(lines[1], "╮│") ||
-		!strings.HasSuffix(lines[2], "││") ||
-		!strings.HasSuffix(lines[3], "╰│") {
+	if !strings.HasSuffix(lines[0], "  ") ||
+		!strings.HasSuffix(lines[1], " ╮") ||
+		!strings.HasSuffix(lines[2], " │") ||
+		!strings.HasSuffix(lines[3], " ╰") {
 		t.Fatalf("hierarchy path is incomplete:\n%s", rendered)
 	}
 	for index, line := range lines {

--- a/internal/ui/input_test.go
+++ b/internal/ui/input_test.go
@@ -783,13 +783,22 @@ func TestWideDashboardSeamsSeparateCatalogFromControlPlane(t *testing.T) {
 	if header < 0 {
 		t.Fatalf("pane header row not found:\n%s", body)
 	}
-	hairline := strings.Index(lines[header], "│")
-	plane := strings.Index(lines[header], "┃")
+	// The header row carries the seams' caps, not the seams: half-strokes
+	// that begin at the band and descend out of it.
+	hairline := strings.Index(lines[header], "╷")
+	plane := strings.Index(lines[header], "╻")
 	if hairline < 0 || plane < 0 || plane < hairline {
-		t.Fatalf("seams are not a hairline then a heavy rule: %q", lines[header])
+		t.Fatalf("seams are not capped under the band: %q", lines[header])
 	}
-	if strings.Count(lines[header], "┃") != 1 {
-		t.Fatalf("more than one plane seam: %q", lines[header])
+	if strings.ContainsAny(lines[header], "│┃") {
+		t.Fatalf("uncapped seam collides with the header band: %q", lines[header])
+	}
+
+	firstRow := lines[header+1]
+	if strings.Index(firstRow, "│") != hairline ||
+		strings.Index(firstRow, "┃") != plane {
+		t.Fatalf("seams do not hang from their caps:\n%q\n%q",
+			lines[header], firstRow)
 	}
 
 	for _, line := range lines[header+1:] {
@@ -826,15 +835,15 @@ func TestAgentPaneHeaderShowsSelectedWorkspace(t *testing.T) {
 		t.Fatalf("agent header lacks right-aligned workspace context: %q", header)
 	}
 
-	rendered := ansi.Strip(renderPaneHeader("Agents", "a-very-long-workspace-name", 24, true))
+	rendered := ansi.Strip(renderPaneHeader("Agents", "a-very-long-workspace-name", 24, true, headerBand{total: 24}))
 	if width := lipgloss.Width(rendered); width != 24 {
 		t.Fatalf("contextual header width = %d, want 24: %q", width, rendered)
 	}
 }
 
 func TestPaneHeaderKeepsLabelAlignmentAcrossFocusStates(t *testing.T) {
-	active := ansi.Strip(renderPaneHeader("Workspaces", "", 24, true))
-	inactive := ansi.Strip(renderPaneHeader("Workspaces", "", 24, false))
+	active := ansi.Strip(renderPaneHeader("Workspaces", "", 24, true, headerBand{total: 24}))
+	inactive := ansi.Strip(renderPaneHeader("Workspaces", "", 24, false, headerBand{total: 24}))
 	if !strings.HasPrefix(active, "Workspaces") ||
 		!strings.HasPrefix(inactive, "Workspaces") {
 		t.Fatalf("labels shifted between focus states:\nactive:   %q\ninactive: %q",

--- a/internal/ui/layout.go
+++ b/internal/ui/layout.go
@@ -122,22 +122,25 @@ func (m Model) renderDashboardBody(width, contentHeight int) string {
 
 	dimWorkspaces, dimAgents, dimInteraction := m.paneDimmings(contentHeight)
 
-	// Nothing rules between Workspaces and Agents. They are two views of one
-	// hierarchy — the columns of a file explorer — and explorers separate
-	// their columns with air, not lines. Dropping that hairline leaves the
-	// plane seam as the only rule in the body, which is the whole point of
-	// it, and gives the hierarchy connector room to read as a connection
-	// instead of a mark alongside a rule it was competing with.
+	// A hairline divides Workspaces from Agents, with air on both sides of
+	// it — the treatment yazi gives its miller columns, and the reason two
+	// adjacent scrolling lists read as columns rather than as a grid. The
+	// rule was never the problem; a rule pressed flush against both lists
+	// was. It stays subordinate to the plane seam by every means available:
+	// light where that one is heavy, and painted in the header band's own
+	// faded gradient where that one takes the accent.
 	workspaces := m.renderPane(
 		"Workspaces",
 		"",
-		// Two columns of slack past the margin: one blank, then the
-		// connector in the block's last column, reaching for the agents.
-		m.renderWorkspaces(max(1, workspaceWidth-3), listHeight),
+		// Past the margin: a blank column, the connector, another blank,
+		// then the rule. The arc reaches for the agents without crowding
+		// the divider, and the divider keeps air on both sides.
+		m.renderWorkspaces(max(1, workspaceWidth-5), listHeight),
 		paneFrame{
 			width:   workspaceWidth,
 			height:  contentHeight,
 			active:  m.activePane == paneWorkspaces,
+			edges:   paneEdges{right: seamColumn},
 			band:    headerBand{start: 0, total: width},
 			margins: paneMargins{top: true, left: true},
 			dimming: dimWorkspaces,
@@ -153,7 +156,7 @@ func (m Model) renderDashboardBody(width, contentHeight int) string {
 	}
 	agents := m.renderPane(
 		"Agents",
-		m.selectedWorkspaceLabel(),
+		"",
 		m.renderAgents(max(1, agentWidth-2), listHeight),
 		paneFrame{
 			width:   agentWidth,
@@ -184,8 +187,10 @@ func (m Model) renderDashboardBody(width, contentHeight int) string {
 	)
 	return lipgloss.JoinHorizontal(
 		lipgloss.Top,
-		workspaces,
-		capSeam(agents, agentWidth, seamPlane),
+		capSeam(workspaces, workspaceWidth, seamColumn,
+			headerBand{start: 0, total: width}),
+		capSeam(agents, agentWidth, seamPlane,
+			headerBand{start: workspaceWidth, total: width}),
 		interaction,
 	)
 }
@@ -194,7 +199,7 @@ func (m Model) renderDashboardBody(width, contentHeight int) string {
 // from the header band instead of colliding with it. The band is drawn as an
 // underline along the bottom of the header row, which is exactly where these
 // glyphs begin — the seam reads as descending out of the frame.
-func capSeam(paneContent string, width int, seam paneSeam) string {
+func capSeam(paneContent string, width int, seam paneSeam, band headerBand) string {
 	if seam == seamNone || width < 1 {
 		return paneContent
 	}
@@ -211,7 +216,7 @@ func capSeam(paneContent string, width int, seam paneSeam) string {
 		width,
 		width-1,
 		glyph,
-		lipgloss.NewStyle().Foreground(seam.foreground()),
+		lipgloss.NewStyle().Foreground(seamColor(seam, band, width)),
 	)
 	return strings.Join(lines, "\n")
 }
@@ -297,9 +302,9 @@ func paintHierarchyConnector(
 		return paneContent
 	}
 
-	// The connector lives in the workspaces block's last column — the air
-	// where a rule used to be — so the gold arc reaches toward the agent it
-	// names, spanning exactly its two endpoint rows with rounded caps.
+	// The connector lives in the column just inside the rule, so the arc
+	// reaches toward the agent it names without crowding the divider,
+	// spanning exactly its two endpoint rows with rounded caps.
 	style := lipgloss.NewStyle().Foreground(colorWaiting)
 	first := min(workspaceRow, agentRow)
 	last := max(workspaceRow, agentRow)
@@ -320,7 +325,7 @@ func paintHierarchyConnector(
 		lines[row] = replaceStyledCell(
 			lines[row],
 			width,
-			width-1,
+			width-3,
 			glyph,
 			style,
 		)
@@ -626,14 +631,18 @@ func (s paneSeam) border() lipgloss.Border {
 	return border
 }
 
-// foreground colors the rule. A column seam is furniture and stays the
-// border grey; a plane seam takes the accent, so the one line that divides
-// browsing from driving is also the one line on screen that isn't furniture.
-func (s paneSeam) foreground() lipgloss.TerminalColor {
-	if s == seamPlane {
+// seamColor paints a rule. A plane seam takes the accent, so the one line
+// that divides browsing from driving is the one line on screen that isn't
+// furniture. A column seam takes the header band's color at the column it
+// hangs from — the catalog's divider is made of the same faded gradient as
+// the frame it descends out of, which subordinates it to the accent seam by
+// material as well as by weight.
+func seamColor(seam paneSeam, band headerBand, width int) lipgloss.TerminalColor {
+	if seam == seamPlane || band.total <= 1 {
 		return colorAccent
 	}
-	return colorBorder
+	column := clamp(band.start+width-1, 0, band.total-1)
+	return bandColor(float64(column)/float64(band.total-1), false)
 }
 
 // paneEdges describes both sides of a pane's frame. A plane seam is drawn in
@@ -689,7 +698,7 @@ func (m Model) renderPane(
 		style = style.Width(innerWidth).
 			BorderStyle(edges.right.border()).
 			BorderRight(true).
-			BorderForeground(edges.right.foreground())
+			BorderForeground(seamColor(edges.right, frame.band, width))
 	}
 	// The gutter is the far half of a plane seam, so it comes out of this
 	// pane's own columns: the header rule and every body row start one cell
@@ -797,37 +806,41 @@ func renderPaneHeader(
 	active bool,
 	band headerBand,
 ) string {
-	underlined := func(style lipgloss.Style) lipgloss.Style {
-		return style.Underline(true)
-	}
 	// A run of band, positioned by how far into this pane it starts.
 	fill := func(offset, count int) string {
 		return renderBandRun(
 			" ", band.start+offset, max(0, count), band.total, active, true)
 	}
 
-	left := underlined(mutedStyle.Copy().Bold(true)).
-		Render(truncate(" "+label, width))
+	// Labels interrupt the band; they do not sit on it. A rule running under
+	// the words is the construction of a table header — and it was breaking
+	// the band's gradient besides, since an underline takes the color of the
+	// text above it. lazygit sets its titles into the rule the same way.
+	// Each label is followed by a blank the band skips, so the line resumes
+	// clear of the descenders.
+	labelStyle := mutedStyle.Copy().Bold(true)
 	if active {
-		left = underlined(titleStyle.Copy()).
-			Render(truncate(" "+label, width))
+		labelStyle = titleStyle.Copy()
 	}
+	// The padding sits outside truncate, which collapses whitespace runs and
+	// would otherwise eat it.
+	left := labelStyle.Render(" " + truncate(label, max(1, width-2)) + " ")
 	leftWidth := lipgloss.Width(left)
 
-	remaining := width - leftWidth - 2
+	remaining := width - leftWidth - 4
 	if strings.TrimSpace(contextLabel) == "" || remaining < 4 {
 		return left + fill(leftWidth, width-leftWidth)
 	}
 
-	rightStyle := underlined(mutedStyle.Copy())
+	rightStyle := mutedStyle.Copy()
 	if strings.ContainsAny(contextLabel, "‹›") {
-		rightStyle = underlined(accentStyle.Copy())
+		rightStyle = accentStyle.Copy()
 	}
-	right := rightStyle.Render(truncate(contextLabel, remaining))
+	right := rightStyle.Render(" " + truncate(contextLabel, remaining) + " ")
 	rightWidth := lipgloss.Width(right)
 	// One column of band survives past the context label, so it never ends
 	// flush against the seam it sits beside.
-	gap := max(2, width-leftWidth-rightWidth-1)
+	gap := max(1, width-leftWidth-rightWidth-1)
 	tail := max(0, width-leftWidth-gap-rightWidth)
 	return left + fill(leftWidth, gap) + right +
 		fill(leftWidth+gap+rightWidth, tail)

--- a/internal/ui/layout.go
+++ b/internal/ui/layout.go
@@ -19,21 +19,41 @@ func (m Model) renderHeader() string {
 	// No chrome: the wordmark's own gradient is the identity, floating on
 	// the terminal background with the counters at the far edge.
 	left := renderWordmark(m.shimmerPhaseOrRest())
-	right := mutedStyle.Render(fmt.Sprintf("%d active", working))
+	// The counters speak the rows' own language: same glyphs, same colors as
+	// statusVisual paints down the agent list, so the header doubles as the
+	// legend for everything below it.
+	counts := []string{
+		renderHeaderCount("●", colorWorking, false,
+			fmt.Sprintf("%d working", working)),
+	}
 	if waiting > 0 {
-		right += "  " + lipgloss.NewStyle().Foreground(colorWaiting).
-			Render(fmt.Sprintf("%d waiting", waiting))
+		counts = append(counts, renderHeaderCount("○", colorWaiting, false,
+			fmt.Sprintf("%d waiting", waiting)))
 	}
 	if urgent > 0 {
 		attentionLabel := fmt.Sprintf("%d need input", urgent)
 		if urgent == 1 {
 			attentionLabel = "1 needs input"
 		}
-		right += "  " + lipgloss.NewStyle().Foreground(colorWaiting).Bold(true).
-			Render(attentionLabel)
+		counts = append(counts,
+			renderHeaderCount("!", colorWaiting, true, attentionLabel))
 	}
+	right := strings.Join(counts, mutedStyle.Render("  ·  "))
 	gap := max(1, width-lipgloss.Width(left)-lipgloss.Width(right)-1)
 	return left + strings.Repeat(" ", gap) + right + " "
+}
+
+// renderHeaderCount pairs a count with the glyph the agent rows use for that
+// state. The glyph carries the color and the words stay muted, except for the
+// input tier, which is the one thing in the header worth raising a voice over.
+func renderHeaderCount(symbol string, color lipgloss.TerminalColor, loud bool, label string) string {
+	symbolStyle := lipgloss.NewStyle().Foreground(color)
+	labelStyle := mutedStyle
+	if loud {
+		symbolStyle = symbolStyle.Bold(true)
+		labelStyle = lipgloss.NewStyle().Foreground(color).Bold(true)
+	}
+	return symbolStyle.Render(symbol) + " " + labelStyle.Render(label)
 }
 
 // bodyDimensions is the area modals and the dashboard share: the terminal
@@ -107,11 +127,14 @@ func (m Model) renderDashboardBody(width, contentHeight int) string {
 		// One extra column of slack keeps row text from touching the
 		// hierarchy connector drawn in the pane's padding column.
 		m.renderWorkspaces(max(1, workspaceWidth-3), contentHeight-1),
-		workspaceWidth,
-		contentHeight,
-		m.activePane == paneWorkspaces,
-		paneEdges{right: seamColumn},
-		dimWorkspaces,
+		paneFrame{
+			width:   workspaceWidth,
+			height:  contentHeight,
+			active:  m.activePane == paneWorkspaces,
+			edges:   paneEdges{right: seamColumn},
+			band:    headerBand{start: 0, total: width},
+			dimming: dimWorkspaces,
+		},
 	)
 	if workspaceRow, agentRow, ok := m.hierarchyConnectorRows(contentHeight); ok {
 		workspaces = paintHierarchyConnector(
@@ -125,11 +148,14 @@ func (m Model) renderDashboardBody(width, contentHeight int) string {
 		"Agents",
 		m.selectedWorkspaceLabel(),
 		m.renderAgents(max(1, agentWidth-2), contentHeight-1),
-		agentWidth,
-		contentHeight,
-		m.activePane == paneAgents,
-		paneEdges{right: seamPlane},
-		dimAgents,
+		paneFrame{
+			width:   agentWidth,
+			height:  contentHeight,
+			active:  m.activePane == paneAgents,
+			edges:   paneEdges{right: seamPlane},
+			band:    headerBand{start: workspaceWidth, total: width},
+			dimming: dimAgents,
+		},
 	)
 	interaction := m.renderPane(
 		"Spanreed",
@@ -138,13 +164,47 @@ func (m Model) renderDashboardBody(width, contentHeight int) string {
 			max(1, interactionWidth-3),
 			contentHeight-1,
 		),
-		interactionWidth,
-		contentHeight,
-		m.activePane == paneInteraction,
-		paneEdges{gutter: true},
-		dimInteraction,
+		paneFrame{
+			width:   interactionWidth,
+			height:  contentHeight,
+			active:  m.activePane == paneInteraction,
+			edges:   paneEdges{gutter: true},
+			band:    headerBand{start: workspaceWidth + agentWidth, total: width},
+			dimming: dimInteraction,
+		},
 	)
-	return lipgloss.JoinHorizontal(lipgloss.Top, workspaces, agents, interaction)
+	return lipgloss.JoinHorizontal(
+		lipgloss.Top,
+		capSeam(workspaces, workspaceWidth, seamColumn),
+		capSeam(agents, agentWidth, seamPlane),
+		interaction,
+	)
+}
+
+// capSeam trims a seam's topmost cell to a half-stroke, so the rule hangs
+// from the header band instead of colliding with it. The band is drawn as an
+// underline along the bottom of the header row, which is exactly where these
+// glyphs begin — the seam reads as descending out of the frame.
+func capSeam(paneContent string, width int, seam paneSeam) string {
+	if seam == seamNone || width < 1 {
+		return paneContent
+	}
+	glyph := "╷"
+	if seam == seamPlane {
+		glyph = "╻"
+	}
+	lines := strings.Split(paneContent, "\n")
+	if len(lines) == 0 {
+		return paneContent
+	}
+	lines[0] = replaceStyledCell(
+		lines[0],
+		width,
+		width-1,
+		glyph,
+		lipgloss.NewStyle().Foreground(seam.foreground()),
+	)
+	return strings.Join(lines, "\n")
 }
 
 // paneDimmings decides how far each pane recedes. The lit path is the
@@ -422,33 +482,36 @@ func (m Model) renderFocusedPane(width, height int) string {
 			"Agents",
 			contextLabel,
 			m.renderAgents(max(1, width-2), height-1),
-			width,
-			height,
-			true,
-			paneEdges{},
-			paneDimming{},
+			paneFrame{
+				width:  width,
+				height: height,
+				active: true,
+				band:   headerBand{total: width},
+			},
 		)
 	case paneInteraction:
 		return m.renderPane(
 			"Spanreed",
 			"‹",
 			m.renderInteraction(max(1, width-2), height-1),
-			width,
-			height,
-			true,
-			paneEdges{},
-			paneDimming{},
+			paneFrame{
+				width:  width,
+				height: height,
+				active: true,
+				band:   headerBand{total: width},
+			},
 		)
 	default:
 		return m.renderPane(
 			"Workspaces",
 			"Agents ›",
 			m.renderWorkspaces(max(1, width-2), height-1),
-			width,
-			height,
-			true,
-			paneEdges{},
-			paneDimming{},
+			paneFrame{
+				width:  width,
+				height: height,
+				active: true,
+				band:   headerBand{total: width},
+			},
 		)
 	}
 }
@@ -570,16 +633,32 @@ type paneEdges struct {
 	gutter bool
 }
 
+// headerBand places a pane's header rule inside the dashboard-wide band of
+// light: start is the column the pane begins at, total the full width the
+// gradient is stretched across.
+type headerBand struct {
+	start int
+	total int
+}
+
+// paneFrame is everything about a pane that isn't its text.
+type paneFrame struct {
+	width   int
+	height  int
+	active  bool
+	edges   paneEdges
+	band    headerBand
+	dimming paneDimming
+}
+
 func (m Model) renderPane(
 	label string,
 	contextLabel string,
 	content string,
-	width int,
-	height int,
-	active bool,
-	edges paneEdges,
-	dimming paneDimming,
+	frame paneFrame,
 ) string {
+	width, height := frame.width, frame.height
+	edges, dimming := frame.edges, frame.dimming
 	innerWidth := max(1, width)
 	style := lipgloss.NewStyle().Width(innerWidth).Height(height).MaxHeight(height)
 	if edges.right != seamNone {
@@ -597,11 +676,16 @@ func (m Model) renderPane(
 	// pane's own columns: the header rule and every body row start one cell
 	// in, leaving the heavy rule with air on its far side.
 	contentWidth := innerWidth
+	band := frame.band
 	if edges.gutter {
 		contentWidth = max(1, innerWidth-1)
 		style = style.PaddingLeft(1)
+		// The gutter is dead space in the band's run, but it is still a
+		// column of the dashboard: the header rule resumes past it rather
+		// than restarting the gradient.
+		band.start++
 	}
-	header := renderPaneHeader(label, contextLabel, contentWidth, active)
+	header := renderPaneHeader(label, contextLabel, contentWidth, frame.active, band)
 	if dimming.dim {
 		content = dimPane(content, dimming.keep)
 	}
@@ -675,27 +759,36 @@ func dimParams(params string) string {
 
 // renderPaneHeader underlines the entire header cell, padding included, so
 // the header reads as a full-width ruled box top rather than floating text.
-func renderPaneHeader(label, contextLabel string, width int, active bool) string {
+// The underline is the top edge of the dashboard's band of light: every blank
+// cell takes the band's color at its own column, and the active pane's run
+// rises to full strength — the "selected tab" indicator is that stretch of
+// brightness, not a separate rail or a swapped accent.
+func renderPaneHeader(
+	label, contextLabel string,
+	width int,
+	active bool,
+	band headerBand,
+) string {
 	underlined := func(style lipgloss.Style) lipgloss.Style {
 		return style.Underline(true)
 	}
-	fill := underlined(lipgloss.NewStyle().Foreground(colorBorder))
+	// A run of band, positioned by how far into this pane it starts.
+	fill := func(offset, count int) string {
+		return renderBandRun(
+			" ", band.start+offset, max(0, count), band.total, active, true)
+	}
 
 	left := underlined(mutedStyle.Copy().Bold(true)).
 		Render(truncate(" "+label, width))
 	if active {
-		// The active pane's header rule renders in accent — the pane's
-		// "selected tab" indicator. The rule alone carries the signal; no
-		// rail, no extra chrome.
-		fill = underlined(lipgloss.NewStyle().Foreground(colorAccent))
 		left = underlined(titleStyle.Copy()).
 			Render(truncate(" "+label, width))
 	}
+	leftWidth := lipgloss.Width(left)
 
-	remaining := width - lipgloss.Width(left) - 2
+	remaining := width - leftWidth - 2
 	if strings.TrimSpace(contextLabel) == "" || remaining < 4 {
-		pad := max(0, width-lipgloss.Width(left))
-		return left + fill.Render(strings.Repeat(" ", pad))
+		return left + fill(leftWidth, width-leftWidth)
 	}
 
 	rightStyle := underlined(mutedStyle.Copy())
@@ -703,10 +796,11 @@ func renderPaneHeader(label, contextLabel string, width int, active bool) string
 		rightStyle = underlined(accentStyle.Copy())
 	}
 	right := rightStyle.Render(truncate(contextLabel, remaining))
-	gap := max(2, width-lipgloss.Width(left)-lipgloss.Width(right))
-	tail := max(0, width-lipgloss.Width(left)-gap-lipgloss.Width(right))
-	return left + fill.Render(strings.Repeat(" ", gap)) + right +
-		fill.Render(strings.Repeat(" ", tail))
+	rightWidth := lipgloss.Width(right)
+	gap := max(2, width-leftWidth-rightWidth)
+	tail := max(0, width-leftWidth-gap-rightWidth)
+	return left + fill(leftWidth, gap) + right +
+		fill(leftWidth+gap+rightWidth, tail)
 }
 
 func (m Model) interactionDimensions() (int, int) {

--- a/internal/ui/layout.go
+++ b/internal/ui/layout.go
@@ -118,21 +118,28 @@ func (m Model) renderDashboardBody(width, contentHeight int) string {
 	}
 
 	workspaceWidth, agentWidth, interactionWidth := m.paneWidths(width)
+	listHeight := contentHeight - 2
 
 	dimWorkspaces, dimAgents, dimInteraction := m.paneDimmings(contentHeight)
 
+	// Nothing rules between Workspaces and Agents. They are two views of one
+	// hierarchy — the columns of a file explorer — and explorers separate
+	// their columns with air, not lines. Dropping that hairline leaves the
+	// plane seam as the only rule in the body, which is the whole point of
+	// it, and gives the hierarchy connector room to read as a connection
+	// instead of a mark alongside a rule it was competing with.
 	workspaces := m.renderPane(
 		"Workspaces",
 		"",
-		// One extra column of slack keeps row text from touching the
-		// hierarchy connector drawn in the pane's padding column.
-		m.renderWorkspaces(max(1, workspaceWidth-3), contentHeight-1),
+		// Two columns of slack past the margin: one blank, then the
+		// connector in the block's last column, reaching for the agents.
+		m.renderWorkspaces(max(1, workspaceWidth-3), listHeight),
 		paneFrame{
 			width:   workspaceWidth,
 			height:  contentHeight,
 			active:  m.activePane == paneWorkspaces,
-			edges:   paneEdges{right: seamColumn},
 			band:    headerBand{start: 0, total: width},
+			margins: paneMargins{top: true, left: true},
 			dimming: dimWorkspaces,
 		},
 	)
@@ -147,13 +154,14 @@ func (m Model) renderDashboardBody(width, contentHeight int) string {
 	agents := m.renderPane(
 		"Agents",
 		m.selectedWorkspaceLabel(),
-		m.renderAgents(max(1, agentWidth-2), contentHeight-1),
+		m.renderAgents(max(1, agentWidth-2), listHeight),
 		paneFrame{
 			width:   agentWidth,
 			height:  contentHeight,
 			active:  m.activePane == paneAgents,
 			edges:   paneEdges{right: seamPlane},
 			band:    headerBand{start: workspaceWidth, total: width},
+			margins: paneMargins{top: true, left: true},
 			dimming: dimAgents,
 		},
 	)
@@ -162,7 +170,7 @@ func (m Model) renderDashboardBody(width, contentHeight int) string {
 		"",
 		m.renderInteraction(
 			max(1, interactionWidth-3),
-			contentHeight-1,
+			listHeight,
 		),
 		paneFrame{
 			width:   interactionWidth,
@@ -170,12 +178,13 @@ func (m Model) renderDashboardBody(width, contentHeight int) string {
 			active:  m.activePane == paneInteraction,
 			edges:   paneEdges{gutter: true},
 			band:    headerBand{start: workspaceWidth + agentWidth, total: width},
+			margins: paneMargins{top: true},
 			dimming: dimInteraction,
 		},
 	)
 	return lipgloss.JoinHorizontal(
 		lipgloss.Top,
-		capSeam(workspaces, workspaceWidth, seamColumn),
+		workspaces,
 		capSeam(agents, agentWidth, seamPlane),
 		interaction,
 	)
@@ -220,12 +229,12 @@ func (m Model) paneDimmings(contentHeight int) (
 	workspaces = paneDimming{dim: true}
 	if len(m.groups) > 0 {
 		workspaces.keep = m.selectedRowRange(
-			len(m.groups), m.workspaceCursor, contentHeight-1)
+			len(m.groups), m.workspaceCursor, contentHeight-2)
 	}
 	agents = paneDimming{dim: true}
 	if list := m.agentsForSelectedWorkspace(); len(list) > 0 {
 		agents.keep = m.selectedRowRange(
-			len(list), m.agentCursor, contentHeight-1)
+			len(list), m.agentCursor, contentHeight-2)
 	}
 	return workspaces, agents, paneDimming{}
 }
@@ -240,7 +249,7 @@ func (m Model) hierarchyConnectorRows(contentHeight int) (int, int, bool) {
 	}
 
 	expanded := m.expandedRows()
-	listHeight := contentHeight - 1
+	listHeight := contentHeight - 2
 	workspaceCapacity := listRowCapacity(listHeight, expanded)
 	workspaceStart, workspaceEnd := visibleRange(
 		len(m.groups),
@@ -264,8 +273,10 @@ func (m Model) hierarchyConnectorRows(contentHeight int) (int, int, bool) {
 	if expanded {
 		rowStep = 3
 	}
-	workspaceRow := 1 + (m.workspaceCursor-workspaceStart)*rowStep
-	agentRow := 1 + (m.agentCursor-agentStart)*rowStep
+	// Two rows of chrome above the first list row: the header band and the
+	// blank row the inset opens with.
+	workspaceRow := 2 + (m.workspaceCursor-workspaceStart)*rowStep
+	agentRow := 2 + (m.agentCursor-agentStart)*rowStep
 	return workspaceRow, agentRow, true
 }
 
@@ -286,9 +297,9 @@ func paintHierarchyConnector(
 		return paneContent
 	}
 
-	// The connector lives in the padding column between the workspace text
-	// and the pane divider, so the divider stays continuous and the gold
-	// arc spans exactly its two endpoint rows — rounded caps, no spill.
+	// The connector lives in the workspaces block's last column — the air
+	// where a rule used to be — so the gold arc reaches toward the agent it
+	// names, spanning exactly its two endpoint rows with rounded caps.
 	style := lipgloss.NewStyle().Foreground(colorWaiting)
 	first := min(workspaceRow, agentRow)
 	last := max(workspaceRow, agentRow)
@@ -309,7 +320,7 @@ func paintHierarchyConnector(
 		lines[row] = replaceStyledCell(
 			lines[row],
 			width,
-			width-2,
+			width-1,
 			glyph,
 			style,
 		)
@@ -641,6 +652,13 @@ type headerBand struct {
 	total int
 }
 
+// paneMargins is the air a pane keeps inside its own frame: a blank row
+// under the header band, and a column between the frame and the text.
+type paneMargins struct {
+	top  bool
+	left bool
+}
+
 // paneFrame is everything about a pane that isn't its text.
 type paneFrame struct {
 	width   int
@@ -648,6 +666,7 @@ type paneFrame struct {
 	active  bool
 	edges   paneEdges
 	band    headerBand
+	margins paneMargins
 	dimming paneDimming
 }
 
@@ -689,11 +708,20 @@ func (m Model) renderPane(
 	if dimming.dim {
 		content = dimPane(content, dimming.keep)
 	}
-	body := lipgloss.NewStyle().
-		Width(contentWidth).
-		MaxWidth(contentWidth).
-		Render(content)
-	return style.Render(lipgloss.JoinVertical(lipgloss.Left, header, body))
+	bodyStyle := lipgloss.NewStyle().Width(contentWidth).MaxWidth(contentWidth)
+	if frame.margins.top {
+		// Every pane opens a row below the band, so its content sits inside
+		// the frame rather than pressed against it. The blank row is
+		// prepended after dimming, which keeps the undimmed range indexed
+		// against the rows themselves.
+		content = "\n" + content
+	}
+	if frame.margins.left {
+		bodyStyle = bodyStyle.PaddingLeft(1)
+	}
+	return style.Render(
+		lipgloss.JoinVertical(lipgloss.Left, header, bodyStyle.Render(content)),
+	)
 }
 
 // dimPane lays the terminal's faint attribute over a list pane so its
@@ -797,7 +825,9 @@ func renderPaneHeader(
 	}
 	right := rightStyle.Render(truncate(contextLabel, remaining))
 	rightWidth := lipgloss.Width(right)
-	gap := max(2, width-leftWidth-rightWidth)
+	// One column of band survives past the context label, so it never ends
+	// flush against the seam it sits beside.
+	gap := max(2, width-leftWidth-rightWidth-1)
 	tail := max(0, width-leftWidth-gap-rightWidth)
 	return left + fill(leftWidth, gap) + right +
 		fill(leftWidth+gap+rightWidth, tail)

--- a/internal/ui/layout.go
+++ b/internal/ui/layout.go
@@ -110,7 +110,7 @@ func (m Model) renderDashboardBody(width, contentHeight int) string {
 		workspaceWidth,
 		contentHeight,
 		m.activePane == paneWorkspaces,
-		true,
+		paneEdges{right: seamColumn},
 		dimWorkspaces,
 	)
 	if workspaceRow, agentRow, ok := m.hierarchyConnectorRows(contentHeight); ok {
@@ -128,20 +128,20 @@ func (m Model) renderDashboardBody(width, contentHeight int) string {
 		agentWidth,
 		contentHeight,
 		m.activePane == paneAgents,
-		true,
+		paneEdges{right: seamPlane},
 		dimAgents,
 	)
 	interaction := m.renderPane(
 		"Spanreed",
 		"",
 		m.renderInteraction(
-			max(1, interactionWidth-2),
+			max(1, interactionWidth-3),
 			contentHeight-1,
 		),
 		interactionWidth,
 		contentHeight,
 		m.activePane == paneInteraction,
-		false,
+		paneEdges{gutter: true},
 		dimInteraction,
 	)
 	return lipgloss.JoinHorizontal(lipgloss.Top, workspaces, agents, interaction)
@@ -425,7 +425,7 @@ func (m Model) renderFocusedPane(width, height int) string {
 			width,
 			height,
 			true,
-			false,
+			paneEdges{},
 			paneDimming{},
 		)
 	case paneInteraction:
@@ -436,7 +436,7 @@ func (m Model) renderFocusedPane(width, height int) string {
 			width,
 			height,
 			true,
-			false,
+			paneEdges{},
 			paneDimming{},
 		)
 	default:
@@ -447,7 +447,7 @@ func (m Model) renderFocusedPane(width, height int) string {
 			width,
 			height,
 			true,
-			false,
+			paneEdges{},
 			paneDimming{},
 		)
 	}
@@ -524,6 +524,52 @@ func (m Model) selectedRowRange(total, cursor, listHeight int) undimmedRows {
 	return undimmedRows{start: (cursor - start) * step, count: size}
 }
 
+// paneSeam is the rule down a pane's right edge. Not every boundary divides
+// the same kind of thing, and the rule says which is which.
+type paneSeam int
+
+const (
+	// seamNone ends a pane at the terminal's edge — nothing to divide.
+	seamNone paneSeam = iota
+	// seamColumn separates two views of one hierarchy: workspaces and the
+	// agents inside the selected one. A hairline, because crossing it is
+	// just moving down the tree.
+	seamColumn
+	// seamPlane separates the catalog from the Spanreed. Left of it is a
+	// file explorer — a tree you browse. Right of it is the control plane
+	// where an agent is read and driven. The rule goes heavy and the pane
+	// beyond it opens with a column of air (see paneEdges.gutter), so the
+	// two halves read as different surfaces rather than a third column.
+	seamPlane
+)
+
+// border returns the box-drawing rule a seam paints down the pane edge.
+func (s paneSeam) border() lipgloss.Border {
+	border := lipgloss.NormalBorder()
+	if s == seamPlane {
+		border.Right = "┃"
+	}
+	return border
+}
+
+// foreground colors the rule. A column seam is furniture and stays the
+// border grey; a plane seam takes the accent, so the one line that divides
+// browsing from driving is also the one line on screen that isn't furniture.
+func (s paneSeam) foreground() lipgloss.TerminalColor {
+	if s == seamPlane {
+		return colorAccent
+	}
+	return colorBorder
+}
+
+// paneEdges describes both sides of a pane's frame. A plane seam is drawn in
+// two halves by two panes: the pane on its left owns the heavy rule, the pane
+// on its right owns the column of air that follows it.
+type paneEdges struct {
+	right  paneSeam
+	gutter bool
+}
+
 func (m Model) renderPane(
 	label string,
 	contextLabel string,
@@ -531,27 +577,37 @@ func (m Model) renderPane(
 	width int,
 	height int,
 	active bool,
-	borderRight bool,
+	edges paneEdges,
 	dimming paneDimming,
 ) string {
 	innerWidth := max(1, width)
 	style := lipgloss.NewStyle().Width(innerWidth).Height(height).MaxHeight(height)
-	if borderRight {
-		// Dividers are structure, not state: focus is shown by the header
-		// underline and the single hot cursor row, never the frame.
+	if edges.right != seamNone {
+		// Dividers are structure, not state: a seam looks the same whichever
+		// pane holds the cursor, so the accent on the plane seam reads as a
+		// permanent fixture rather than a focus signal. Focus stays with the
+		// header underline and the single hot cursor row.
 		innerWidth = max(1, width-1)
 		style = style.Width(innerWidth).
-			BorderStyle(lipgloss.NormalBorder()).
+			BorderStyle(edges.right.border()).
 			BorderRight(true).
-			BorderForeground(colorBorder)
+			BorderForeground(edges.right.foreground())
 	}
-	header := renderPaneHeader(label, contextLabel, innerWidth, active)
+	// The gutter is the far half of a plane seam, so it comes out of this
+	// pane's own columns: the header rule and every body row start one cell
+	// in, leaving the heavy rule with air on its far side.
+	contentWidth := innerWidth
+	if edges.gutter {
+		contentWidth = max(1, innerWidth-1)
+		style = style.PaddingLeft(1)
+	}
+	header := renderPaneHeader(label, contextLabel, contentWidth, active)
 	if dimming.dim {
 		content = dimPane(content, dimming.keep)
 	}
 	body := lipgloss.NewStyle().
-		Width(innerWidth).
-		MaxWidth(innerWidth).
+		Width(contentWidth).
+		MaxWidth(contentWidth).
 		Render(content)
 	return style.Render(lipgloss.JoinVertical(lipgloss.Left, header, body))
 }
@@ -660,7 +716,9 @@ func (m Model) interactionDimensions() (int, int) {
 		return max(1, width-2), contentHeight
 	}
 	_, _, interactionWidth := m.paneWidths(width)
-	return max(1, interactionWidth-2), contentHeight
+	// One column goes to the plane seam's gutter, two to the pane's own
+	// slack; renderDashboardBody splits it the same way.
+	return max(1, interactionWidth-3), contentHeight
 }
 
 // basePaneWidths splits a dashboard row between the three panes. The

--- a/internal/ui/spanreed.go
+++ b/internal/ui/spanreed.go
@@ -27,19 +27,7 @@ func (m Model) renderInteraction(width, height int) string {
 			nil,
 		)
 	}
-	metaParts := []string{
-		string(managedAgent.Provider),
-		agentStateLabel(managedAgent),
-	}
-	if badge := modeBadge(managedAgent.Mode); badge != "" {
-		metaParts = append(metaParts, badge)
-	}
-	meta := interactionMeta(
-		strings.Join(metaParts, "  "),
-		agentCheckout(managedAgent),
-		shortPath(managedAgent.Cwd),
-		width,
-	)
+	meta := interactionMeta(managedAgent, width)
 	switch {
 	case managedAgent.EffectiveMark() == agent.MarkAttention:
 		meta = lipgloss.NewStyle().Foreground(colorWaiting).
@@ -149,26 +137,85 @@ func (m Model) renderInteraction(width, height int) string {
 // primary one leaves the reader unable to tell an unbadged agent from a
 // dashboard that does not know. Either way the badge is the last token to
 // yield width, and the path — which merely restates it — is the first.
-func interactionMeta(status string, checkout checkoutBadge, path string, width int) string {
-	if checkout.text == "" {
-		return mutedStyle.Render(
-			truncate(strings.TrimSpace(status+"  "+path), width),
-		)
+// A metaToken is one fact in the Spanreed's masthead. Rendering and measuring
+// are separate concerns because the styled string carries escape sequences no
+// width calculation should see.
+type metaToken struct {
+	plain    string
+	rendered string
+}
+
+func (t metaToken) width() int { return lipgloss.Width(t.plain) }
+
+// metaSeparator groups the masthead's facts into readable tokens instead of
+// letting them run together on spacing alone.
+const metaSeparator = " · "
+
+// interactionMeta is the masthead under the agent's name: what it is, what it
+// is doing, what it may do unattended, which checkout it stands in, and where
+// that is on disk. The state leads with the glyph the agent rows and the
+// header counters use for it — the Spanreed is the fourth place that
+// vocabulary appears, and the only one that used to spell the state as a bare
+// grey word. Tokens drop from the tail when the pane narrows, so the loudest
+// facts outlive the path.
+func interactionMeta(managedAgent agent.Agent, width int) string {
+	symbol, symbolStyle := statusVisual(managedAgent)
+	tokens := []metaToken{{
+		plain: symbol + " " + agentStateLabel(managedAgent),
+		rendered: symbolStyle.Render(symbol) + " " +
+			mutedStyle.Render(agentStateLabel(managedAgent)),
+	}}
+	if provider := string(managedAgent.Provider); provider != "" {
+		tokens = append(tokens, metaToken{provider, mutedStyle.Render(provider)})
 	}
-	rendered := mutedStyle.Render(truncate(status, width))
-	badge := truncate(
-		checkout.text,
-		max(0, width-lipgloss.Width(rendered)-2),
-	)
-	if badge == "" {
-		return rendered
+	if badge := modeBadge(managedAgent.Mode); badge != "" {
+		// AUTO is the one token here that changes what happens without you.
+		// The dispatch modal has always said it in amber; saying it in grey
+		// on the screen that stays open was the inconsistency.
+		style := mutedStyle
+		if managedAgent.Mode == agent.ModeAuto {
+			style = lipgloss.NewStyle().Foreground(colorWaiting).Bold(true)
+		}
+		tokens = append(tokens, metaToken{badge, style.Render(badge)})
 	}
-	rendered += "  " + checkoutStyle(checkout).Render(badge)
-	remaining := width - lipgloss.Width(rendered) - 2
-	if path != "" && remaining > 0 {
-		rendered += "  " + mutedStyle.Render(truncate(path, remaining))
+	if checkout := agentCheckout(managedAgent); checkout.text != "" {
+		tokens = append(tokens, metaToken{
+			checkout.text,
+			checkoutStyle(checkout).Render(checkout.text),
+		})
 	}
-	return rendered
+	if path := shortPath(managedAgent.Cwd); path != "" {
+		tokens = append(tokens, metaToken{path, mutedStyle.Render(path)})
+	}
+	return joinMetaTokens(tokens, width)
+}
+
+func joinMetaTokens(tokens []metaToken, width int) string {
+	separator := lipgloss.Width(metaSeparator)
+	total := 0
+	kept := 0
+	for _, token := range tokens {
+		cost := token.width()
+		if kept > 0 {
+			cost += separator
+		}
+		if total+cost > width {
+			break
+		}
+		total += cost
+		kept++
+	}
+	if kept == 0 {
+		if len(tokens) == 0 {
+			return ""
+		}
+		return truncate(tokens[0].plain, width)
+	}
+	parts := make([]string, 0, kept)
+	for _, token := range tokens[:kept] {
+		parts = append(parts, token.rendered)
+	}
+	return strings.Join(parts, mutedStyle.Render(metaSeparator))
 }
 
 // checkoutStyle picks the badge's color. A linked worktree is the tree worth

--- a/internal/ui/workspaces.go
+++ b/internal/ui/workspaces.go
@@ -124,10 +124,16 @@ func (m Model) renderWorkspaceRow(
 ) string {
 	active, urgent, waiting := workspaceStats(group.agents)
 	contentWidth := max(1, width-1)
-	minimumNameWidth := min(10, max(1, contentWidth/2))
+	// What the name actually asks for, floored so a long one still yields
+	// ground to the chips rather than shouldering them off the row.
+	nameNeed := min(
+		lipgloss.Width(group.context.Name),
+		min(10, max(1, contentWidth/2)),
+	)
 	chips := fitCountChips(
 		workspaceCountChips(active, urgent, waiting, len(group.agents)),
-		max(1, contentWidth-lipgloss.Width("  ")-minimumNameWidth-1),
+		max(1, contentWidth-lipgloss.Width("  ")-1),
+		nameNeed,
 	)
 	suffix := chipsPlain(chips)
 	// The left column is the selection's alone now that the counts carry
@@ -237,18 +243,27 @@ func workspaceCountChips(active, urgent, waiting, total int) []countChip {
 	return chips
 }
 
-// fitCountChips drops the quietest tiers until the cluster fits. The first
-// chip always survives: a narrow pane still owes you the loudest thing
-// happening in that workspace.
-func fitCountChips(chips []countChip, width int) []countChip {
-	for len(chips) > 1 && lipgloss.Width(chipsPlain(chips)) > width {
+// fitCountChips drops the quietest tiers until the cluster and the name both
+// fit in available. The name asks for what it needs rather than a fixed
+// reservation — a nine-letter workspace should not hold a column open for a
+// twenty-letter one, which is what used to leave a three-tier row showing a
+// single chip beside four columns of nothing. The first chip always survives:
+// a narrow pane still owes you the loudest thing happening in there.
+func fitCountChips(chips []countChip, available, nameNeed int) []countChip {
+	for len(chips) > 1 &&
+		available-lipgloss.Width(chipsPlain(chips)) < nameNeed {
 		chips = chips[:len(chips)-1]
 	}
 	return chips
 }
 
+// A chip breathes: a space between the glyph and its numeral, and a wider
+// one between chips, so a cluster reads as pairs rather than a run of
+// characters. Same rhythm as the header counters.
+const chipGap = "  "
+
 func chipText(chip countChip) string {
-	return chip.glyph + strconv.Itoa(chip.count)
+	return chip.glyph + " " + strconv.Itoa(chip.count)
 }
 
 func chipsPlain(chips []countChip) string {
@@ -256,7 +271,7 @@ func chipsPlain(chips []countChip) string {
 	for _, chip := range chips {
 		parts = append(parts, chipText(chip))
 	}
-	return strings.Join(parts, " ")
+	return strings.Join(parts, chipGap)
 }
 
 func chipsStyled(chips []countChip) string {
@@ -264,7 +279,7 @@ func chipsStyled(chips []countChip) string {
 	for _, chip := range chips {
 		parts = append(parts, chip.style.Render(chipText(chip)))
 	}
-	return strings.Join(parts, " ")
+	return strings.Join(parts, chipGap)
 }
 
 func renderSelectedWorkspaceRow(

--- a/internal/ui/workspaces.go
+++ b/internal/ui/workspaces.go
@@ -6,6 +6,7 @@ package ui
 import (
 	"fmt"
 	"path/filepath"
+	"strconv"
 	"strings"
 
 	tea "github.com/charmbracelet/bubbletea"
@@ -122,45 +123,19 @@ func (m Model) renderWorkspaceRow(
 	danger bool,
 ) string {
 	active, urgent, waiting := workspaceStats(group.agents)
-	countLabel := fmt.Sprintf("%d agents", len(group.agents))
-	if len(group.agents) == 1 {
-		countLabel = "1 agent"
-	}
-	suffixes := []string{}
-	if urgent > 0 {
-		suffixes = append(suffixes, fmt.Sprintf("%d input", urgent))
-	}
-	if waiting > 0 {
-		suffixes = append(suffixes, fmt.Sprintf("%d waiting", waiting))
-	}
-	if active > 0 {
-		suffixes = append(suffixes, fmt.Sprintf("%d active", active))
-	}
-	suffixes = append(suffixes, countLabel)
 	contentWidth := max(1, width-1)
 	minimumNameWidth := min(10, max(1, contentWidth/2))
-	maxSuffixWidth := max(
-		1,
-		contentWidth-lipgloss.Width("  ")-minimumNameWidth-1,
+	chips := fitCountChips(
+		workspaceCountChips(active, urgent, waiting, len(group.agents)),
+		max(1, contentWidth-lipgloss.Width("  ")-minimumNameWidth-1),
 	)
-	suffix := truncate(suffixes[len(suffixes)-1], maxSuffixWidth)
-	for _, candidate := range suffixes {
-		if lipgloss.Width(candidate) <= maxSuffixWidth {
-			suffix = candidate
-			break
-		}
-	}
-	// One indicator column: the most important glyph wins, and any state
-	// it displaces still speaks through the name styling.
+	suffix := chipsPlain(chips)
+	// The left column is the selection's alone now that the counts carry
+	// state. It used to show whichever state glyph outranked the others,
+	// which said the same thing as the cluster on the right and cost the
+	// name a column to say it twice.
 	indicator := " "
-	switch {
-	case urgent > 0:
-		indicator = "!"
-	case waiting > 0:
-		indicator = "○"
-	case active > 0:
-		indicator = "●"
-	case selected && !focused:
+	if selected && !focused {
 		indicator = "›"
 	}
 	gutter := indicator + " "
@@ -199,40 +174,97 @@ func (m Model) renderWorkspaceRow(
 		)
 	}
 
-	indicatorStyle := mutedStyle
-	if indicator == "›" {
-		indicatorStyle = lipgloss.NewStyle().Foreground(colorBorder)
-	}
+	indicatorStyle := lipgloss.NewStyle().Foreground(colorBorder)
 	renderedName := titleStyle.Render(name)
-	suffixStyle := mutedStyle
 	switch {
 	case tier == tierUrgent:
-		// Urgent attention outranks the working glow: the whole row goes
-		// loud amber.
-		attentionStyle := lipgloss.NewStyle().Foreground(colorWaiting).Bold(true)
-		indicatorStyle = attentionStyle
-		renderedName = attentionStyle.Render(name)
-		suffixStyle = attentionStyle
-	case tier == tierWaiting:
-		// Soft tier: amber marker and count only; the row stays calm.
-		softStyle := lipgloss.NewStyle().Foreground(colorWaiting)
-		indicatorStyle = softStyle
-		suffixStyle = softStyle
+		// Urgent attention outranks the working glow: the name goes loud
+		// amber to match the chip already shouting on the right.
+		renderedName = lipgloss.NewStyle().
+			Foreground(colorWaiting).
+			Bold(true).
+			Render(name)
 	case active > 0:
-		indicatorStyle = lipgloss.NewStyle().
-			Foreground(colorWorking).
-			Bold(true)
 		renderedName = shimmerText(name, m.shimmerPhaseOrRest(), nil)
 	}
 	top := indicatorStyle.Render(gutter) +
 		renderedName +
 		strings.Repeat(" ", gap) +
-		suffixStyle.Render(suffix)
+		chipsStyled(chips)
 	bottom := mutedStyle.Render(" " + bottomContent)
 	if !m.expandedRows() {
 		return top
 	}
 	return lipgloss.JoinVertical(lipgloss.Left, top, bottom)
+}
+
+// A countChip is one tier of a workspace's population, told in the glyph the
+// agent rows use for it. Words lived in this column once — "1 input",
+// "2 agents" — and a twenty-column pane cannot afford both a sentence and a
+// name, so every workspace read as "stormlig… 1 input". A glyph and a numeral
+// say the same thing in two columns and speak the vocabulary the header and
+// the rows already established.
+type countChip struct {
+	glyph string
+	count int
+	style lipgloss.Style
+}
+
+// workspaceCountChips orders the tiers loudest first. A workspace with
+// nothing pending reports its population instead, in the muted dot the agent
+// rows use for a state worth no alarm — including the honest "· 0".
+func workspaceCountChips(active, urgent, waiting, total int) []countChip {
+	chips := make([]countChip, 0, 3)
+	if urgent > 0 {
+		chips = append(chips, countChip{
+			"!", urgent,
+			lipgloss.NewStyle().Foreground(colorWaiting).Bold(true),
+		})
+	}
+	if waiting > 0 {
+		chips = append(chips, countChip{
+			"○", waiting, lipgloss.NewStyle().Foreground(colorWaiting),
+		})
+	}
+	if active > 0 {
+		chips = append(chips, countChip{
+			"●", active, lipgloss.NewStyle().Foreground(colorWorking),
+		})
+	}
+	if len(chips) == 0 {
+		chips = append(chips, countChip{"·", total, mutedStyle})
+	}
+	return chips
+}
+
+// fitCountChips drops the quietest tiers until the cluster fits. The first
+// chip always survives: a narrow pane still owes you the loudest thing
+// happening in that workspace.
+func fitCountChips(chips []countChip, width int) []countChip {
+	for len(chips) > 1 && lipgloss.Width(chipsPlain(chips)) > width {
+		chips = chips[:len(chips)-1]
+	}
+	return chips
+}
+
+func chipText(chip countChip) string {
+	return chip.glyph + strconv.Itoa(chip.count)
+}
+
+func chipsPlain(chips []countChip) string {
+	parts := make([]string, 0, len(chips))
+	for _, chip := range chips {
+		parts = append(parts, chipText(chip))
+	}
+	return strings.Join(parts, " ")
+}
+
+func chipsStyled(chips []countChip) string {
+	parts := make([]string, 0, len(chips))
+	for _, chip := range chips {
+		parts = append(parts, chip.style.Render(chipText(chip)))
+	}
+	return strings.Join(parts, " ")
 }
 
 func renderSelectedWorkspaceRow(

--- a/internal/ui/workspaces.go
+++ b/internal/ui/workspaces.go
@@ -136,15 +136,12 @@ func (m Model) renderWorkspaceRow(
 		nameNeed,
 	)
 	suffix := chipsPlain(chips)
-	// The left column is the selection's alone now that the counts carry
-	// state. It used to show whichever state glyph outranked the others,
-	// which said the same thing as the cluster on the right and cost the
-	// name a column to say it twice.
-	indicator := " "
-	if selected && !focused {
-		indicator = "›"
-	}
-	gutter := indicator + " "
+	// Nothing marks this column. A selected-but-unfocused workspace is
+	// already named by the row that stays at full strength while its
+	// neighbours dim, and by the connector arc pointing out of it — an arrow
+	// saying it a third time is texture, not information. The two columns
+	// remain so quiet rows line up with the focused row's marker.
+	gutter := "  "
 	nameWidth := max(
 		1,
 		contentWidth-lipgloss.Width(gutter)-lipgloss.Width(suffix)-1,
@@ -180,7 +177,6 @@ func (m Model) renderWorkspaceRow(
 		)
 	}
 
-	indicatorStyle := lipgloss.NewStyle().Foreground(colorBorder)
 	renderedName := titleStyle.Render(name)
 	switch {
 	case tier == tierUrgent:
@@ -193,7 +189,7 @@ func (m Model) renderWorkspaceRow(
 	case active > 0:
 		renderedName = shimmerText(name, m.shimmerPhaseOrRest(), nil)
 	}
-	top := indicatorStyle.Render(gutter) +
+	top := gutter +
 		renderedName +
 		strings.Repeat(" ", gap) +
 		chipsStyled(chips)


### PR DESCRIPTION
The dashboard drew every line the same way, so nothing it drew meant
anything. Both pane dividers were an identical hairline in border grey,
the pane headers were ruled with the terminal's underline attribute in a
flat color, and the footer rule carried a gradient neither of them shared.
Three materials, no relationship between them.

This branch gives the chrome a hierarchy and then removes what turned out
to be saying the same thing twice.

## The seams

The boundary between the Agents list and the Spanreed is not the same kind
of boundary as the one inside the catalog. Left of it is a tree you browse;
right of it is the control plane where an agent is read and driven. It is
now a heavy rule in the stormlight accent, drawn in two halves by the panes
on either side — Agents owns the rule, the Spanreed owns the column of air
behind it — with the gutter coming out of the Spanreed's own columns so the
widths still sum.

The catalog's own divider stays a hairline, painted in the header band's
faded gradient, with air on both sides. It was briefly deleted altogether
on the theory that file explorers separate columns with whitespace; running
yazi and reading the published guidance said otherwise, and the real fault
was a rule pressed flush against both lists rather than the rule itself.

Both seams hang from half-stroke caps under the header band instead of
colliding with it.

## The band

`bandColor` samples the wordmark's sapphire→ice gradient across the full
terminal width, held back toward the border grey. The pane header rules and
the footer rule are both runs of it, positioned by where they sit in the
dashboard rather than restarting per pane, so the frame's top and bottom
edges are one continuous sweep. Focus is the segment that rises to full
strength, which retired the flat accent the active header used to swap in.

Labels interrupt the band rather than riding on it — a rule under the words
is a table header, and an underline takes the color of the text above it,
which was breaking the gradient at every pane.

## One vocabulary for state

The glyphs `statusVisual` paints down the agent list now also carry the
header counters (`● 1 working · ○ 1 waiting · ! 1 needs input`), the
workspace population chips (`! 2  ○ 1`), and the Spanreed's masthead
(`○ idle · claude · AUTO · main checkout · …`). The header reads as the
legend for everything under it.

Workspace counts were prose before — `1 input`, `2 agents` — which cost a
twenty-column pane its names, so every row read `stormlig… 1 input`. `AUTO`
was muted in the masthead while the dispatch modal has always shown it in
amber; it is the one token there that changes what happens without you.

## Things said twice, now said once

- The Agents header no longer repeats the selected workspace name. The wide
  layout names it four other ways; the narrow layout, which shows one pane
  at a time and has none of them, keeps the label.
- Workspace rows drop their `›` marker — the undimmed row and the connector
  arc already say it.
- The workspace row's leading state glyph is gone; the count chips say it.

## Also

- Every pane opens a row below the band, and the list panes carry a column
  of left margin.
- The hierarchy connector has its own column between the text and the rule.
- `truncate` collapses whitespace runs, which had been eating the leading
  space on every pane label since well before this branch.
- `renderPane`'s argument list had reached eight; the frame half is now a
  `paneFrame`.
- The Spanreed masthead is measured tokens instead of spliced strings, so it
  degrades from the tail: state and provider outlive the checkout, which
  outlives the path.

## Testing

`go test ./...` passes except for `TestDispatchTabEscapesThePathPicker`,
`TestDispatchHintsNameTheNextField`, and `TestDispatchPathNavPicksIntoTheNextField`,
which fail identically on `origin/main` (verified in a detached worktree at
the current tip) and are unrelated to this work.

Layouts were checked at 120, 110, 80, and 60 columns, and against the live
binary under a headless tmux server with isolated XDG state — the seam
colors, the band's continuity into the footer rule, and which header cells
carry the underline were all read back from the emitted bytes rather than
assumed.