### PR TITLE
Keep the new-agent form inside its modal

### DIFF
--- a/internal/ui/dispatch.go
+++ b/internal/ui/dispatch.go
@@ -289,6 +289,13 @@ const (
 // spaced reports whether sections are separated by blank lines.
 func (d dispatchDensity) spaced() bool { return d == densityRoomy }
 
+// separated reports whether the form keeps the two blanks that set the
+// header and the directory section apart. They used to be unconditional, so
+// the tightest form still spent two rows on whitespace it had already
+// decided it could not afford — which is most of what pushed the form out of
+// a twenty-row terminal.
+func (d dispatchDensity) separated() bool { return d != densityTight }
+
 // showsName reports whether the optional name row is drawn — and therefore
 // whether it can hold focus at all.
 func (d dispatchDensity) showsName() bool { return d <= densitySnug }
@@ -370,17 +377,41 @@ func (m Model) dispatchContentDimensions() (int, int) {
 func (m Model) renderDispatchAt(width, height int) string {
 	contentWidth := max(1, width-4)
 	layout := m.dispatchLayout(width, height)
-	lines := append(
-		layout.head,
+
+	tail := []string{
 		indentLines(m.renderTaskComposer(contentWidth, layout.taskHeight), "  "),
-	)
-	if layout.density.spaced() {
-		lines = append(lines, "")
 	}
-	lines = append(lines,
+	if layout.density.spaced() {
+		tail = append(tail, "")
+	}
+	tail = append(tail,
 		"  "+mutedStyle().Render(truncate(m.commandHints(), contentWidth)),
 	)
-	return strings.Join(lines, "\n")
+
+	return strings.Join(
+		append(trimHeadToFit(layout.head, renderedRows(tail), height), tail...),
+		"\n",
+	)
+}
+
+// trimHeadToFit drops leading rows until the form fits the box it is drawn
+// in. Below about eighteen rows the terminal cannot hold even the tightest
+// form, and something has to go; what must not go is the composer and the
+// hint line, because between them they are the field the form exists to fill
+// and the only thing on screen that says how to leave.
+//
+// So the head yields, from the top. Those rows are the ones the reader can
+// most afford to lose: the title says what they already know they opened,
+// and the provider list restates a choice the summary line carries anyway.
+// Clipping from the bottom instead — which is what happens when nothing
+// trims and the modal simply cuts — takes the composer's own border and the
+// hints with it, leaving a form that looks broken and strands the reader in
+// it.
+func trimHeadToFit(head []string, tailRows, height int) []string {
+	for len(head) > 0 && renderedRows(head)+tailRows > height {
+		head = head[1:]
+	}
+	return head
 }
 
 // dispatchHeadLines renders every row above the task composer. It stops
@@ -412,13 +443,17 @@ func (m Model) dispatchHeadLines(width, height int, density dispatchDensity) []s
 	gap := max(1, width-lipgloss.Width(headerLeft)-lipgloss.Width(headerRight)-1)
 	lines := []string{
 		headerLeft + strings.Repeat(" ", gap) + headerRight,
-		"",
-		"  " + providerStyle.Render("Coding agent"),
 	}
+	if density.separated() {
+		lines = append(lines, "")
+	}
+	lines = append(lines, "  "+providerStyle.Render("Coding agent"))
 	lines = append(lines, m.renderProviderRows(contentWidth)...)
 	if m.chooseDispatchDirectory {
+		if density.separated() {
+			lines = append(lines, "")
+		}
 		lines = append(lines,
-			"",
 			"  "+m.renderDispatchSectionTitle(
 				directoryStyle,
 				"Working directory",

--- a/internal/ui/input_test.go
+++ b/internal/ui/input_test.go
@@ -336,10 +336,17 @@ func TestDispatchViewFitsCompactPaneWithUnavailableProviders(t *testing.T) {
 		!strings.Contains(view, "not found") {
 		t.Fatalf("provider availability is unclear:\n%s", view)
 	}
-	if !strings.Contains(view, "Coding agent") ||
-		!strings.Contains(view, "Task") ||
+	// A box this short cannot hold the whole form, so the section label above
+	// the provider rows is one of the rows that yields. What may not yield is
+	// the composer and the hint line: the rows the reader types into and
+	// reads to get out. This used to fit only because the form overran the
+	// modal and the hints were the part quietly cut off.
+	if !strings.Contains(view, "Task") ||
 		strings.Contains(view, "Working directory") {
 		t.Fatalf("contextual new-agent form is incorrect:\n%s", view)
+	}
+	if strings.Count(view, "╭") != strings.Count(view, "╰") {
+		t.Fatalf("the form was cut off inside the composer:\n%s", view)
 	}
 	assertViewFitsPane(t, model, 39, 15)
 }
@@ -600,6 +607,50 @@ func TestDispatchFormFitsItsModal(t *testing.T) {
 					size[0], size[1], picker, composer, modal)
 			}
 			assertViewFitsPane(t, model, size[0]-1, size[1]-1)
+		}
+	}
+}
+
+// The form must fit the modal it is drawn in, at every height a terminal
+// can be, and it must never buy that fit by cutting off the composer or the
+// hint line. A twenty-row terminal used to render fourteen rows into a
+// twelve-row box: the modal cut the overflow from the bottom, so the task
+// box lost its lower border and the hints vanished entirely, leaving no
+// on-screen way to tell how to submit or escape. See #79.
+func TestDispatchFormFitsEveryHeight(t *testing.T) {
+	for _, picker := range []bool{false, true} {
+		for width := 60; width <= 160; width += 20 {
+			for height := 12; height <= 50; height++ {
+				model := dispatchTaskFixture(t, width, height)
+				model.chooseDispatchDirectory = picker
+				if picker {
+					model.prepareDirectoryChoices(model.initialCwd)
+					model.directoryIndex = 0
+				}
+				model.syncTaskComposerSize()
+
+				boxWidth, boxHeight := model.dispatchContentDimensions()
+				form := ansi.Strip(model.renderDispatchAt(boxWidth, boxHeight))
+				rows := strings.Split(form, "\n")
+				if len(rows) > boxHeight {
+					t.Fatalf("%dx%d picker=%v: form is %d rows in a %d-row box:\n%s",
+						width, height, picker, len(rows), boxHeight, form)
+				}
+				// The composer is drawn as a bordered box, so an intact one
+				// opens and closes; a clipped form loses the closing edge.
+				if strings.Count(form, "\u256d") != strings.Count(form, "\u2570") {
+					t.Fatalf("%dx%d picker=%v: the composer border is cut:\n%s",
+						width, height, picker, form)
+				}
+				// The hint row is the last thing drawn, and a narrow box
+				// truncates its text — so what is checked is that a row
+				// follows the composer at all, not what it says.
+				last := rows[len(rows)-1]
+				if strings.TrimSpace(last) == "" || strings.Contains(last, "\u2570") {
+					t.Fatalf("%dx%d picker=%v: nothing follows the composer:\n%s",
+						width, height, picker, form)
+				}
+			}
 		}
 	}
 }


### PR DESCRIPTION
Fixes #79.

## The bug

At 120x20 the form rendered 14 rows into a 12-row box. The modal cut the overflow from the bottom, so the task box lost its closing border and the hint line disappeared — a form that looks broken, with nothing on screen saying how to submit or escape.

## Two causes

**The tightest form still paid for whitespace.** `dispatchDensity.spaced()` governed three of the form's five blank lines; the two separating the header and the directory section were unconditional. So `densityTight` — the rung that exists precisely because there is no room — still spent two rows on blanks. That is most of the twenty-row shortfall. Those two now follow the density like the rest, which takes the tight head from 10 rows to 8 and makes 120x20 fit exactly.

**Nothing checked.** `dispatchTaskHeight` clamps the composer to a one-row floor, so once the arithmetic goes negative the form is simply taller than its box and nothing notices.

## Below eighteen rows, fitting is not possible

The minimum form is ten rows — header, provider label, two providers, mode, task label, three for the composer, one for hints — against a box of six to nine. Something must go, so `trimHeadToFit` decides what: the head yields from the top. A title restates what the reader just opened and the provider rows restate the summary line; the composer and the hint are the field the form exists to fill and the only thing on screen that says how to get out. Clipping from the bottom took exactly those two.

## The test

`TestDispatchFormFitsEveryHeight` walks every height from 12 to 50 at five widths, with and without the directory picker — 400 configurations — asserting three things: the form fits its box, the composer's border opens and closes, and a row still follows the composer. Confirmed to **fail on `main`** (`60x12: form is 11 rows in a 6-row box`).

## One assertion changed

`TestDispatchViewFitsCompactPaneWithUnavailableProviders` no longer requires the "Coding agent" label at 40x16. That box holds eight rows, and the providers, mode, task label, composer and hints already fill them — the label only appeared before because the form overran its modal and the hints were the part quietly cut. It now asserts the composer's border survives, which is the property that was actually at stake. Flagging it because relaxing an assertion deserves a second opinion.

## Verification

- Full suite, vet, build green.
- Live at 120x20, 120x24 and 120x16: composer border balanced, hint row present at all three.

A note on method, since it nearly cost me this fix: driving the binary through `-e PATH="$PWD:$PATH"` is not reliable — the pane shell's startup files reset `PATH`, so `stormlight` resolves to the installed binary instead of the branch build. It looked exactly like the fix not working. Invoke the build by absolute path.