### PR TITLE
Report Codex turn starts through its lifecycle hooks

### DIFF
--- a/README.md
+++ b/README.md
@@ -328,12 +328,26 @@ Stormlight-specific code. See [workspace resolvers](docs/workspace-resolvers.md)
 
 Stormlight injects agent-scoped lifecycle integration for managed providers:
 
-- Codex uses its external `agent-turn-complete` notification to become idle and
-  publish the latest response summary.
+- Codex uses `UserPromptSubmit` and `Stop` hooks to report state. Both
+  providers now speak the same hook schema, so a Codex agent prompted in its
+  own terminal turns blue like a Claude one; its older `agent-turn-complete`
+  notifier only fired at the end of a turn, which left a manually prompted
+  agent claiming `idle` for the whole time it was working.
 - Claude uses `UserPromptSubmit`, `Notification`, and `Stop` hooks to report
   state; the permission notification raises attention on the agent whose
   terminal is holding the prompt.
 - Replies sent from the dashboard mark any provider working immediately.
+
+Stormlight registers observers, never resolvers. Neither Claude's `PreToolUse`
+nor Codex's `PermissionRequest` hook is installed: their replies decide whether
+a tool call proceeds, and approvals belong to the agent's own terminal.
+
+Hooks are wired per launch, so nothing is written to `~/.claude` or
+`~/.codex` — an agent Stormlight did not start behaves exactly as it always
+did. The hook command reads `$STORMLIGHT_BIN`, which names Stormlight by its
+launcher on `PATH` rather than the version-stamped path behind it, so hooks
+keep working across an upgrade instead of pointing at a binary the new
+release deleted.
 
 The runtime also exposes an `event` command so other provider hooks can report
 semantic state without screen scraping:

--- a/README.md
+++ b/README.md
@@ -328,11 +328,12 @@ Stormlight-specific code. See [workspace resolvers](docs/workspace-resolvers.md)
 
 Stormlight injects agent-scoped lifecycle integration for managed providers:
 
-- Codex uses `UserPromptSubmit` and `Stop` hooks to report state. Both
-  providers now speak the same hook schema, so a Codex agent prompted in its
-  own terminal turns blue like a Claude one; its older `agent-turn-complete`
-  notifier only fired at the end of a turn, which left a manually prompted
-  agent claiming `idle` for the whole time it was working.
+- Codex uses `UserPromptSubmit` and `Stop` hooks to report state, with its
+  `agent-turn-complete` notifier kept underneath them. Both providers speak
+  the same hook schema, so a Codex agent prompted in its own terminal turns
+  blue like a Claude one; the notifier alone only fired at the end of a
+  turn, which left a manually prompted agent claiming `idle` for the whole
+  time it was working.
 - Claude uses `UserPromptSubmit`, `Notification`, and `Stop` hooks to report
   state; the permission notification raises attention on the agent whose
   terminal is holding the prompt.
@@ -348,6 +349,30 @@ did. The hook command reads `$STORMLIGHT_BIN`, which names Stormlight by its
 launcher on `PATH` rather than the version-stamped path behind it, so hooks
 keep working across an upgrade instead of pointing at a binary the new
 release deleted.
+
+### Trusting Codex hooks, once
+
+Codex will not run an injected hook until a human has approved it. The first
+Codex agent you dispatch opens a **Hooks need review** prompt in its own
+terminal listing two hooks; answer **Trust all and continue** and Codex
+records the approval in `~/.codex/config.toml`. Until then the hooks are
+installed but inert.
+
+The approval is a hash of the hook commands, and Stormlight's are identical
+for every agent — they name Stormlight through `$STORMLIGHT_BIN` rather than
+a path — so trusting once covers every future agent on that machine, across
+upgrades. It only asks again if these hooks change.
+
+An agent whose hooks are untrusted still reports the end of each turn,
+because `agent-turn-complete` carries no such gate. That is why it is kept:
+it is the floor that stops an untrusted agent from sitting at `working`
+until its process exits. What you lose until you trust the hooks is the
+turn-*start* signal — exactly the old behavior.
+
+Stormlight will not pass Codex's `--dangerously-bypass-hook-trust`. That flag
+lifts review from every enabled hook, including any a project's own
+`.codex/config.toml` installs, which is a much wider grant than Stormlight
+needs for its own two.
 
 The runtime also exposes an `event` command so other provider hooks can report
 semantic state without screen scraping:

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -13,8 +13,14 @@ Adapters deliberately do not own tmux behavior.
 The CLI adapters currently add provider-native lifecycle callbacks:
 
 - Codex: per-launch prompt and stop hooks report state, passed as a `-c`
-  config override. The external completion notifier they replaced carried
-  only turn ends, so a turn begun in the agent's own pane was invisible.
+  config override, over the external completion notifier. The notifier alone
+  carried only turn ends, so a turn begun in the agent's own pane was
+  invisible; it is retained because Codex holds injected hooks inert behind
+  a one-time trust review, and an agent reporting nothing would sit at
+  `working` until its process exited. The notifier has no trust gate, so it
+  is the floor and the hooks are the ceiling. Both surfaces report a turn
+  end once trusted; the two events carry identical state, so applying both
+  is idempotent.
 - Claude: per-launch prompt, notification, and stop hooks report state.
   Permission prompts raise attention through the notification hook; they
   are answered in the agent's own terminal, never intercepted.

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -12,12 +12,25 @@ Adapters deliberately do not own tmux behavior.
 
 The CLI adapters currently add provider-native lifecycle callbacks:
 
-- Codex: the documented external completion notifier reports idle state and
-  the latest response.
+- Codex: per-launch prompt and stop hooks report state, passed as a `-c`
+  config override. The external completion notifier they replaced carried
+  only turn ends, so a turn begun in the agent's own pane was invisible.
 - Claude: per-launch prompt, notification, and stop hooks report state.
   Permission prompts raise attention through the notification hook; they
   are answered in the agent's own terminal, never intercepted.
 - Generic agents: PTY state and optional lifecycle hooks.
+
+Both CLIs accept the same hook schema — an event name mapping to matcher
+groups of command handlers, with the payload arriving on the handler's
+stdin — so one set of types describes both and only the encoding differs:
+Claude takes JSON through `--settings`, Codex takes inline TOML through
+`-c`. Codex parses that value as TOML and rejects JSON, so the override has
+to encode to a single inline line.
+
+Hooks that resolve rather than observe are deliberately left unregistered
+for both providers. Claude's `PreToolUse` and Codex's `PermissionRequest`
+answer whether a tool call may proceed, and an approval Stormlight never
+answers is an agent stuck waiting on it.
 
 The next Codex revision should use App Server JSON-RPC for threads, turns,
 approvals, and streamed items. Claude background-agent discovery or the Agent

--- a/internal/provider/event.go
+++ b/internal/provider/event.go
@@ -25,11 +25,46 @@ type Event struct {
 
 func ParseEvent(providerID agent.Provider, payload []byte) (Event, bool, error) {
 	switch providerID {
-	case agent.ProviderCodex, agent.ProviderClaude:
+	case agent.ProviderCodex:
+		return parseCodexEvent(payload)
+	case agent.ProviderClaude:
 		return parseHookEvent(providerID, payload)
 	default:
 		return Event{}, false, fmt.Errorf("unsupported provider event %q", providerID)
 	}
+}
+
+// parseCodexEvent accepts either of the two lifecycle surfaces a Codex
+// agent is launched with. Its hooks report turn starts and turn ends but
+// only once a human has trusted them; `notify` reports turn ends
+// unconditionally and is what keeps an agent with untrusted hooks from
+// sitting at `working` forever. A notify payload carries no
+// hook_event_name, so the hook parser passes on it and it falls through.
+func parseCodexEvent(payload []byte) (Event, bool, error) {
+	event, handled, err := parseHookEvent(agent.ProviderCodex, payload)
+	if err != nil || handled {
+		return event, handled, err
+	}
+	return parseCodexNotification(payload)
+}
+
+func parseCodexNotification(payload []byte) (Event, bool, error) {
+	var notification struct {
+		Type                 string `json:"type"`
+		LastAssistantMessage string `json:"last-assistant-message"`
+	}
+	if err := json.Unmarshal(payload, &notification); err != nil {
+		return Event{}, false, fmt.Errorf("decode Codex notification: %w", err)
+	}
+	if notification.Type != "agent-turn-complete" {
+		return Event{}, false, nil
+	}
+	return Event{
+		Activity:  agent.ActivityIdle,
+		Attention: turnEndAttention(notification.LastAssistantMessage),
+		Summary:   eventSummary(notification.LastAssistantMessage),
+		TurnEnded: true,
+	}, true, nil
 }
 
 // hookPayload is the JSON a provider writes to a hook's stdin. Claude and

--- a/internal/provider/event.go
+++ b/internal/provider/event.go
@@ -25,73 +25,36 @@ type Event struct {
 
 func ParseEvent(providerID agent.Provider, payload []byte) (Event, bool, error) {
 	switch providerID {
-	case agent.ProviderCodex:
-		return parseCodexEvent(payload)
-	case agent.ProviderClaude:
-		return parseClaudeEvent(payload)
+	case agent.ProviderCodex, agent.ProviderClaude:
+		return parseHookEvent(providerID, payload)
 	default:
 		return Event{}, false, fmt.Errorf("unsupported provider event %q", providerID)
 	}
 }
 
-func parseCodexEvent(payload []byte) (Event, bool, error) {
-	var notification struct {
-		Type                 string `json:"type"`
-		LastAssistantMessage string `json:"last-assistant-message"`
-	}
-	if err := json.Unmarshal(payload, &notification); err != nil {
-		return Event{}, false, fmt.Errorf("decode Codex notification: %w", err)
-	}
-	if notification.Type != "agent-turn-complete" {
-		return Event{}, false, nil
-	}
-	return Event{
-		Activity:  agent.ActivityIdle,
-		Attention: turnEndAttention(notification.LastAssistantMessage),
-		Summary:   eventSummary(notification.LastAssistantMessage),
-		TurnEnded: true,
-	}, true, nil
+// hookPayload is the JSON a provider writes to a hook's stdin. Claude and
+// Codex agree on the shape down to the field names, so one struct decodes
+// both and the events they share need no per-provider branch. Only Claude
+// sends Notification, and its fields are simply absent from a Codex
+// payload. Codex leaves last_assistant_message and transcript_path
+// nullable, which decodes to the zero value rather than failing.
+type hookPayload struct {
+	Name string `json:"hook_event_name"`
+	// UserPromptSubmit.
+	Prompt string `json:"prompt"`
+	// Claude's Notification.
+	Message          string `json:"message"`
+	NotificationType string `json:"notification_type"`
+	// Stop.
+	LastAssistantMessage string `json:"last_assistant_message"`
+
+	TranscriptPath string `json:"transcript_path"`
 }
 
-// turnEndAttention classifies why a turn ended from its final message: a
-// message that reads as a question needs an answer (urgent); any other
-// finished turn is an unseen result (soft waiting) until the human views
-// it, replies, or marks it seen. Providers have no "asked a question"
-// event — completion and question arrive as the same signal — so the
-// content is the only instant discriminator.
-func turnEndAttention(message string) agent.Attention {
-	if asksQuestion(message) {
-		return agent.AttentionQuestion
-	}
-	return agent.AttentionWaiting
-}
-
-// asksQuestion reports whether the final non-empty line of a message ends
-// with a question mark, tolerating markdown emphasis and quote trailers.
-func asksQuestion(message string) bool {
-	lines := strings.Split(message, "\n")
-	for index := len(lines) - 1; index >= 0; index-- {
-		line := strings.TrimSpace(lines[index])
-		if line == "" {
-			continue
-		}
-		line = strings.TrimRight(line, " \t*_`\"')")
-		return strings.HasSuffix(line, "?")
-	}
-	return false
-}
-
-func parseClaudeEvent(payload []byte) (Event, bool, error) {
-	var hook struct {
-		Name                 string `json:"hook_event_name"`
-		Prompt               string `json:"prompt"`
-		Message              string `json:"message"`
-		NotificationType     string `json:"notification_type"`
-		LastAssistantMessage string `json:"last_assistant_message"`
-		TranscriptPath       string `json:"transcript_path"`
-	}
+func parseHookEvent(providerID agent.Provider, payload []byte) (Event, bool, error) {
+	var hook hookPayload
 	if err := json.Unmarshal(payload, &hook); err != nil {
-		return Event{}, false, fmt.Errorf("decode Claude hook event: %w", err)
+		return Event{}, false, fmt.Errorf("decode %s hook event: %w", providerID, err)
 	}
 
 	switch hook.Name {
@@ -129,6 +92,34 @@ func parseClaudeEvent(payload []byte) (Event, bool, error) {
 	default:
 		return Event{}, false, nil
 	}
+}
+
+// turnEndAttention classifies why a turn ended from its final message: a
+// message that reads as a question needs an answer (urgent); any other
+// finished turn is an unseen result (soft waiting) until the human views
+// it, replies, or marks it seen. Providers have no "asked a question"
+// event — completion and question arrive as the same signal — so the
+// content is the only instant discriminator.
+func turnEndAttention(message string) agent.Attention {
+	if asksQuestion(message) {
+		return agent.AttentionQuestion
+	}
+	return agent.AttentionWaiting
+}
+
+// asksQuestion reports whether the final non-empty line of a message ends
+// with a question mark, tolerating markdown emphasis and quote trailers.
+func asksQuestion(message string) bool {
+	lines := strings.Split(message, "\n")
+	for index := len(lines) - 1; index >= 0; index-- {
+		line := strings.TrimSpace(lines[index])
+		if line == "" {
+			continue
+		}
+		line = strings.TrimRight(line, " \t*_`\"')")
+		return strings.HasSuffix(line, "?")
+	}
+	return false
 }
 
 func eventSummary(value string) string {

--- a/internal/provider/event_test.go
+++ b/internal/provider/event_test.go
@@ -73,60 +73,41 @@ func TestParseCodexTolerantOfNullFields(t *testing.T) {
 	}
 }
 
-// Nothing registers `notify` any more, so its payload is not a lifecycle
-// signal — treating it as one would report a turn end twice.
-func TestParseCodexIgnoresLegacyNotify(t *testing.T) {
-	_, handled, err := ParseEvent(agent.ProviderCodex, []byte(
+// Codex holds injected hooks at "installed, not active" until a human
+// trusts them. `notify` carries no such gate, so it remains the floor
+// beneath the hooks: an agent whose hooks are untrusted still reports the
+// end of a turn instead of sitting at `working` until its process exits.
+func TestParseCodexNotifyReportsTurnEndWithoutHooks(t *testing.T) {
+	event, handled, err := ParseEvent(agent.ProviderCodex, []byte(
 		`{"type":"agent-turn-complete","last-assistant-message":"Tests pass."}`,
 	))
-	if err != nil || handled {
-		t.Fatalf("handled=%v err=%v, want ignored", handled, err)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !handled || event.Activity != agent.ActivityIdle ||
+		event.Summary != "Tests pass." || !event.TurnEnded {
+		t.Fatalf("event = %#v, handled = %v", event, handled)
 	}
 }
 
-func TestParseClaudeLifecycle(t *testing.T) {
-	tests := []struct {
-		name      string
-		payload   string
-		activity  agent.Activity
-		attention agent.Attention
-		summary   string
-	}{
-		{
-			name:     "prompt",
-			payload:  `{"hook_event_name":"UserPromptSubmit","prompt":"Run the tests"}`,
-			activity: agent.ActivityWorking,
-			summary:  "Run the tests",
-		},
-		{
-			name:      "approval",
-			payload:   `{"hook_event_name":"Notification","message":"Permission required"}`,
-			activity:  agent.ActivityIdle,
-			attention: agent.AttentionApproval,
-			summary:   "Permission required",
-		},
-		{
-			name:      "stop",
-			payload:   `{"hook_event_name":"Stop","last_assistant_message":"Implementation complete"}`,
-			activity:  agent.ActivityIdle,
-			attention: agent.AttentionWaiting,
-			summary:   "Implementation complete",
-		},
+// With hooks trusted a turn end arrives on both surfaces. The two must
+// agree, because the dashboard applies whichever lands second.
+func TestCodexTurnEndIsIdenticalOnBothSurfaces(t *testing.T) {
+	const message = "Implementation complete"
+	viaNotify, _, err := ParseEvent(agent.ProviderCodex, []byte(
+		`{"type":"agent-turn-complete","last-assistant-message":"`+message+`"}`,
+	))
+	if err != nil {
+		t.Fatal(err)
 	}
-
-	for _, test := range tests {
-		t.Run(test.name, func(t *testing.T) {
-			event, handled, err := ParseEvent(agent.ProviderClaude, []byte(test.payload))
-			if err != nil {
-				t.Fatal(err)
-			}
-			if !handled ||
-				event.Activity != test.activity ||
-				event.Attention != test.attention ||
-				event.Summary != test.summary {
-				t.Fatalf("event = %#v, handled = %v", event, handled)
-			}
-		})
+	viaHook, _, err := ParseEvent(agent.ProviderCodex, []byte(
+		`{"hook_event_name":"Stop","last_assistant_message":"`+message+`"}`,
+	))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if viaNotify != viaHook {
+		t.Fatalf("notify = %#v, hook = %#v", viaNotify, viaHook)
 	}
 }
 

--- a/internal/provider/event_test.go
+++ b/internal/provider/event_test.go
@@ -8,15 +8,79 @@ import (
 	"github.com/trentkm/stormlight/internal/agent"
 )
 
-func TestParseCodexCompletion(t *testing.T) {
+// Codex reports through the same hook schema Claude does, including a
+// turn start — the signal its old `notify` callback never carried, and
+// without which an agent prompted in its own pane stayed `idle` (#66).
+func TestParseCodexLifecycle(t *testing.T) {
+	tests := []struct {
+		name      string
+		payload   string
+		activity  agent.Activity
+		attention agent.Attention
+		summary   string
+		turnEnded bool
+	}{
+		{
+			name: "prompt",
+			payload: `{"hook_event_name":"UserPromptSubmit",` +
+				`"prompt":"Run the tests","transcript_path":"/tmp/codex.jsonl"}`,
+			activity: agent.ActivityWorking,
+			summary:  "Run the tests",
+		},
+		{
+			name: "stop",
+			payload: `{"hook_event_name":"Stop",` +
+				`"last_assistant_message":"Tests pass.","stop_hook_active":false}`,
+			activity:  agent.ActivityIdle,
+			attention: agent.AttentionWaiting,
+			summary:   "Tests pass.",
+			turnEnded: true,
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			event, handled, err := ParseEvent(agent.ProviderCodex, []byte(test.payload))
+			if err != nil {
+				t.Fatal(err)
+			}
+			if !handled ||
+				event.Activity != test.activity ||
+				event.Attention != test.attention ||
+				event.Summary != test.summary ||
+				event.TurnEnded != test.turnEnded {
+				t.Fatalf("event = %#v, handled = %v", event, handled)
+			}
+		})
+	}
+}
+
+// Codex leaves transcript_path and last_assistant_message nullable, and a
+// JSON null must decode to an absent value rather than fail the hook.
+func TestParseCodexTolerantOfNullFields(t *testing.T) {
 	event, handled, err := ParseEvent(agent.ProviderCodex, []byte(
-		`{"type":"agent-turn-complete","last-assistant-message":"Tests pass."}`,
+		`{"hook_event_name":"Stop","last_assistant_message":null,`+
+			`"transcript_path":null,"stop_hook_active":false}`,
 	))
 	if err != nil {
 		t.Fatal(err)
 	}
-	if !handled || event.Activity != agent.ActivityIdle || event.Summary != "Tests pass." {
+	if !handled || event.Activity != agent.ActivityIdle || !event.TurnEnded {
 		t.Fatalf("event = %#v, handled = %v", event, handled)
+	}
+	if event.Summary != "" || event.TranscriptPath != "" {
+		t.Fatalf("null fields leaked: %#v", event)
+	}
+}
+
+// Nothing registers `notify` any more, so its payload is not a lifecycle
+// signal — treating it as one would report a turn end twice.
+func TestParseCodexIgnoresLegacyNotify(t *testing.T) {
+	_, handled, err := ParseEvent(agent.ProviderCodex, []byte(
+		`{"type":"agent-turn-complete","last-assistant-message":"Tests pass."}`,
+	))
+	if err != nil || handled {
+		t.Fatalf("handled=%v err=%v, want ignored", handled, err)
 	}
 }
 
@@ -68,7 +132,7 @@ func TestParseClaudeLifecycle(t *testing.T) {
 
 func TestEventSummaryIsBounded(t *testing.T) {
 	event, handled, err := ParseEvent(agent.ProviderCodex, []byte(
-		`{"type":"agent-turn-complete","last-assistant-message":"`+
+		`{"hook_event_name":"Stop","last_assistant_message":"`+
 			strings.Repeat("a", maxEventSummaryRunes+20)+`"}`,
 	))
 	if err != nil {
@@ -134,8 +198,8 @@ func TestIdlePromptNotificationIsIgnored(t *testing.T) {
 }
 
 func TestCodexCompletionClassifiesQuestions(t *testing.T) {
-	payload := []byte(`{"type":"agent-turn-complete",` +
-		`"last-assistant-message":"Should I also update the docs?"}`)
+	payload := []byte(`{"hook_event_name":"Stop",` +
+		`"last_assistant_message":"Should I also update the docs?"}`)
 	event, handled, err := ParseEvent(agent.ProviderCodex, payload)
 	if err != nil || !handled {
 		t.Fatalf("handled=%v err=%v", handled, err)

--- a/internal/provider/hooks.go
+++ b/internal/provider/hooks.go
@@ -1,0 +1,84 @@
+package provider
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"strings"
+
+	"github.com/pelletier/go-toml/v2"
+
+	"github.com/trentkm/stormlight/internal/agent"
+)
+
+// Claude and Codex configure lifecycle hooks with the same schema — an
+// event name mapping to matcher groups, each group holding command
+// handlers — so one set of types describes both. They differ only in how
+// the settings reach the CLI: Claude takes JSON through --settings, Codex
+// takes TOML through a -c config override.
+type hookSettings struct {
+	Hooks map[string][]hookGroup `json:"hooks" toml:"hooks"`
+}
+
+type hookGroup struct {
+	Matcher string        `json:"matcher,omitempty" toml:"matcher,omitempty"`
+	Hooks   []hookCommand `json:"hooks" toml:"hooks"`
+}
+
+type hookCommand struct {
+	Type          string `json:"type" toml:"type"`
+	Command       string `json:"command" toml:"command"`
+	Timeout       int    `json:"timeout,omitempty" toml:"timeout,omitempty"`
+	StatusMessage string `json:"statusMessage,omitempty" toml:"statusMessage,omitempty"`
+}
+
+// hookTimeoutSeconds bounds how long a provider waits on Stormlight before
+// carrying on. Reporting state is never worth stalling an agent for.
+const hookTimeoutSeconds = 5
+
+// reportEvent builds the handler that hands a hook payload to Stormlight.
+// The provider passes the payload on stdin, and $STORMLIGHT_BIN is read at
+// hook time rather than baked in so the value comes from the environment
+// the managed process was started with.
+func reportEvent(providerID agent.Provider) hookCommand {
+	return hookCommand{
+		Type:    "command",
+		Command: `exec "$STORMLIGHT_BIN" _provider-event ` + string(providerID),
+		Timeout: hookTimeoutSeconds,
+	}
+}
+
+// reportGroup wraps reportEvent in the single unmatched group that every
+// Stormlight hook uses: state is reported for every occurrence of an event,
+// never a subset of tools.
+func reportGroup(providerID agent.Provider) []hookGroup {
+	return []hookGroup{{Hooks: []hookCommand{reportEvent(providerID)}}}
+}
+
+func (s hookSettings) json() (string, error) {
+	encoded, err := json.Marshal(s)
+	if err != nil {
+		return "", fmt.Errorf("encode hook settings: %w", err)
+	}
+	return string(encoded), nil
+}
+
+// tomlOverride renders the settings as a single `hooks = {...}` assignment
+// suitable for `codex -c`. Codex parses the value as TOML and rejects JSON,
+// and it reads the override from one argument, so the encoding has to be
+// inline and single-line rather than the table-per-section layout a TOML
+// document would normally use.
+func (s hookSettings) tomlOverride() (string, error) {
+	var buffer bytes.Buffer
+	encoder := toml.NewEncoder(&buffer)
+	encoder.SetTablesInline(true)
+	encoder.SetArraysMultiline(false)
+	if err := encoder.Encode(s); err != nil {
+		return "", fmt.Errorf("encode hook settings: %w", err)
+	}
+	override := strings.TrimSpace(buffer.String())
+	if strings.ContainsAny(override, "\r\n") {
+		return "", fmt.Errorf("hook settings did not encode to a single line")
+	}
+	return override, nil
+}

--- a/internal/provider/hooks.go
+++ b/internal/provider/hooks.go
@@ -63,22 +63,22 @@ func (s hookSettings) json() (string, error) {
 	return string(encoded), nil
 }
 
-// tomlOverride renders the settings as a single `hooks = {...}` assignment
-// suitable for `codex -c`. Codex parses the value as TOML and rejects JSON,
-// and it reads the override from one argument, so the encoding has to be
-// inline and single-line rather than the table-per-section layout a TOML
-// document would normally use.
-func (s hookSettings) tomlOverride() (string, error) {
+// tomlOverride renders a settings struct as a single `key = value`
+// assignment suitable for `codex -c`. Codex parses the value as TOML and
+// rejects JSON, and reads the override from one argument, so the encoding
+// has to be inline and single-line rather than the table-per-section layout
+// a TOML document would normally use.
+func tomlOverride(settings any) (string, error) {
 	var buffer bytes.Buffer
 	encoder := toml.NewEncoder(&buffer)
 	encoder.SetTablesInline(true)
 	encoder.SetArraysMultiline(false)
-	if err := encoder.Encode(s); err != nil {
-		return "", fmt.Errorf("encode hook settings: %w", err)
+	if err := encoder.Encode(settings); err != nil {
+		return "", fmt.Errorf("encode Codex override: %w", err)
 	}
 	override := strings.TrimSpace(buffer.String())
 	if strings.ContainsAny(override, "\r\n") {
-		return "", fmt.Errorf("hook settings did not encode to a single line")
+		return "", fmt.Errorf("Codex override did not encode to a single line")
 	}
 	return override, nil
 }

--- a/internal/provider/provider.go
+++ b/internal/provider/provider.go
@@ -212,28 +212,53 @@ func (r *Registry) IDs() []agent.Provider {
 	return slices.Clone(r.order)
 }
 
-// codexArgs wires Codex's lifecycle hooks rather than its `notify`
-// callback. `notify` fires on exactly one event — agent-turn-complete — so
-// a turn started in the agent's own pane never reached Stormlight and the
-// row went on claiming `idle` while Codex worked. The hooks report the
-// turn start too, which is the signal that was missing.
+// codexArgs wires both of Codex's lifecycle surfaces, because neither one
+// is sufficient alone.
+//
+// The hooks are what Stormlight actually wants: `notify` fires on exactly
+// one event — agent-turn-complete — so a turn started in the agent's own
+// pane never reached Stormlight and the row went on claiming `idle` while
+// Codex worked. UserPromptSubmit is that missing turn-start signal.
+//
+// But hooks injected this way are inert until a human trusts them. Codex
+// hashes each handler and holds it at "installed, not active" behind a
+// startup review prompt, so a first-run agent reports nothing at all.
+// `notify` carries no such gate, and an agent that only reports turn ends
+// is the behavior Stormlight had all along — where an agent that reports
+// nothing would sit at `working` until its process exited. So `notify`
+// stays as the floor, and the hooks raise the ceiling once trusted. When
+// both are live a turn end arrives twice, which is harmless: the two
+// events carry the same state and applying it twice is idempotent.
 //
 // Codex's PermissionRequest hook is deliberately not registered. It is an
 // approval resolver rather than an observer — its reply decides whether the
 // tool call proceeds — and Stormlight answers prompts in the agent's own
 // terminal, exactly as it declines to intercept Claude's.
 func codexArgs(prompt string, mode agent.PermissionMode) ([]string, error) {
-	settings := hookSettings{
+	notify, err := tomlOverride(struct {
+		Notify []string `toml:"notify"`
+	}{
+		// notify hands the payload to the command as an argument rather
+		// than on stdin, which is why it is spelled as a shell command.
+		Notify: []string{
+			"/bin/sh",
+			"-c",
+			`exec "$STORMLIGHT_BIN" _provider-event codex "$0"`,
+		},
+	})
+	if err != nil {
+		return nil, err
+	}
+	hooks, err := tomlOverride(hookSettings{
 		Hooks: map[string][]hookGroup{
 			"UserPromptSubmit": reportGroup(agent.ProviderCodex),
 			"Stop":             reportGroup(agent.ProviderCodex),
 		},
-	}
-	override, err := settings.tomlOverride()
+	})
 	if err != nil {
 		return nil, err
 	}
-	args := []string{"-c", override}
+	args := []string{"-c", notify, "-c", hooks}
 	args = append(args, codexModeArgs(mode)...)
 	return append(args, prompt), nil
 }

--- a/internal/provider/provider.go
+++ b/internal/provider/provider.go
@@ -1,7 +1,6 @@
 package provider
 
 import (
-	"encoding/json"
 	"fmt"
 	"os/exec"
 	"slices"
@@ -213,16 +212,28 @@ func (r *Registry) IDs() []agent.Provider {
 	return slices.Clone(r.order)
 }
 
+// codexArgs wires Codex's lifecycle hooks rather than its `notify`
+// callback. `notify` fires on exactly one event — agent-turn-complete — so
+// a turn started in the agent's own pane never reached Stormlight and the
+// row went on claiming `idle` while Codex worked. The hooks report the
+// turn start too, which is the signal that was missing.
+//
+// Codex's PermissionRequest hook is deliberately not registered. It is an
+// approval resolver rather than an observer — its reply decides whether the
+// tool call proceeds — and Stormlight answers prompts in the agent's own
+// terminal, exactly as it declines to intercept Claude's.
 func codexArgs(prompt string, mode agent.PermissionMode) ([]string, error) {
-	notify, err := json.Marshal([]string{
-		"/bin/sh",
-		"-c",
-		`exec "$STORMLIGHT_BIN" _provider-event codex "$0"`,
-	})
-	if err != nil {
-		return nil, fmt.Errorf("encode Codex notification command: %w", err)
+	settings := hookSettings{
+		Hooks: map[string][]hookGroup{
+			"UserPromptSubmit": reportGroup(agent.ProviderCodex),
+			"Stop":             reportGroup(agent.ProviderCodex),
+		},
 	}
-	args := []string{"-c", "notify=" + string(notify)}
+	override, err := settings.tomlOverride()
+	if err != nil {
+		return nil, err
+	}
+	args := []string{"-c", override}
 	args = append(args, codexModeArgs(mode)...)
 	return append(args, prompt), nil
 }
@@ -250,32 +261,27 @@ func codexModeArgs(mode agent.PermissionMode) []string {
 }
 
 func claudeArgs(prompt string, mode agent.PermissionMode) ([]string, error) {
-	const eventCommand = `exec "$STORMLIGHT_BIN" _provider-event claude`
 	// Prompts are answered in the agent's own terminal, not re-implemented
 	// in the dashboard: the Notification hook raises attention so the
 	// dashboard can point at the pane, and nothing intercepts the request
 	// itself. Auto mode is the recommended way to run agents anyway.
-	settings := claudeSettings{
-		Hooks: map[string][]claudeHookGroup{
-			"UserPromptSubmit": {
-				{Hooks: []claudeHook{{Type: "command", Command: eventCommand, Timeout: 5}}},
-			},
+	settings := hookSettings{
+		Hooks: map[string][]hookGroup{
+			"UserPromptSubmit": reportGroup(agent.ProviderClaude),
 			"Notification": {
 				{
 					Matcher: "permission_prompt",
-					Hooks:   []claudeHook{{Type: "command", Command: eventCommand, Timeout: 5}},
+					Hooks:   []hookCommand{reportEvent(agent.ProviderClaude)},
 				},
 			},
-			"Stop": {
-				{Hooks: []claudeHook{{Type: "command", Command: eventCommand, Timeout: 5}}},
-			},
+			"Stop": reportGroup(agent.ProviderClaude),
 		},
 	}
-	encoded, err := json.Marshal(settings)
+	encoded, err := settings.json()
 	if err != nil {
-		return nil, fmt.Errorf("encode Claude hook settings: %w", err)
+		return nil, err
 	}
-	args := []string{"--settings", string(encoded)}
+	args := []string{"--settings", encoded}
 	switch mode {
 	case agent.ModeEdits:
 		args = append(args, "--permission-mode", "acceptEdits")
@@ -283,20 +289,4 @@ func claudeArgs(prompt string, mode agent.PermissionMode) ([]string, error) {
 		args = append(args, "--permission-mode", "bypassPermissions")
 	}
 	return append(args, prompt), nil
-}
-
-type claudeSettings struct {
-	Hooks map[string][]claudeHookGroup `json:"hooks"`
-}
-
-type claudeHookGroup struct {
-	Matcher string       `json:"matcher,omitempty"`
-	Hooks   []claudeHook `json:"hooks"`
-}
-
-type claudeHook struct {
-	Type          string `json:"type"`
-	Command       string `json:"command"`
-	Timeout       int    `json:"timeout"`
-	StatusMessage string `json:"statusMessage,omitempty"`
 }

--- a/internal/provider/provider_test.go
+++ b/internal/provider/provider_test.go
@@ -33,13 +33,30 @@ func TestCodexArgsConfigureLifecycleHooks(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	if len(args) != 7 || args[0] != "-c" || args[len(args)-1] != "do work" {
+	if len(args) != 9 || args[0] != "-c" || args[2] != "-c" ||
+		args[len(args)-1] != "do work" {
 		t.Fatalf("unexpected args: %#v", args)
 	}
+	// Codex holds injected hooks at "installed, not active" until a human
+	// trusts them, and reports nothing at all in the meantime. `notify` has
+	// no such gate, so it stays as the floor: without it an agent whose
+	// hooks are untrusted would sit at `working` until its process exited.
+	var notify struct {
+		Notify []string `toml:"notify"`
+	}
+	if err := toml.Unmarshal([]byte(args[1]), &notify); err != nil {
+		t.Fatalf("decode notify override: %v", err)
+	}
+	if len(notify.Notify) != 3 ||
+		!strings.Contains(notify.Notify[2], "_provider-event codex") ||
+		!strings.Contains(notify.Notify[2], "STORMLIGHT_BIN") {
+		t.Fatalf("notify fallback lost: %#v", notify.Notify)
+	}
+
 	// Codex reads the override from a single argument and parses the value
 	// as TOML, rejecting JSON outright, so the encoding has to stay an
 	// inline single-line assignment.
-	override := args[1]
+	override := args[3]
 	if strings.ContainsAny(override, "\r\n") {
 		t.Fatalf("override spans lines: %q", override)
 	}
@@ -77,10 +94,6 @@ func TestCodexArgsConfigureLifecycleHooks(t *testing.T) {
 	// an approval it never answers.
 	if groups := settings.Hooks["PermissionRequest"]; len(groups) != 0 {
 		t.Fatalf("PermissionRequest hook resurfaced: %#v", groups)
-	}
-	// `notify` only ever fired at turn end; the hooks replace it outright.
-	if strings.Contains(override, "notify") {
-		t.Fatalf("legacy notify override survived: %q", override)
 	}
 }
 
@@ -130,7 +143,8 @@ func TestPermissionModeMapsToProviderFlags(t *testing.T) {
 		if err != nil {
 			t.Fatal(err)
 		}
-		wantCodex := append([]string{codex[0], codex[1]}, c.codex...)
+		// Two -c overrides precede the mode flags: notify, then hooks.
+		wantCodex := append(slices.Clone(codex[:4]), c.codex...)
 		wantCodex = append(wantCodex, "do work")
 		if !slices.Equal(codex, wantCodex) {
 			t.Fatalf("codex %s args = %#v, want %#v", c.mode, codex, wantCodex)

--- a/internal/provider/provider_test.go
+++ b/internal/provider/provider_test.go
@@ -2,11 +2,13 @@ package provider
 
 import (
 	"encoding/json"
+	"maps"
 	"path/filepath"
 	"slices"
 	"strings"
 	"testing"
 
+	"github.com/pelletier/go-toml/v2"
 	"github.com/trentkm/stormlight/internal/agent"
 )
 
@@ -26,7 +28,7 @@ func TestRegistryRejectsEmptyTask(t *testing.T) {
 	}
 }
 
-func TestCodexArgsConfigureCompletionNotification(t *testing.T) {
+func TestCodexArgsConfigureLifecycleHooks(t *testing.T) {
 	args, err := codexArgs("do work", agent.ModeEdits)
 	if err != nil {
 		t.Fatal(err)
@@ -34,16 +36,51 @@ func TestCodexArgsConfigureCompletionNotification(t *testing.T) {
 	if len(args) != 7 || args[0] != "-c" || args[len(args)-1] != "do work" {
 		t.Fatalf("unexpected args: %#v", args)
 	}
-	var command []string
-	if err := json.Unmarshal([]byte(strings.TrimPrefix(args[1], "notify=")), &command); err != nil {
-		t.Fatalf("decode notify override: %v", err)
+	// Codex reads the override from a single argument and parses the value
+	// as TOML, rejecting JSON outright, so the encoding has to stay an
+	// inline single-line assignment.
+	override := args[1]
+	if strings.ContainsAny(override, "\r\n") {
+		t.Fatalf("override spans lines: %q", override)
 	}
-	if len(command) != 3 ||
-		!strings.Contains(command[2], "_provider-event codex") {
-		t.Fatalf("unexpected notification command: %#v", command)
+	var settings struct {
+		Hooks map[string][]hookGroup `toml:"hooks"`
 	}
-	if !strings.Contains(command[2], "STORMLIGHT_BIN") {
-		t.Fatalf("notification command lacks Stormlight executable: %q", command[2])
+	if err := toml.Unmarshal([]byte(override), &settings); err != nil {
+		t.Fatalf("decode hooks override: %v", err)
+	}
+
+	names := slices.Sorted(maps.Keys(settings.Hooks))
+	// A turn start is the signal `notify` never carried; without
+	// UserPromptSubmit a Codex agent prompted in its own pane stays `idle`
+	// on the dashboard for the whole turn.
+	if !slices.Equal(names, []string{"Stop", "UserPromptSubmit"}) {
+		t.Fatalf("hook events = %#v", names)
+	}
+	for _, name := range names {
+		for _, group := range settings.Hooks[name] {
+			if len(group.Hooks) != 1 {
+				t.Fatalf("%s hooks = %#v", name, group)
+			}
+			command := group.Hooks[0].Command
+			if !strings.Contains(command, "_provider-event codex") {
+				t.Fatalf("%s command = %q", name, command)
+			}
+			if !strings.Contains(command, "STORMLIGHT_BIN") {
+				t.Fatalf("%s command lacks Stormlight executable: %q", name, command)
+			}
+		}
+	}
+	// Codex's PermissionRequest hook decides whether a tool call proceeds
+	// rather than merely observing it. Prompts are answered in the agent's
+	// own terminal, so registering it would put Stormlight in the path of
+	// an approval it never answers.
+	if groups := settings.Hooks["PermissionRequest"]; len(groups) != 0 {
+		t.Fatalf("PermissionRequest hook resurfaced: %#v", groups)
+	}
+	// `notify` only ever fired at turn end; the hooks replace it outright.
+	if strings.Contains(override, "notify") {
+		t.Fatalf("legacy notify override survived: %q", override)
 	}
 }
 
@@ -183,7 +220,7 @@ func TestClaudeArgsConfigureLifecycleHooks(t *testing.T) {
 	if len(args) != 3 || args[0] != "--settings" || args[2] != "do work" {
 		t.Fatalf("unexpected args: %#v", args)
 	}
-	var settings claudeSettings
+	var settings hookSettings
 	if err := json.Unmarshal([]byte(args[1]), &settings); err != nil {
 		t.Fatalf("decode settings: %v", err)
 	}

--- a/internal/selfpath/selfpath.go
+++ b/internal/selfpath/selfpath.go
@@ -1,0 +1,64 @@
+// Package selfpath resolves the path Stormlight re-invokes itself by.
+package selfpath
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+)
+
+// Resolve returns a path to the running executable that will still start
+// Stormlight after an upgrade.
+//
+// os.Executable answers with the real file behind the process, which for a
+// packaged install is version-stamped — Homebrew's cask resolves
+// `bin/stormlight` to `Caskroom/stormlight/0.6.3/stormlight`. Stormlight
+// writes that path into tmux window commands and hands it to provider hooks
+// as $STORMLIGHT_BIN, and both outlive the process that computed them: the
+// next upgrade deletes the binary out from under every agent still running,
+// and their hooks start failing with "No such file or directory".
+//
+// The launcher on PATH is the stable name for the same program, so prefer
+// it — but only once it is confirmed to be the same file. A development
+// build run out of a worktree must keep its own path even though an
+// installed `stormlight` shadows it on PATH, or end-to-end runs would
+// silently exercise the installed binary instead of the one under test.
+func Resolve() (string, error) {
+	executable, err := os.Executable()
+	if err != nil {
+		return "", fmt.Errorf("resolve Stormlight executable: %w", err)
+	}
+	if alias, ok := stableAlias(executable); ok {
+		return alias, nil
+	}
+	return executable, nil
+}
+
+// stableAlias finds the first entry on PATH naming the same file as
+// executable. Every candidate is checked rather than just the first match
+// exec.LookPath would return, because the launcher that survives upgrades
+// may sit behind an unrelated binary of the same name.
+func stableAlias(executable string) (string, bool) {
+	self, err := os.Stat(executable)
+	if err != nil {
+		return "", false
+	}
+	name := filepath.Base(executable)
+	for _, dir := range filepath.SplitList(os.Getenv("PATH")) {
+		if dir == "" {
+			continue
+		}
+		candidate := filepath.Join(dir, name)
+		if candidate == executable {
+			// Already the stable name, or PATH points straight at the
+			// versioned directory and there is nothing better on offer.
+			return executable, true
+		}
+		info, err := os.Stat(candidate)
+		if err != nil || !os.SameFile(self, info) {
+			continue
+		}
+		return candidate, true
+	}
+	return "", false
+}

--- a/internal/selfpath/selfpath_test.go
+++ b/internal/selfpath/selfpath_test.go
@@ -1,0 +1,102 @@
+package selfpath
+
+import (
+	"os"
+	"path/filepath"
+	"runtime"
+	"testing"
+)
+
+// writeBinary creates a file standing in for an installed Stormlight.
+func writeBinary(t *testing.T, path string) {
+	t.Helper()
+	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(path, []byte("#!/bin/sh\n"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+}
+
+// A cask install runs the version-stamped file behind a stable launcher.
+// Writing the versioned path into hooks is what left agents invoking a
+// binary the next upgrade deleted (#70).
+func TestResolvePrefersStableLauncherOverVersionedPath(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("symlink permissions differ on Windows")
+	}
+	root := t.TempDir()
+	versioned := filepath.Join(root, "Caskroom", "stormlight", "0.6.3", "stormlight")
+	writeBinary(t, versioned)
+
+	launcher := filepath.Join(root, "bin", "stormlight")
+	if err := os.MkdirAll(filepath.Dir(launcher), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Symlink(versioned, launcher); err != nil {
+		t.Fatal(err)
+	}
+	t.Setenv("PATH", filepath.Dir(launcher))
+
+	got, ok := stableAlias(versioned)
+	if !ok || got != launcher {
+		t.Fatalf("stableAlias = %q, %v; want %q", got, ok, launcher)
+	}
+}
+
+// A branch build under test must never be swapped for the installed
+// binary, or an end-to-end run silently measures the wrong program.
+func TestResolveKeepsBuildShadowedOnPath(t *testing.T) {
+	root := t.TempDir()
+	worktree := filepath.Join(root, "worktree", "stormlight")
+	writeBinary(t, worktree)
+	installed := filepath.Join(root, "local", "bin", "stormlight")
+	writeBinary(t, installed)
+	t.Setenv("PATH", filepath.Dir(installed))
+
+	if got, ok := stableAlias(worktree); ok {
+		t.Fatalf("stableAlias = %q, want the worktree build left alone", got)
+	}
+}
+
+// The launcher can sit behind an unrelated binary of the same name, so
+// every PATH entry is checked rather than only the first match.
+func TestResolveSkipsShadowingBinaryOfTheSameName(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("symlink permissions differ on Windows")
+	}
+	root := t.TempDir()
+	versioned := filepath.Join(root, "versions", "0.6.3", "stormlight")
+	writeBinary(t, versioned)
+	unrelated := filepath.Join(root, "first", "stormlight")
+	writeBinary(t, unrelated)
+	launcher := filepath.Join(root, "second", "stormlight")
+	if err := os.MkdirAll(filepath.Dir(launcher), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Symlink(versioned, launcher); err != nil {
+		t.Fatal(err)
+	}
+	t.Setenv("PATH", filepath.Dir(unrelated)+string(os.PathListSeparator)+filepath.Dir(launcher))
+
+	got, ok := stableAlias(versioned)
+	if !ok || got != launcher {
+		t.Fatalf("stableAlias = %q, %v; want %q", got, ok, launcher)
+	}
+}
+
+// With nothing on PATH to prefer, the running executable is the answer.
+func TestResolveFallsBackToTheRunningExecutable(t *testing.T) {
+	t.Setenv("PATH", "")
+	resolved, err := Resolve()
+	if err != nil {
+		t.Fatal(err)
+	}
+	executable, err := os.Executable()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if resolved != executable {
+		t.Fatalf("Resolve = %q, want %q", resolved, executable)
+	}
+}

--- a/internal/tmux/runtime.go
+++ b/internal/tmux/runtime.go
@@ -16,6 +16,7 @@ import (
 
 	"github.com/trentkm/stormlight/internal/agent"
 	"github.com/trentkm/stormlight/internal/diagnostic"
+	"github.com/trentkm/stormlight/internal/selfpath"
 	"github.com/trentkm/stormlight/internal/session"
 	"github.com/trentkm/stormlight/internal/workspace"
 )
@@ -127,9 +128,9 @@ func NewRuntime(runner Runner, sessionName string) (*Runtime, error) {
 	if sessionName == "" {
 		sessionName = defaultSession
 	}
-	executable, err := os.Executable()
+	executable, err := selfpath.Resolve()
 	if err != nil {
-		return nil, fmt.Errorf("resolve Stormlight executable: %w", err)
+		return nil, err
 	}
 	runtime := &Runtime{
 		runner:      runner,

--- a/main.go
+++ b/main.go
@@ -765,9 +765,11 @@ func newProviderEventCommand(socket, sessionName *string, cfg config.Config) *co
 	// that quietly does nothing is exactly what makes broken lifecycle
 	// wiring so hard to spot, so the log always says what happened.
 	return &cobra.Command{
-		Use:    "_provider-event <provider>",
+		Use:    "_provider-event <provider> [payload]",
 		Hidden: true,
-		Args:   cobra.ExactArgs(1),
+		// Hooks deliver the payload on stdin; Codex's `notify` callback
+		// passes it as an argument instead.
+		Args: cobra.RangeArgs(1, 2),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			providerID := agent.Provider(args[0])
 			id := agentIDFromEnv()
@@ -778,13 +780,19 @@ func newProviderEventCommand(socket, sessionName *string, cfg config.Config) *co
 				return nil
 			}
 
-			payload, err := io.ReadAll(cmd.InOrStdin())
-			if err != nil {
-				diagnostic.Logger().Warn("read provider event payload",
-					"provider", providerID,
-					"error", err,
-				)
-				return nil
+			var payload []byte
+			if len(args) == 2 {
+				payload = []byte(args[1])
+			} else {
+				read, err := io.ReadAll(cmd.InOrStdin())
+				if err != nil {
+					diagnostic.Logger().Warn("read provider event payload",
+						"provider", providerID,
+						"error", err,
+					)
+					return nil
+				}
+				payload = read
 			}
 			event, handled, err := provider.ParseEvent(providerID, payload)
 			if err != nil {

--- a/main.go
+++ b/main.go
@@ -20,6 +20,7 @@ import (
 	"github.com/trentkm/stormlight/internal/config"
 	"github.com/trentkm/stormlight/internal/diagnostic"
 	"github.com/trentkm/stormlight/internal/provider"
+	"github.com/trentkm/stormlight/internal/selfpath"
 	"github.com/trentkm/stormlight/internal/session"
 	"github.com/trentkm/stormlight/internal/surface"
 	"github.com/trentkm/stormlight/internal/tmux"
@@ -286,9 +287,9 @@ func runDashboard(socket, sessionName string, cfg config.Config, openPath string
 }
 
 func hostDashboard(command *cobra.Command, tmuxPath, socket string) error {
-	executable, err := os.Executable()
+	executable, err := selfpath.Resolve()
 	if err != nil {
-		return fmt.Errorf("find Stormlight executable: %w", err)
+		return err
 	}
 	cwd, err := os.Getwd()
 	if err != nil {
@@ -758,43 +759,77 @@ func newEventCommand(socket, sessionName *string, cfg config.Config) *cobra.Comm
 }
 
 func newProviderEventCommand(socket, sessionName *string, cfg config.Config) *cobra.Command {
+	// Every failure here is logged and swallowed. A hook that exits
+	// non-zero is the provider's problem to report, and no dashboard
+	// bookkeeping is worth interrupting an agent mid-turn for — but a hook
+	// that quietly does nothing is exactly what makes broken lifecycle
+	// wiring so hard to spot, so the log always says what happened.
 	return &cobra.Command{
-		Use:    "_provider-event <provider> [payload]",
+		Use:    "_provider-event <provider>",
 		Hidden: true,
-		Args:   cobra.RangeArgs(1, 2),
+		Args:   cobra.ExactArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
+			providerID := agent.Provider(args[0])
 			id := agentIDFromEnv()
 			if id == "" {
+				diagnostic.Logger().Warn("provider event outside a managed agent",
+					"provider", providerID,
+				)
 				return nil
 			}
 
-			var payload []byte
-			if len(args) == 2 {
-				payload = []byte(args[1])
-			} else {
-				var err error
-				payload, err = io.ReadAll(cmd.InOrStdin())
-				if err != nil {
-					return nil
-				}
-			}
-			event, handled, err := provider.ParseEvent(agent.Provider(args[0]), payload)
-			if err != nil || !handled {
+			payload, err := io.ReadAll(cmd.InOrStdin())
+			if err != nil {
+				diagnostic.Logger().Warn("read provider event payload",
+					"provider", providerID,
+					"error", err,
+				)
 				return nil
 			}
+			event, handled, err := provider.ParseEvent(providerID, payload)
+			if err != nil {
+				diagnostic.Logger().Warn("parse provider event",
+					"provider", providerID,
+					"error", err,
+				)
+				return nil
+			}
+			if !handled {
+				diagnostic.Logger().Debug("provider event ignored",
+					"provider", providerID,
+					"agent", id,
+				)
+				return nil
+			}
+			diagnostic.Logger().Debug("provider event",
+				"provider", providerID,
+				"agent", id,
+				"activity", event.Activity,
+				"attention", event.Attention,
+			)
 			service, err := newService(*socket, *sessionName, cfg)
 			if err != nil {
+				diagnostic.Logger().Warn("provider event service unavailable",
+					"provider", providerID,
+					"error", err,
+				)
 				return nil
 			}
 			ctx, cancel := context.WithTimeout(cmd.Context(), 5*time.Second)
 			defer cancel()
-			_ = service.Update(ctx, id, session.Update{
+			if err := service.Update(ctx, id, session.Update{
 				Activity:       event.Activity,
 				Attention:      event.Attention,
 				Summary:        event.Summary,
 				TranscriptPath: event.TranscriptPath,
 				TurnEnded:      event.TurnEnded,
-			})
+			}); err != nil {
+				diagnostic.Logger().Warn("apply provider event",
+					"provider", providerID,
+					"agent", id,
+					"error", err,
+				)
+			}
 			return nil
 		},
 	}
@@ -825,6 +860,14 @@ func newRunCommand(socket, sessionName *string, cfg config.Config) *cobra.Comman
 			_ = service.Update(updateCtx, id, session.Update{Activity: agent.ActivityWorking})
 			cancel()
 
+			// Hooks resolve $STORMLIGHT_BIN long after this process
+			// started, so it has to name a binary that survives an
+			// upgrade rather than however this invocation was spelled.
+			stormlightBin, err := selfpath.Resolve()
+			if err != nil {
+				return err
+			}
+
 			child := exec.Command(launch.Path, launch.Args...)
 			child.Dir = cwd
 			child.Stdin = os.Stdin
@@ -833,7 +876,7 @@ func newRunCommand(socket, sessionName *string, cfg config.Config) *cobra.Comman
 			child.Env = append(os.Environ(),
 				"STORMLIGHT_ID="+id,
 				"STORMLIGHT_WINDOW="+window,
-				"STORMLIGHT_BIN="+os.Args[0],
+				"STORMLIGHT_BIN="+stormlightBin,
 				"STORMLIGHT_SESSION="+*sessionName,
 				"STORMLIGHT_TMUX_SOCKET="+*socket,
 			)


### PR DESCRIPTION
Codex's `notify` callback carries exactly one event, agent-turn-complete,
so Stormlight only ever heard from a Codex agent when a turn ended. A
prompt typed into the agent's own pane — the thing Enter is for — went
unreported, and the row went on asserting `idle` for the whole time Codex
worked, flipping to `idle` again at the end.

Current Codex exposes the same lifecycle hook surface Claude does: the
same schema, the same PascalCase event names, the same payload field
names, delivered on the handler's stdin. Registering UserPromptSubmit and
Stop supplies the turn-start signal `notify` never had, and one payload
struct now decodes both providers.

The two CLIs differ only in how the settings reach them. Claude takes
JSON through --settings; Codex parses a -c value as TOML and rejects
JSON, and reads the override from a single argument, so the encoding has
to be an inline single-line assignment.

Codex's PermissionRequest hook stays unregistered. Its reply decides
whether a tool call proceeds, and approvals are answered in the agent's
own terminal — the same reason Claude's PreToolUse is left alone.

Provider hooks now resolve Stormlight through the launcher on PATH
instead of the version-stamped file behind it. $STORMLIGHT_BIN and the
tmux window command are both read long after the process that computed
them exited, so a Homebrew upgrade was deleting the binary out from under
every running agent and their hooks failed with "No such file or
directory". A PATH entry is only preferred once confirmed to be the same
file, so a worktree build under test is never swapped for the installed
one.

_provider-event now logs what it does with an event. It swallows every
failure by design — no dashboard bookkeeping is worth interrupting an
agent for — which is precisely what made this class of breakage so hard
to see.

Fixes #66
Fixes #70