### PR TITLE
Curve every overlay's corners

### DIFF
--- a/internal/surface/surface.go
+++ b/internal/surface/surface.go
@@ -25,10 +25,15 @@ type Command struct {
 }
 
 type Popup struct {
-	Width       string
-	Height      string
-	Title       string
+	Width  string
+	Height string
+	Title  string
+	// BorderStyle colors the frame; BorderLines picks which glyphs draw it
+	// (tmux's single, rounded, heavy, double, …). Both are passed through
+	// verbatim — the surface decides how to render a popup, not what one
+	// should look like.
 	BorderStyle string
+	BorderLines string
 }
 
 type Request struct {

--- a/internal/tmux/surface.go
+++ b/internal/tmux/surface.go
@@ -107,6 +107,9 @@ func (s *Surface) Present(
 	if popup.BorderStyle != "" {
 		args = append(args, "-S", popup.BorderStyle)
 	}
+	if popup.BorderLines != "" {
+		args = append(args, "-b", popup.BorderLines)
+	}
 	args = append(args, request.Command.Path)
 	args = append(args, request.Command.Args...)
 	return surface.Presentation{

--- a/internal/tmux/surface_test.go
+++ b/internal/tmux/surface_test.go
@@ -28,6 +28,7 @@ func TestSurfacePresentsCommandsInTmuxPopup(t *testing.T) {
 			Height:      "76%",
 			Title:       " Stormlight · Choose directory ",
 			BorderStyle: "fg=#e5c07b",
+			BorderLines: "rounded",
 		},
 	})
 	if err != nil {
@@ -45,6 +46,7 @@ func TestSurfacePresentsCommandsInTmuxPopup(t *testing.T) {
 		"-d", "/workspace/project",
 		"-T", " Stormlight · Choose directory ",
 		"-S", "fg=#e5c07b",
+		"-b", "rounded",
 		"/opt/homebrew/bin/yazi",
 		"--chooser-file", "/tmp/choice",
 		"--cwd-file", "/tmp/cwd",

--- a/internal/ui/dispatch.go
+++ b/internal/ui/dispatch.go
@@ -478,10 +478,12 @@ func (m Model) renderTaskComposer(width, height int) string {
 	input.SetWidth(innerWidth)
 	input.SetHeight(height)
 
+	// Curved, like the modal it sits inside. A square box nested in a rounded
+	// one reads as a rendering slip rather than a distinction.
 	style := lipgloss.NewStyle().
 		Width(innerWidth).
 		Height(height).
-		BorderStyle(lipgloss.NormalBorder()).
+		BorderStyle(lipgloss.RoundedBorder()).
 		BorderForeground(colorBorder)
 	if m.formFocus == dispatchTask {
 		style = style.BorderForeground(colorAccent)

--- a/internal/ui/input_test.go
+++ b/internal/ui/input_test.go
@@ -635,16 +635,31 @@ func TestModalRendersCompleteBorder(t *testing.T) {
 	if len(lines) != 8 {
 		t.Fatalf("modal height = %d, want 8:\n%s", len(lines), rendered)
 	}
-	if !strings.HasPrefix(lines[0], "┌") ||
-		!strings.HasSuffix(lines[0], "┐") ||
-		!strings.HasPrefix(lines[len(lines)-1], "└") ||
-		!strings.HasSuffix(lines[len(lines)-1], "┘") {
-		t.Fatalf("modal border is incomplete:\n%s", rendered)
+	if !strings.HasPrefix(lines[0], "╭") ||
+		!strings.HasSuffix(lines[0], "╮") ||
+		!strings.HasPrefix(lines[len(lines)-1], "╰") ||
+		!strings.HasSuffix(lines[len(lines)-1], "╯") {
+		t.Fatalf("modal border is incomplete or not curved:\n%s", rendered)
 	}
 	for index, line := range lines {
 		if width := lipgloss.Width(line); width != 32 {
 			t.Fatalf("modal line %d width = %d, want 32", index+1, width)
 		}
+	}
+}
+
+// The composer sits inside the dispatch modal, so it curves with it. A square
+// box nested in a rounded one reads as a rendering slip.
+func TestTaskComposerCurvesWithItsModal(t *testing.T) {
+	box := strings.Split(
+		ansi.Strip(NewModel(stubBackend{}).renderTaskComposer(40, 3)),
+		"\n",
+	)
+	if !strings.HasPrefix(box[0], "╭") ||
+		!strings.HasSuffix(box[0], "╮") ||
+		!strings.HasPrefix(box[len(box)-1], "╰") ||
+		!strings.HasSuffix(box[len(box)-1], "╯") {
+		t.Fatalf("task composer is not curved:\n%s", strings.Join(box, "\n"))
 	}
 }
 

--- a/internal/ui/layout.go
+++ b/internal/ui/layout.go
@@ -377,6 +377,9 @@ func modalDimensions(
 	return width, height
 }
 
+// Modals curve their corners. Square corners are what the dashboard's own
+// rules and seams are drawn with, so an overlay that shares them reads as
+// another region of the layout; the arc says this floats above it.
 func renderModal(content string, width, height int) string {
 	if width < 3 || height < 3 {
 		return fitBlock(content, width, height)
@@ -387,7 +390,7 @@ func renderModal(content string, width, height int) string {
 	return lipgloss.NewStyle().
 		Width(innerWidth).
 		Height(innerHeight).
-		BorderStyle(lipgloss.NormalBorder()).
+		BorderStyle(lipgloss.RoundedBorder()).
 		BorderForeground(colorWaiting).
 		Render(content)
 }

--- a/internal/ui/overlays.go
+++ b/internal/ui/overlays.go
@@ -13,6 +13,22 @@ import (
 	"github.com/trentkm/stormlight/internal/surface"
 )
 
+// overlayPopup is the frame every Stormlight overlay wears. A tmux popup and
+// a lipgloss modal are drawn by different things but mean the same thing to
+// whoever is looking at them, so they share a curve and the dashboard's amber
+// (theme.Waiting's dark value — tmux styles take a literal color, not an
+// adaptive one). Only the title and how much room the hosted program wants
+// vary between overlays.
+func overlayPopup(title, width string) *surface.Popup {
+	return &surface.Popup{
+		Width:       width,
+		Height:      "76%",
+		Title:       title,
+		BorderStyle: "fg=#e5c07b",
+		BorderLines: "rounded",
+	}
+}
+
 func (m Model) openTaskEditor() (tea.Model, tea.Cmd) {
 	if m.nvimPath == "" {
 		m.err = fmt.Errorf("Neovim is not installed or not on PATH")
@@ -81,12 +97,7 @@ func taskEditorCmd(
 
 	var popup *surface.Popup
 	if current.Capabilities().Popups {
-		popup = &surface.Popup{
-			Width:       "82%",
-			Height:      "76%",
-			Title:       " Stormlight · Edit task ",
-			BorderStyle: "fg=#e5c07b",
-		}
+		popup = overlayPopup(" Stormlight · Edit task ", "82%")
 	}
 	presentation, err := current.Present(surface.Request{
 		Command: surface.Command{
@@ -189,12 +200,7 @@ func yaziPickerCmd(
 
 	var popup *surface.Popup
 	if current.Capabilities().Popups {
-		popup = &surface.Popup{
-			Width:       "78%",
-			Height:      "76%",
-			Title:       " Stormlight · Choose directory ",
-			BorderStyle: "fg=#e5c07b",
-		}
+		popup = overlayPopup(" Stormlight · Choose directory ", "78%")
 	}
 	presentation, err := current.Present(surface.Request{
 		Command: surface.Command{


### PR DESCRIPTION
Modals and popups now draw rounded corners instead of square ones.

The dashboard draws its own structure with square rules and seams, so an overlay built from the same corners reads as another region of the layout rather than something floating above it. The hierarchy connector already arcs (`╭╮╰╯` in `paintHierarchyConnector`); the overlays now agree with it.

- `renderModal` covers the six lipgloss modals at once — new agent, add workspace, workspace info, help, rename, marks.
- The task composer nested inside the dispatch modal curves too; a square box inside a rounded one reads as a rendering slip rather than a distinction.
- tmux popups are drawn by tmux, not lipgloss, so they need their own say: `surface.Popup` gains `BorderLines`, and the tmux surface passes it as `display-popup -b`. Both call sites went through a single `overlayPopup` helper rather than repeating the frame — the duplication is what let the amber and the curve drift apart to begin with.

`-b` needs tmux 3.2+; the repo floor is 3.3 and popups are already gated to 3.7, so nothing new is required.

## Verification

Built and driven headlessly under an isolated socket and XDG state. Add-workspace and new-agent modals render curved, composer included:

```
│     ╭────────────────────────────────────────────────────────────╮
│     │  New agent                                                 │
│     │  Task                                             0 chars  │
│     │  ╭──────────────────────────────────────────────────────╮  │
│     │  │What should the agent do?                             │  │
│     │  ╰──────────────────────────────────────────────────────╯  │
│     ╰────────────────────────────────────────────────────────────╯
```

The Yazi popup was confirmed against a live tmux 3.7b with an attached client — its top-left corner arrives on the wire as `E2 95 AD` (`╭`), so tmux accepted `-b rounded`.

## Note

`go test ./...` has three failures in `internal/ui` (`TestDispatchTabEscapesThePathPicker`, `TestDispatchHintsNameTheNextField`, `TestDispatchPathNavPicksIntoTheNextField`). They are identical on `origin/main` at 59af0cc and unrelated to this change — flagging rather than fixing here.