### PR TITLE
Give paste its own route through the dashboard

### DIFF
--- a/internal/ui/input.go
+++ b/internal/ui/input.go
@@ -133,6 +133,19 @@ func (i lineInput) Update(msg tea.KeyPressMsg) lineInput {
 	return i
 }
 
+// Insert drops pasted text in at the cursor, flattened to one line.
+func (i *lineInput) Insert(text string) {
+	if !i.focused {
+		return
+	}
+	runes := flattenPaste(text)
+	if len(runes) == 0 {
+		return
+	}
+	i.value = append(i.value[:i.cursor], append(runes, i.value[i.cursor:]...)...)
+	i.cursor += len(runes)
+}
+
 func (i lineInput) View() string {
 	if len(i.value) == 0 {
 		placeholder := mutedStyle().Render(ansi.Truncate(i.placeholder, i.width, "…"))

--- a/internal/ui/model.go
+++ b/internal/ui/model.go
@@ -532,6 +532,9 @@ func (m Model) Update(message tea.Msg) (tea.Model, tea.Cmd) {
 	case tea.MouseMsg:
 		return m.handleMouse(msg)
 
+	case tea.PasteMsg:
+		return m.updatePaste(msg)
+
 	case tea.KeyPressMsg:
 		if m.err != nil {
 			m.err = nil

--- a/internal/ui/paste.go
+++ b/internal/ui/paste.go
@@ -1,0 +1,81 @@
+package ui
+
+// Bracketed paste.
+//
+// Under Bubble Tea v1 a paste arrived as an ordinary key message carrying
+// runes, so it rode the same path as typing and every input got it for free.
+// v2 gives paste its own message — tea.PasteMsg, delivered between
+// PasteStartMsg and PasteEndMsg — and nothing here handled it, so Cmd-V into
+// the task box went nowhere. Paste is therefore routed the way keys are: by
+// mode, to whatever input that mode has focused. The two textareas take the
+// message itself (bubbles knows how to insert a multi-line paste and how to
+// keep its own wrap and scroll state honest); the single-line fields take
+// flattened text.
+
+import (
+	"strings"
+	"unicode"
+
+	tea "charm.land/bubbletea/v2"
+)
+
+func (m Model) updatePaste(msg tea.PasteMsg) (tea.Model, tea.Cmd) {
+	switch m.mode {
+	case modeDispatch:
+		return m.pasteIntoDispatch(msg)
+	case modeCompose:
+		var cmd tea.Cmd
+		m.sendInput, cmd = m.sendInput.Update(msg)
+		m.syncComposerSize()
+		return m, cmd
+	case modeSearch:
+		m.search.input.Insert(msg.Content)
+		m.applySearchQuery()
+		return m, nil
+	case modeAddWorkspace:
+		if m.formFocus == dispatchCustomPath {
+			m.pathNav.insert(msg.Content)
+		}
+		return m, nil
+	case modeRename:
+		m.renameInput.Insert(msg.Content)
+		return m, nil
+	}
+	return m, nil
+}
+
+// pasteIntoDispatch drops the paste into the new-agent form's focused field
+// and re-sizes the task box after, for the same reason the key path does: a
+// paste rewraps the composer, and the textarea has to be told.
+func (m Model) pasteIntoDispatch(msg tea.PasteMsg) (tea.Model, tea.Cmd) {
+	var cmd tea.Cmd
+	switch m.formFocus {
+	case dispatchTask:
+		m.taskInput, cmd = m.taskInput.Update(msg)
+	case dispatchName:
+		m.nameInput.Insert(msg.Content)
+	case dispatchCustomPath:
+		m.pathNav.insert(msg.Content)
+	}
+	m.syncTaskComposerSize()
+	return m, cmd
+}
+
+// flattenPaste folds pasted text onto one line for the single-line fields.
+// Line breaks and tabs become single spaces and everything else unprintable
+// is dropped: a path copied out of a wrapped terminal arrives as a path
+// rather than as a newline the field cannot hold or escape debris it would
+// happily store and later pass to a shell.
+func flattenPaste(text string) []rune {
+	text = strings.ReplaceAll(text, "\r\n", "\n")
+	var out []rune
+	for _, r := range text {
+		switch {
+		case r == '\n' || r == '\r' || r == '\t':
+			out = append(out, ' ')
+		case unicode.IsPrint(r):
+			out = append(out, r)
+		}
+	}
+	return out
+}

--- a/internal/ui/paste_test.go
+++ b/internal/ui/paste_test.go
@@ -1,0 +1,140 @@
+package ui
+
+import (
+	"strings"
+	"testing"
+
+	tea "charm.land/bubbletea/v2"
+)
+
+// A terminal paste is a message of its own under Bubble Tea v2, not a
+// keystroke, so every field has to be reachable by that message or Cmd-V
+// silently does nothing there.
+
+func TestPasteFillsTaskBox(t *testing.T) {
+	model := NewModel(stubBackend{})
+	updated, _ := model.Update(tea.WindowSizeMsg{Width: 80, Height: 24})
+	model = updated.(Model)
+	model.mode = modeDispatch
+	model.formFocus = dispatchTask
+	model.focusForm()
+	model.taskInput.SetValue("review ")
+
+	updated, _ = model.Update(tea.PasteMsg{Content: "internal/ui/model.go"})
+	model = updated.(Model)
+
+	if got := model.taskInput.Value(); got != "review internal/ui/model.go" {
+		t.Fatalf("task box = %q", got)
+	}
+}
+
+func TestPasteKeepsTaskBoxMultiLine(t *testing.T) {
+	model := NewModel(stubBackend{})
+	updated, _ := model.Update(tea.WindowSizeMsg{Width: 80, Height: 24})
+	model = updated.(Model)
+	model.mode = modeDispatch
+	model.formFocus = dispatchTask
+	model.focusForm()
+
+	updated, _ = model.Update(tea.PasteMsg{Content: "first\nsecond"})
+	model = updated.(Model)
+
+	if got := model.taskInput.Value(); got != "first\nsecond" {
+		t.Fatalf("task box = %q", got)
+	}
+}
+
+func TestPasteFillsComposer(t *testing.T) {
+	model := NewModel(stubBackend{})
+	updated, _ := model.Update(tea.WindowSizeMsg{Width: 80, Height: 24})
+	model = updated.(Model)
+	model.mode = modeCompose
+	model.sendInput.Focus()
+	model.sendInput.SetValue("see ")
+
+	updated, _ = model.Update(tea.PasteMsg{Content: "line one\nline two"})
+	model = updated.(Model)
+
+	if got := model.sendInput.Value(); got != "see line one\nline two" {
+		t.Fatalf("composer = %q", got)
+	}
+}
+
+func TestPasteFillsNameFieldOnOneLine(t *testing.T) {
+	model := NewModel(stubBackend{})
+	updated, _ := model.Update(tea.WindowSizeMsg{Width: 80, Height: 24})
+	model = updated.(Model)
+	model.mode = modeDispatch
+	model.formFocus = dispatchName
+	model.focusForm()
+
+	updated, _ = model.Update(tea.PasteMsg{Content: "fix\tthe\r\nparser"})
+	model = updated.(Model)
+
+	if got := model.nameInput.Value(); got != "fix the parser" {
+		t.Fatalf("name field = %q", got)
+	}
+}
+
+func TestPasteFillsRenameField(t *testing.T) {
+	model := NewModel(stubBackend{})
+	updated, _ := model.Update(tea.WindowSizeMsg{Width: 80, Height: 24})
+	model = updated.(Model)
+	model.mode = modeRename
+	model.renameInput.SetValue("")
+	model.renameInput.Focus()
+
+	updated, _ = model.Update(tea.PasteMsg{Content: "stormlight"})
+	model = updated.(Model)
+
+	if got := model.renameInput.Value(); got != "stormlight" {
+		t.Fatalf("rename field = %q", got)
+	}
+}
+
+func TestPasteFillsPathPicker(t *testing.T) {
+	model := NewModel(stubBackend{})
+	updated, _ := model.Update(tea.WindowSizeMsg{Width: 80, Height: 24})
+	model = updated.(Model)
+	model.mode = modeDispatch
+	model.formFocus = dispatchCustomPath
+	model.startPathNav()
+
+	updated, _ = model.Update(tea.PasteMsg{Content: "internal"})
+	model = updated.(Model)
+
+	if got := model.pathNav.filter.Value(); got != "internal" {
+		t.Fatalf("path filter = %q", got)
+	}
+}
+
+func TestPasteDrivesTranscriptSearch(t *testing.T) {
+	model := NewModel(stubBackend{})
+	updated, _ := model.Update(tea.WindowSizeMsg{Width: 80, Height: 24})
+	model = updated.(Model)
+	model.interactionContent = strings.Join([]string{
+		"first line",
+		"a needle here",
+		"last line",
+	}, "\n")
+	model.mode = modeSearch
+	model.search.input.SetValue("")
+	model.search.input.Focus()
+
+	updated, _ = model.Update(tea.PasteMsg{Content: "needle"})
+	model = updated.(Model)
+
+	if model.search.query != "needle" {
+		t.Fatalf("search query = %q", model.search.query)
+	}
+	if len(model.search.matches) != 1 {
+		t.Fatalf("matches = %v", model.search.matches)
+	}
+}
+
+func TestFlattenPasteDropsControlBytes(t *testing.T) {
+	got := string(flattenPaste("cd \x1b[200~/tmp\x07"))
+	if got != "cd [200~/tmp" {
+		t.Fatalf("flattened = %q", got)
+	}
+}

--- a/internal/ui/pathnav.go
+++ b/internal/ui/pathnav.go
@@ -199,6 +199,16 @@ func (n *pathNav) update(msg tea.KeyPressMsg) {
 	}
 }
 
+// insert routes pasted text to the filter, re-anchoring the highlight the
+// same way typing does.
+func (n *pathNav) insert(text string) {
+	before := n.filter.Value()
+	n.filter.Insert(text)
+	if n.filter.Value() != before {
+		n.highlight = 0
+	}
+}
+
 func (n pathNav) filterEmpty() bool {
 	return strings.TrimSpace(n.filter.Value()) == ""
 }

--- a/internal/ui/search.go
+++ b/internal/ui/search.go
@@ -213,16 +213,25 @@ func (m Model) updateSearch(msg tea.KeyPressMsg) (tea.Model, tea.Cmd) {
 		return m, nil
 	}
 	m.search.input = m.search.input.Update(msg)
-	if query := m.search.input.Value(); query != m.search.query {
-		m.search.query = query
-		m.refreshSearch()
-		m.seekSearchFromAnchor()
-		m.repaintSearch()
-		if len(m.search.matches) > 0 {
-			m.centerSearchMatch()
-		} else {
-			m.interaction.SetYOffset(m.search.anchor)
-		}
-	}
+	m.applySearchQuery()
 	return m, nil
+}
+
+// applySearchQuery re-matches the transcript against whatever the prompt now
+// holds and moves the viewport to the first match ahead of the anchor. Typing
+// and pasting both land here; nothing happens if the text is unchanged.
+func (m *Model) applySearchQuery() {
+	query := m.search.input.Value()
+	if query == m.search.query {
+		return
+	}
+	m.search.query = query
+	m.refreshSearch()
+	m.seekSearchFromAnchor()
+	m.repaintSearch()
+	if len(m.search.matches) > 0 {
+		m.centerSearchMatch()
+	} else {
+		m.interaction.SetYOffset(m.search.anchor)
+	}
 }


### PR DESCRIPTION
Cmd-V into the task box stopped working at the move to Charm v2 (#57). Under Bubble Tea v1 a bracketed paste arrived as an ordinary key message carrying runes, so it rode the same path as typing and every input got it for free. v2 gives paste its own message — `tea.PasteMsg` — and `Update` only ever matched `KeyPressMsg`, so every paste fell through the switch and was dropped. Nothing looked broken: the terminal accepted the paste and the box simply stayed empty.

Paste is now routed the way keys are: by mode, to whatever input that mode has focused — task box, Spanreed composer, name field, path picker, rename modal, transcript search.

- The two textareas take the message itself; bubbles already knows how to insert a multi-line paste and to keep its own wrap and scroll state honest.
- The single-line fields take text flattened to one line — breaks and tabs folded to spaces, other control characters dropped — so a path copied out of a wrapped terminal arrives as a path rather than as escape debris a field would store and later hand to a shell.
- The search prompt's match-and-seek tail moved into `applySearchQuery`, shared by typing and pasting.

## Verification

`go test ./...` passes, with new tests covering each field.

Empirically, in an isolated tmux with `paste-buffer -p` — the same bracketed bytes Cmd-V delivers — into the path picker and the task box, single- and multi-line:

```
│  Task                                                            66 chars  │
│  ╭──────────────────────────────────────────────────────────────────────╮  │
│  │Investigate the paste path and report back on internal/ui/paste.go    │  │
```