### PR TITLE
Carry the tally and the waiting queue into the tmux bar

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,18 +46,20 @@ where you already are. The counters keep their words while the lineage still
 has room for its own; below that they fall back to the glyph and the number,
 which the dashboard header is the legend for.
 
-When something is waiting, `Ctrl-]` hands you the next one directly, oldest
-first: agents queue in the order they started waiting, and arriving marks a
-result seen the same way opening its terminal from the dashboard does, so
-pressing it again moves on. An agent blocked on a question or an approval
-keeps its amber until you answer it, and the cycle steps past rather than
-sticking. Press the tmux prefix followed by `Q` to return to the dashboard,
-or `N` for the same queue. Stormlight installs these bindings only when the
-keys are unbound or already owned by Stormlight. While the prefix is active,
-the managed session highlights the tmux status bar and shows `Q` for return,
-`N` for the queue, and `?` for the full tmux key list. Closing the dashboard
-removes only its temporary session; agents keep running on the Stormlight
-server.
+When something is waiting, `Ctrl-]` hands you the next one directly and
+`Ctrl-\` steps back: agents queue in the order they started waiting, and the
+ring is circular, so pressing forward walks the whole inbox and comes round
+again. Visiting an agent deliberately does not clear its amber — landing in
+a window is not an answer to what the agent is asking — so the queue holds
+still and your place in it is what moves. Attention comes down where it
+always has: from the dashboard, from `M`, or from the agent's own next
+report. Press the tmux prefix followed by `Q` to return to the dashboard, or
+`N` and `P` for the same queue. Stormlight installs these bindings only when
+the keys are unbound or already owned by Stormlight. While the prefix is
+active, the managed session highlights the tmux status bar and shows `Q` for
+return, `N` and `P` for the queue, and `?` for the full tmux key list.
+Closing the dashboard removes only its temporary session; agents keep
+running on the Stormlight server.
 
 ## Requirements
 
@@ -169,8 +171,8 @@ IDs may be shortened as long as the prefix remains unambiguous.
 | `Enter` | Enter Agents from Workspaces, or open the selected agent terminal |
 | `Ctrl-6` | Return from an agent to the dashboard (vim's alternate-buffer toggle; also shown in the agent status bar, which is clickable) |
 | tmux prefix, then `Q` | Return from an agent to the dashboard (tmux-native fallback) |
-| `Ctrl-]` | From an agent, switch to the next one waiting on you, oldest first |
-| tmux prefix, then `N` | The same queue (tmux-native fallback) |
+| `Ctrl-]` / `Ctrl-\` | From an agent, step forward or back through the agents waiting on you, oldest first |
+| tmux prefix, then `N` / `P` | The same queue (tmux-native fallback) |
 | `n` | Add a workspace in Workspaces; create an agent in the selected workspace elsewhere |
 | `o` | Create an agent with an explicit directory picker |
 | `i` / `s` | Write a reply in Spanreed |
@@ -423,7 +425,8 @@ mode     = "edits"         # ask | edits | auto
 [tmux]
 socket      = "stormlight"
 return_keys = ["C-6", "C-^"]
-next_keys   = ["C-]"]      # cycle the agents waiting on you
+next_keys     = ["C-]"]    # step forward through the agents waiting on you
+previous_keys = ['C-\\']    # and back
 
 [workspaces."~/repos/trusted-project"]
 mode = "auto"              # per-directory dispatch defaults (matches subdirs)

--- a/README.md
+++ b/README.md
@@ -38,12 +38,23 @@ current pane directly and reaches agents through a nested client. Selecting an
 agent switches to its window, and that window's status bar names where you
 are — `workspace › worktree › agent` — rather than listing the session's other
 agents, which the dashboard is already for. A narrow terminal drops the outer
-segments first; the agent's own name always stays. Press the tmux prefix
-followed by `Q` to return to the dashboard. Stormlight installs this binding
-only when `Q` is unbound or already owned by Stormlight. While the prefix is
-active, the managed session highlights the tmux status bar and shows `Q` for
-return and `?` for the full tmux key list. Closing the dashboard removes only
-its temporary session; agents keep running on the Stormlight server.
+segments first; the agent's own name always stays. The right of that bar
+carries the dashboard's own counters — working, waiting, needing input, and
+idle — so the question that would otherwise send you back to the dashboard
+is answered where you already are.
+
+When something is waiting, `Alt-n` hands you the next one directly, oldest
+first: agents queue in the order they started waiting, and arriving marks a
+result seen the same way opening its terminal from the dashboard does, so
+pressing it again moves on. An agent blocked on a question or an approval
+keeps its amber until you answer it, and the cycle steps past rather than
+sticking. Press the tmux prefix followed by `Q` to return to the dashboard,
+or `N` for the same queue. Stormlight installs these bindings only when the
+keys are unbound or already owned by Stormlight. While the prefix is active,
+the managed session highlights the tmux status bar and shows `Q` for return,
+`N` for the queue, and `?` for the full tmux key list. Closing the dashboard
+removes only its temporary session; agents keep running on the Stormlight
+server.
 
 ## Requirements
 
@@ -155,6 +166,8 @@ IDs may be shortened as long as the prefix remains unambiguous.
 | `Enter` | Enter Agents from Workspaces, or open the selected agent terminal |
 | `Ctrl-6` | Return from an agent to the dashboard (vim's alternate-buffer toggle; also shown in the agent status bar, which is clickable) |
 | tmux prefix, then `Q` | Return from an agent to the dashboard (tmux-native fallback) |
+| `Alt-n` | From an agent, switch to the next one waiting on you, oldest first |
+| tmux prefix, then `N` | The same queue (tmux-native fallback) |
 | `n` | Add a workspace in Workspaces; create an agent in the selected workspace elsewhere |
 | `o` | Create an agent with an explicit directory picker |
 | `i` / `s` | Write a reply in Spanreed |
@@ -407,6 +420,7 @@ mode     = "edits"         # ask | edits | auto
 [tmux]
 socket      = "stormlight"
 return_keys = ["C-6", "C-^"]
+next_keys   = ["M-n"]      # cycle the agents waiting on you
 
 [workspaces."~/repos/trusted-project"]
 mode = "auto"              # per-directory dispatch defaults (matches subdirs)

--- a/README.md
+++ b/README.md
@@ -40,10 +40,13 @@ are — `workspace › worktree › agent` — rather than listing the session's
 agents, which the dashboard is already for. A narrow terminal drops the outer
 segments first; the agent's own name always stays. The right of that bar
 carries the dashboard's own counters — working, waiting, needing input, and
-idle — so the question that would otherwise send you back to the dashboard
-is answered where you already are.
+idle — behind a divider that separates them from the key hints, so the
+question that would otherwise send you back to the dashboard is answered
+where you already are. The counters keep their words while the lineage still
+has room for its own; below that they fall back to the glyph and the number,
+which the dashboard header is the legend for.
 
-When something is waiting, `Alt-n` hands you the next one directly, oldest
+When something is waiting, `Ctrl-]` hands you the next one directly, oldest
 first: agents queue in the order they started waiting, and arriving marks a
 result seen the same way opening its terminal from the dashboard does, so
 pressing it again moves on. An agent blocked on a question or an approval
@@ -166,7 +169,7 @@ IDs may be shortened as long as the prefix remains unambiguous.
 | `Enter` | Enter Agents from Workspaces, or open the selected agent terminal |
 | `Ctrl-6` | Return from an agent to the dashboard (vim's alternate-buffer toggle; also shown in the agent status bar, which is clickable) |
 | tmux prefix, then `Q` | Return from an agent to the dashboard (tmux-native fallback) |
-| `Alt-n` | From an agent, switch to the next one waiting on you, oldest first |
+| `Ctrl-]` | From an agent, switch to the next one waiting on you, oldest first |
 | tmux prefix, then `N` | The same queue (tmux-native fallback) |
 | `n` | Add a workspace in Workspaces; create an agent in the selected workspace elsewhere |
 | `o` | Create an agent with an explicit directory picker |
@@ -420,7 +423,7 @@ mode     = "edits"         # ask | edits | auto
 [tmux]
 socket      = "stormlight"
 return_keys = ["C-6", "C-^"]
-next_keys   = ["M-n"]      # cycle the agents waiting on you
+next_keys   = ["C-]"]      # cycle the agents waiting on you
 
 [workspaces."~/repos/trusted-project"]
 mode = "auto"              # per-directory dispatch defaults (matches subdirs)

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -102,6 +102,7 @@ the durable metadata:
 | `@stormlight_created_at` | Unix creation timestamp |
 | `@stormlight_activity` | Normalized activity state |
 | `@stormlight_attention` | Pending human-attention type |
+| `@stormlight_attention_at` | When the agent joined the attention queue |
 | `@stormlight_mark` | Human's manual override of the derived state |
 | `@stormlight_pane` | Original agent pane |
 | `@stormlight_workspace_id` | Stable workspace group identifier |
@@ -147,6 +148,24 @@ managed session preserves the global tmux status formats and uses
 `client_prefix` to temporarily switch to a high-contrast status style with the
 available return and help keys.
 
+The same attach reserves the queue keys — `M-n` in the root table, `N` under
+the prefix — which hand the client the next agent waiting on a human. Unlike
+the return key these are not essential to escaping an agent, so a foreign
+binding is left in place with a warning rather than failing the attach. The
+binding re-invokes Stormlight rather than expressing the choice as a tmux
+format: the order depends on marks and on when each agent entered the queue,
+which is inference no format language carries. Arriving clears soft attention
+exactly as opening a terminal from the dashboard does, so the queue drains as
+it is worked, and the window arrived in inherits the return target of the one
+left behind.
+
+The right of the managed session's status bar carries the dashboard's own
+tally, written into a session option the bar expands. It is published from
+the application service's listing rather than from each state change, because
+a listing is the only thing that notices a pane dying — whatever the
+dashboard knows, the bar knows a poll later — and a tally that has not moved
+is not rewritten.
+
 ## State model
 
 The public agent record keeps process lifetime, activity, and attention
@@ -176,6 +195,11 @@ their exit status is the story.
 This prevents a resumable completed conversation from being conflated with a
 currently running process, and keeps "needs me now" distinct from "idle on
 me" and from "just idle".
+
+Entry into the amber inbox is stamped, by either route, and the stamp is
+what orders the queue the tmux keys cycle: first in, first out. It records
+entry rather than the latest signal, so a summary or an escalation arriving
+mid-wait does not send an agent to the back of a line it never left.
 
 A mark is the one signal nothing derives. Everything above is inference, and
 inference is sometimes wrong, so a human can say otherwise (`m` in the

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -148,7 +148,7 @@ managed session preserves the global tmux status formats and uses
 `client_prefix` to temporarily switch to a high-contrast status style with the
 available return and help keys.
 
-The same attach reserves the queue keys — `M-n` in the root table, `N` under
+The same attach reserves the queue keys — `C-]` in the root table, `N` under
 the prefix — which hand the client the next agent waiting on a human. Unlike
 the return key these are not essential to escaping an agent, so a foreign
 binding is left in place with a warning rather than failing the attach. The
@@ -160,11 +160,19 @@ it is worked, and the window arrived in inherits the return target of the one
 left behind.
 
 The right of the managed session's status bar carries the dashboard's own
-tally, written into a session option the bar expands. It is published from
-the application service's listing rather than from each state change, because
-a listing is the only thing that notices a pane dying — whatever the
-dashboard knows, the bar knows a poll later — and a tally that has not moved
-is not rewritten.
+tally, written into a session option the bar expands, then a divider and the
+hints for the two keys that leave the window. It is published from the
+application service's listing rather than from each state change, because a
+listing is the only thing that notices a pane dying — whatever the dashboard
+knows, the bar knows a poll later — and a tally that has not moved is not
+rewritten.
+
+The tally is published as a width conditional: spelled out where the lineage
+still has room for its own, glyph and number below that. Both renderings are
+built in Go, and so is the column budget `status-left` yields to them, which
+is published alongside as a second conditional. `status-right-length` cannot
+serve as that budget — it is a cap on the widest form, and reserving it on a
+narrow client cuts the agent's name for space nothing occupies.
 
 ## State model
 

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -148,16 +148,21 @@ managed session preserves the global tmux status formats and uses
 `client_prefix` to temporarily switch to a high-contrast status style with the
 available return and help keys.
 
-The same attach reserves the queue keys — `C-]` in the root table, `N` under
-the prefix — which hand the client the next agent waiting on a human. Unlike
-the return key these are not essential to escaping an agent, so a foreign
-binding is left in place with a warning rather than failing the attach. The
-binding re-invokes Stormlight rather than expressing the choice as a tmux
-format: the order depends on marks and on when each agent entered the queue,
-which is inference no format language carries. Arriving clears soft attention
-exactly as opening a terminal from the dashboard does, so the queue drains as
-it is worked, and the window arrived in inherits the return target of the one
-left behind.
+The same attach reserves the queue keys — `C-]` and `C-\` in the root table,
+`N` and `P` under the prefix — which step the client through the agents
+waiting on a human. Unlike the return key these are not essential to escaping
+an agent, so a foreign binding is left in place with a warning rather than
+failing the attach. The binding re-invokes Stormlight rather than expressing
+the choice as a tmux format: the order depends on marks and on when each
+agent entered the queue, which is inference no format language carries. The
+window arrived in inherits the return target of the one left behind.
+
+Arriving deliberately does not clear attention. Landing in a window answers
+nothing the agent is asking, and a cycle that marked rows seen on the way
+past would empty the inbox with nothing done about it. So the queue holds
+still and only the human's place in it moves — which is why a step is
+relative and reversible rather than a repeated pop of the head, and why the
+ring is circular.
 
 The right of the managed session's status bar carries the dashboard's own
 tally, written into a session option the bar expands, then a divider and the
@@ -207,7 +212,9 @@ me" and from "just idle".
 Entry into the amber inbox is stamped, by either route, and the stamp is
 what orders the queue the tmux keys cycle: first in, first out. It records
 entry rather than the latest signal, so a summary or an escalation arriving
-mid-wait does not send an agent to the back of a line it never left.
+mid-wait does not send an agent to the back of a line it never left. Cycling
+reads that order and nothing else — it never writes attention, so an agent
+leaves the queue only the way it always has.
 
 A mark is the one signal nothing derives. Everything above is inference, and
 inference is sometimes wrong, so a human can say otherwise (`m` in the

--- a/docs/config-design.md
+++ b/docs/config-design.md
@@ -77,6 +77,7 @@ session  = "stormlight-agents" # managed agents session name
 [tmux]
 socket      = "stormlight"     # tmux -L <socket>; "" targets the default server
 return_keys = ["C-6", "C-^"]   # single-press escape keys (root table)
+next_keys   = ["M-n"]          # single-press next-agent-waiting keys (root table)
 
 [ui]
 rows = "compact"               # compact | expanded

--- a/docs/config-design.md
+++ b/docs/config-design.md
@@ -77,7 +77,7 @@ session  = "stormlight-agents" # managed agents session name
 [tmux]
 socket      = "stormlight"     # tmux -L <socket>; "" targets the default server
 return_keys = ["C-6", "C-^"]   # single-press escape keys (root table)
-next_keys   = ["M-n"]          # single-press next-agent-waiting keys (root table)
+next_keys   = ["C-]"]          # single-press next-agent-waiting keys (root table)
 
 [ui]
 rows = "compact"               # compact | expanded

--- a/docs/config-design.md
+++ b/docs/config-design.md
@@ -77,7 +77,8 @@ session  = "stormlight-agents" # managed agents session name
 [tmux]
 socket      = "stormlight"     # tmux -L <socket>; "" targets the default server
 return_keys = ["C-6", "C-^"]   # single-press escape keys (root table)
-next_keys   = ["C-]"]          # single-press next-agent-waiting keys (root table)
+next_keys     = ["C-]"]        # single-press step forward through the queue
+previous_keys = ['C-\\']        # single-press step back through the queue
 
 [ui]
 rows = "compact"               # compact | expanded

--- a/internal/agent/agent.go
+++ b/internal/agent/agent.go
@@ -151,15 +151,22 @@ func ParseMode(value string) (PermissionMode, error) {
 }
 
 type Agent struct {
-	ID          string         `json:"id"`
-	Provider    Provider       `json:"provider"`
-	Name        string         `json:"name"`
-	Task        string         `json:"task"`
-	Summary     string         `json:"summary,omitempty"`
-	Cwd         string         `json:"cwd"`
-	CreatedAt   time.Time      `json:"created_at"`
-	Activity    Activity       `json:"activity"`
-	Attention   Attention      `json:"attention,omitempty"`
+	ID        string    `json:"id"`
+	Provider  Provider  `json:"provider"`
+	Name      string    `json:"name"`
+	Task      string    `json:"task"`
+	Summary   string    `json:"summary,omitempty"`
+	Cwd       string    `json:"cwd"`
+	CreatedAt time.Time `json:"created_at"`
+	Activity  Activity  `json:"activity"`
+	Attention Attention `json:"attention,omitempty"`
+	// AttentionAt is when the agent joined the amber inbox — the moment it
+	// started pending on a human, by either route (a provider signal or the
+	// human's own mark). It is the queue's ordering key, so it records
+	// entry into the state rather than the latest signal: a question that
+	// escalates or a summary that arrives later must not send an agent to
+	// the back of a line it has been in the whole time.
+	AttentionAt time.Time      `json:"attention_at,omitempty"`
 	Mark        Mark           `json:"mark,omitempty"`
 	TmuxSession string         `json:"tmux_session"`
 	WindowID    string         `json:"window_id"`

--- a/internal/agent/stats.go
+++ b/internal/agent/stats.go
@@ -96,16 +96,28 @@ func queuedAt(a Agent) time.Time {
 	return a.AttentionAt
 }
 
-// NextInQueue picks the agent to hand a human next, given a queue from Queue
-// and the agent they are looking at now.
+// QueueStep is which way a cycle moves through the inbox.
+type QueueStep int
+
+const (
+	QueueForward QueueStep = 1
+	QueueBack    QueueStep = -1
+)
+
+// StepInQueue picks the agent to hand a human next, given a queue from Queue,
+// the agent they are looking at now, and which way they asked to go.
 //
-// From inside the queue it advances one place and wraps, so a key pressed
-// repeatedly walks the whole inbox even where arriving does not clear the
-// amber — an urgent prompt stays urgent until it is answered, and a cycle
-// that kept landing on it would never reach anything else. From anywhere
-// else it hands back the head, which is the plain first-in-first-out
-// answer.
-func NextInQueue(queue []Agent, currentID string) (Agent, bool) {
+// Visiting an agent does not take it out of the queue — nothing about
+// arriving answers what the agent is waiting for — so the queue holds still
+// and the human's place in it is what moves. That is why a step is relative:
+// pressing forward repeatedly walks the whole inbox and wraps, and pressing
+// back returns to what was just looked at rather than to the front of a line
+// that never shortened.
+//
+// From outside the queue there is no place to move from, so a step lands on
+// the end it came from: forward on the head, which is the plain
+// first-in-first-out answer, and back on the tail.
+func StepInQueue(queue []Agent, currentID string, step QueueStep) (Agent, bool) {
 	if len(queue) == 0 {
 		return Agent{}, false
 	}
@@ -116,7 +128,11 @@ func NextInQueue(queue []Agent, currentID string) (Agent, bool) {
 		if len(queue) == 1 {
 			return Agent{}, false
 		}
-		return queue[(index+1)%len(queue)], true
+		next := (index + int(step) + len(queue)) % len(queue)
+		return queue[next], true
+	}
+	if step == QueueBack {
+		return queue[len(queue)-1], true
 	}
 	return queue[0], true
 }

--- a/internal/agent/stats.go
+++ b/internal/agent/stats.go
@@ -1,0 +1,122 @@
+package agent
+
+import (
+	"cmp"
+	"slices"
+	"time"
+)
+
+// Stats buckets a set of agents by the state a human reads them as. The
+// buckets partition the set — every agent lands in exactly one, chosen by
+// the same precedence the dashboard's row glyph uses — so a summary built
+// from them adds up to the agents it describes.
+//
+// It lives here rather than in the dashboard because it is no longer the
+// dashboard's alone: the header counts and the managed session's tmux status
+// bar are the same tally shown in two places, and two derivations of it
+// would drift.
+type Stats struct {
+	// Working is running, by Stormlight's reading or the human's.
+	Working int
+	// Urgent is blocked on an explicit human decision.
+	Urgent int
+	// Waiting is a finished turn the human has not seen, including rows the
+	// human flagged themselves.
+	Waiting int
+	// Idle is alive with nothing pending on anyone.
+	Idle int
+	// Exited is a dead pane, whose exit status is its own story.
+	Exited int
+}
+
+// Attention is the size of the amber inbox: everything pending on a human.
+func (s Stats) Attention() int { return s.Urgent + s.Waiting }
+
+// Total is every agent counted.
+func (s Stats) Total() int {
+	return s.Working + s.Urgent + s.Waiting + s.Idle + s.Exited
+}
+
+// Count buckets agents for display, marks included: a row the human
+// corrected is corrected in the counters too, or the summary would keep
+// reporting the reading they overruled.
+func Count(agents []Agent) Stats {
+	var stats Stats
+	for _, managedAgent := range agents {
+		switch {
+		case managedAgent.EffectiveMark() == MarkWorking:
+			stats.Working++
+		case managedAgent.EffectiveMark() == MarkAttention:
+			stats.Waiting++
+		case !managedAgent.ProcessLive:
+			stats.Exited++
+		case managedAgent.Attention.Urgent():
+			stats.Urgent++
+		case managedAgent.Attention == AttentionWaiting:
+			stats.Waiting++
+		case managedAgent.Activity == ActivityWorking,
+			managedAgent.Activity == ActivityStarting:
+			stats.Working++
+		case managedAgent.Activity == ActivityIdle:
+			stats.Idle++
+		default:
+			stats.Exited++
+		}
+	}
+	return stats
+}
+
+// Queue is the agents pending on a human, oldest first.
+//
+// The order is arrival order — when the agent started waiting, not when it
+// was dispatched — so working the queue front to back answers whoever has
+// been held up longest. AttentionAt is the stamp for that; an agent that
+// raised attention before Stormlight recorded stamps falls back to its
+// creation time, which keeps a partial record ordered rather than random.
+func Queue(agents []Agent) []Agent {
+	queue := make([]Agent, 0, len(agents))
+	for _, managedAgent := range agents {
+		if managedAgent.ProcessLive && managedAgent.NeedsAttention() {
+			queue = append(queue, managedAgent)
+		}
+	}
+	slices.SortStableFunc(queue, func(a, b Agent) int {
+		if d := queuedAt(a).Compare(queuedAt(b)); d != 0 {
+			return d
+		}
+		return cmp.Compare(a.ID, b.ID)
+	})
+	return queue
+}
+
+func queuedAt(a Agent) time.Time {
+	if a.AttentionAt.IsZero() {
+		return a.CreatedAt
+	}
+	return a.AttentionAt
+}
+
+// NextInQueue picks the agent to hand a human next, given a queue from Queue
+// and the agent they are looking at now.
+//
+// From inside the queue it advances one place and wraps, so a key pressed
+// repeatedly walks the whole inbox even where arriving does not clear the
+// amber — an urgent prompt stays urgent until it is answered, and a cycle
+// that kept landing on it would never reach anything else. From anywhere
+// else it hands back the head, which is the plain first-in-first-out
+// answer.
+func NextInQueue(queue []Agent, currentID string) (Agent, bool) {
+	if len(queue) == 0 {
+		return Agent{}, false
+	}
+	for index, managedAgent := range queue {
+		if managedAgent.ID != currentID {
+			continue
+		}
+		if len(queue) == 1 {
+			return Agent{}, false
+		}
+		return queue[(index+1)%len(queue)], true
+	}
+	return queue[0], true
+}

--- a/internal/agent/stats_test.go
+++ b/internal/agent/stats_test.go
@@ -102,36 +102,65 @@ func TestQueueFallsBackToCreationTimeWithoutAStamp(t *testing.T) {
 	}
 }
 
-func TestNextInQueueAdvancesAndWraps(t *testing.T) {
+func TestStepInQueueWalksBothWaysAndWraps(t *testing.T) {
 	queue := Queue([]Agent{
 		waiter("a", 100, 0),
 		waiter("b", 200, 0),
 		waiter("c", 300, 0),
 	})
 
-	for _, test := range []struct{ from, want string }{
-		{"", "a"},
-		{"elsewhere", "a"},
-		{"a", "b"},
-		{"b", "c"},
-		{"c", "a"},
+	for _, test := range []struct {
+		from string
+		step QueueStep
+		want string
+	}{
+		// From outside, a step lands on the end it came from.
+		{"", QueueForward, "a"},
+		{"elsewhere", QueueForward, "a"},
+		{"", QueueBack, "c"},
+		{"a", QueueForward, "b"},
+		{"b", QueueForward, "c"},
+		{"c", QueueForward, "a"},
+		{"c", QueueBack, "b"},
+		{"b", QueueBack, "a"},
+		{"a", QueueBack, "c"},
 	} {
-		next, ok := NextInQueue(queue, test.from)
+		next, ok := StepInQueue(queue, test.from, test.step)
 		if !ok || next.ID != test.want {
-			t.Fatalf("next after %q = %q (%v), want %q", test.from, next.ID, ok, test.want)
+			t.Fatalf("step %d from %q = %q (%v), want %q",
+				test.step, test.from, next.ID, ok, test.want)
 		}
 	}
 }
 
-func TestNextInQueueStopsWhenThereIsNowhereToGo(t *testing.T) {
-	if _, ok := NextInQueue(nil, ""); ok {
+// Nothing about arriving answers what an agent is waiting for, so the queue
+// holds still and a step is relative to where the human stands in it: one
+// too far forward has to be one back, not a lap.
+func TestStepInQueueReturnsToWhereItCameFrom(t *testing.T) {
+	queue := Queue([]Agent{
+		waiter("a", 100, 0),
+		waiter("b", 200, 0),
+		waiter("c", 300, 0),
+	})
+	forward, _ := StepInQueue(queue, "a", QueueForward)
+	back, _ := StepInQueue(queue, forward.ID, QueueBack)
+	if back.ID != "a" {
+		t.Fatalf("stepping forward then back landed on %q", back.ID)
+	}
+}
+
+func TestStepInQueueStopsWhenThereIsNowhereToGo(t *testing.T) {
+	if _, ok := StepInQueue(nil, "", QueueForward); ok {
 		t.Fatal("empty queue offered an agent")
 	}
 	queue := Queue([]Agent{waiter("only", 100, 0)})
-	if _, ok := NextInQueue(queue, "only"); ok {
-		t.Fatal("the only waiting agent was offered as the next one")
+	for _, step := range []QueueStep{QueueForward, QueueBack} {
+		if _, ok := StepInQueue(queue, "only", step); ok {
+			t.Fatalf("the only waiting agent was offered as step %d", step)
+		}
 	}
-	if next, ok := NextInQueue(queue, "somewhere-else"); !ok || next.ID != "only" {
+	if next, ok := StepInQueue(queue, "somewhere-else", QueueForward); !ok ||
+		next.ID != "only" {
 		t.Fatalf("next = %q (%v)", next.ID, ok)
 	}
 }

--- a/internal/agent/stats_test.go
+++ b/internal/agent/stats_test.go
@@ -1,0 +1,145 @@
+package agent
+
+import (
+	"testing"
+	"time"
+)
+
+func live(id string, activity Activity, attention Attention) Agent {
+	return Agent{
+		ID:          id,
+		Activity:    activity,
+		Attention:   attention,
+		ProcessLive: true,
+	}
+}
+
+func TestCountPartitionsAgentsByDisplayedState(t *testing.T) {
+	agents := []Agent{
+		live("working", ActivityWorking, AttentionNone),
+		live("starting", ActivityStarting, AttentionNone),
+		live("asked", ActivityIdle, AttentionQuestion),
+		live("unseen", ActivityIdle, AttentionWaiting),
+		live("quiet", ActivityIdle, AttentionNone),
+		{ID: "gone", Activity: ActivityCompleted},
+	}
+	stats := Count(agents)
+	want := Stats{Working: 2, Urgent: 1, Waiting: 1, Idle: 1, Exited: 1}
+	if stats != want {
+		t.Fatalf("stats = %+v, want %+v", stats, want)
+	}
+	if stats.Total() != len(agents) {
+		t.Fatalf("total = %d, want %d", stats.Total(), len(agents))
+	}
+	if stats.Attention() != 2 {
+		t.Fatalf("attention = %d, want 2", stats.Attention())
+	}
+}
+
+// A mark is the human's own reading and outranks everything derived, in the
+// counters exactly as in the rows — otherwise the tally would keep reporting
+// the state they overruled.
+func TestCountHonorsMarksOverDerivedState(t *testing.T) {
+	stalled := live("stalled", ActivityIdle, AttentionWaiting)
+	stalled.Mark = MarkWorking
+	flagged := live("flagged", ActivityWorking, AttentionNone)
+	flagged.Mark = MarkAttention
+
+	stats := Count([]Agent{stalled, flagged})
+	want := Stats{Working: 1, Waiting: 1}
+	if stats != want {
+		t.Fatalf("stats = %+v, want %+v", stats, want)
+	}
+}
+
+// A dead pane has an exit status of its own to report; nothing is pending on
+// a human because of it, and it is certainly not still working.
+func TestCountLeavesDeadPanesOutOfLiveTiers(t *testing.T) {
+	dead := Agent{ID: "dead", Activity: ActivityWorking, Attention: AttentionQuestion}
+	dead.Mark = MarkWorking
+
+	stats := Count([]Agent{dead})
+	if stats != (Stats{Exited: 1}) {
+		t.Fatalf("stats = %+v", stats)
+	}
+}
+
+func waiter(id string, attentionAt, createdAt int64) Agent {
+	value := live(id, ActivityIdle, AttentionWaiting)
+	value.CreatedAt = time.Unix(createdAt, 0).UTC()
+	if attentionAt > 0 {
+		value.AttentionAt = time.Unix(attentionAt, 0).UTC()
+	}
+	return value
+}
+
+func TestQueueOrdersByWhenWaitingStarted(t *testing.T) {
+	// Dispatched last, waiting first: arrival order is the queue, not age.
+	agents := []Agent{
+		waiter("second", 200, 10),
+		waiter("first", 100, 90),
+		live("busy", ActivityWorking, AttentionNone),
+		{ID: "dead", Attention: AttentionWaiting},
+	}
+	queue := Queue(agents)
+	if len(queue) != 2 {
+		t.Fatalf("queue = %#v", ids(queue))
+	}
+	if got := ids(queue); got[0] != "first" || got[1] != "second" {
+		t.Fatalf("queue order = %#v", got)
+	}
+}
+
+// An agent that raised attention before Stormlight recorded stamps still has
+// a place in line: its creation time keeps a partial record ordered.
+func TestQueueFallsBackToCreationTimeWithoutAStamp(t *testing.T) {
+	queue := Queue([]Agent{
+		waiter("stamped", 500, 900),
+		waiter("unstamped", 0, 100),
+	})
+	if got := ids(queue); got[0] != "unstamped" || got[1] != "stamped" {
+		t.Fatalf("queue order = %#v", got)
+	}
+}
+
+func TestNextInQueueAdvancesAndWraps(t *testing.T) {
+	queue := Queue([]Agent{
+		waiter("a", 100, 0),
+		waiter("b", 200, 0),
+		waiter("c", 300, 0),
+	})
+
+	for _, test := range []struct{ from, want string }{
+		{"", "a"},
+		{"elsewhere", "a"},
+		{"a", "b"},
+		{"b", "c"},
+		{"c", "a"},
+	} {
+		next, ok := NextInQueue(queue, test.from)
+		if !ok || next.ID != test.want {
+			t.Fatalf("next after %q = %q (%v), want %q", test.from, next.ID, ok, test.want)
+		}
+	}
+}
+
+func TestNextInQueueStopsWhenThereIsNowhereToGo(t *testing.T) {
+	if _, ok := NextInQueue(nil, ""); ok {
+		t.Fatal("empty queue offered an agent")
+	}
+	queue := Queue([]Agent{waiter("only", 100, 0)})
+	if _, ok := NextInQueue(queue, "only"); ok {
+		t.Fatal("the only waiting agent was offered as the next one")
+	}
+	if next, ok := NextInQueue(queue, "somewhere-else"); !ok || next.ID != "only" {
+		t.Fatalf("next = %q (%v)", next.ID, ok)
+	}
+}
+
+func ids(agents []Agent) []string {
+	values := make([]string, len(agents))
+	for index, managedAgent := range agents {
+		values[index] = managedAgent.ID
+	}
+	return values
+}

--- a/internal/app/service.go
+++ b/internal/app/service.go
@@ -120,7 +120,24 @@ func (s *Service) ListAgents(ctx context.Context) ([]agent.Agent, error) {
 	for index := range agents {
 		agents[index].Workspace = contexts[index]
 	}
+	s.publishStatus(ctx, agents)
 	return agents, nil
+}
+
+// publishStatus hands the runtime's own chrome the tally the dashboard is
+// about to draw. It rides on the listing rather than on state changes
+// because a listing is the only thing that notices a pane dying, and the
+// dashboard polls it — so whatever the dashboard knows, the status bar
+// knows a moment later. Best-effort: a bar that cannot be written is not a
+// reason to fail the listing behind it.
+func (s *Service) publishStatus(ctx context.Context, agents []agent.Agent) {
+	publisher, ok := s.runtime.(session.StatusPublisher)
+	if !ok {
+		return
+	}
+	if err := publisher.PublishStatus(ctx, agent.Count(agents)); err != nil {
+		diagnostic.Logger().Debug("status bar tally not published", "error", err)
+	}
 }
 
 func (s *Service) Dispatch(ctx context.Context, req DispatchRequest) (agent.Agent, error) {

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -39,10 +39,11 @@ type Tmux struct {
 	// tmux server) is distinguishable from an unset key.
 	Socket     *string  `toml:"socket"`
 	ReturnKeys []string `toml:"return_keys"`
-	// NextKeys cycle the attention queue from inside an agent. They live in
-	// tmux's root table alongside ReturnKeys, so a key an agent's own TUI
-	// needs is one this list takes away from it.
-	NextKeys []string `toml:"next_keys"`
+	// NextKeys and PreviousKeys step through the attention queue from inside
+	// an agent. They live in tmux's root table alongside ReturnKeys, so a key
+	// an agent's own TUI needs is one these lists take away from it.
+	NextKeys     []string `toml:"next_keys"`
+	PreviousKeys []string `toml:"previous_keys"`
 }
 
 type UI struct {
@@ -248,6 +249,9 @@ func (c Config) EffectiveTOML(builtinSocket, builtinSession string) (string, err
 	}
 	if len(merged.Tmux.NextKeys) == 0 {
 		merged.Tmux.NextKeys = []string{"C-]"}
+	}
+	if len(merged.Tmux.PreviousKeys) == 0 {
+		merged.Tmux.PreviousKeys = []string{`C-\`}
 	}
 	merged.UI.Rows = valueOr(merged.UI.Rows, "compact")
 	merged.Log.Level = valueOr(merged.Log.Level, "info")

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -247,7 +247,7 @@ func (c Config) EffectiveTOML(builtinSocket, builtinSession string) (string, err
 		merged.Tmux.ReturnKeys = []string{"C-6", "C-^"}
 	}
 	if len(merged.Tmux.NextKeys) == 0 {
-		merged.Tmux.NextKeys = []string{"M-n"}
+		merged.Tmux.NextKeys = []string{"C-]"}
 	}
 	merged.UI.Rows = valueOr(merged.UI.Rows, "compact")
 	merged.Log.Level = valueOr(merged.Log.Level, "info")

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -39,6 +39,10 @@ type Tmux struct {
 	// tmux server) is distinguishable from an unset key.
 	Socket     *string  `toml:"socket"`
 	ReturnKeys []string `toml:"return_keys"`
+	// NextKeys cycle the attention queue from inside an agent. They live in
+	// tmux's root table alongside ReturnKeys, so a key an agent's own TUI
+	// needs is one this list takes away from it.
+	NextKeys []string `toml:"next_keys"`
 }
 
 type UI struct {
@@ -241,6 +245,9 @@ func (c Config) EffectiveTOML(builtinSocket, builtinSession string) (string, err
 	}
 	if len(merged.Tmux.ReturnKeys) == 0 {
 		merged.Tmux.ReturnKeys = []string{"C-6", "C-^"}
+	}
+	if len(merged.Tmux.NextKeys) == 0 {
+		merged.Tmux.NextKeys = []string{"M-n"}
 	}
 	merged.UI.Rows = valueOr(merged.UI.Rows, "compact")
 	merged.Log.Level = valueOr(merged.Log.Level, "info")

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -45,6 +45,7 @@ mode = "auto"
 socket = ""
 return_keys = ["F12"]
 next_keys = ["F11"]
+previous_keys = ["F10"]
 
 [ui]
 rows = "sideways"
@@ -71,6 +72,9 @@ provider = "codex"
 	}
 	if len(cfg.Tmux.NextKeys) != 1 || cfg.Tmux.NextKeys[0] != "F11" {
 		t.Fatalf("next keys = %#v", cfg.Tmux.NextKeys)
+	}
+	if len(cfg.Tmux.PreviousKeys) != 1 || cfg.Tmux.PreviousKeys[0] != "F10" {
+		t.Fatalf("previous keys = %#v", cfg.Tmux.PreviousKeys)
 	}
 	if len(warnings) != 1 || !strings.Contains(warnings[0], "ui.rows") {
 		t.Fatalf("warnings = %#v", warnings)
@@ -139,6 +143,7 @@ func TestEffectiveTOMLFillsBuiltinDefaults(t *testing.T) {
 		`socket = 'stormlight-sock'`,
 		`return_keys = ['C-6', 'C-^']`,
 		`next_keys = ['C-]']`,
+		`previous_keys = ['C-\']`,
 		`rows = 'compact'`,
 		`level = 'info'`,
 	} {
@@ -153,9 +158,10 @@ func TestEffectiveTOMLKeepsFileValuesOverDefaults(t *testing.T) {
 	cfg := Config{
 		Defaults: Defaults{Provider: "claude", Mode: "ask", Session: "mine"},
 		Tmux: Tmux{
-			Socket:     &socket,
-			ReturnKeys: []string{"F12"},
-			NextKeys:   []string{"F11"},
+			Socket:       &socket,
+			ReturnKeys:   []string{"F12"},
+			NextKeys:     []string{"F11"},
+			PreviousKeys: []string{"F10"},
 		},
 		UI:  UI{Rows: "sideways"},
 		Log: Log{Level: "debug"},
@@ -173,6 +179,7 @@ func TestEffectiveTOMLKeepsFileValuesOverDefaults(t *testing.T) {
 		`socket = ''`,
 		`return_keys = ['F12']`,
 		`next_keys = ['F11']`,
+		`previous_keys = ['F10']`,
 		`rows = 'sideways'`,
 		`level = 'debug'`,
 	} {

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -44,6 +44,7 @@ mode = "auto"
 [tmux]
 socket = ""
 return_keys = ["F12"]
+next_keys = ["F11"]
 
 [ui]
 rows = "sideways"
@@ -67,6 +68,9 @@ provider = "codex"
 	}
 	if len(cfg.Tmux.ReturnKeys) != 1 || cfg.Tmux.ReturnKeys[0] != "F12" {
 		t.Fatalf("return keys = %#v", cfg.Tmux.ReturnKeys)
+	}
+	if len(cfg.Tmux.NextKeys) != 1 || cfg.Tmux.NextKeys[0] != "F11" {
+		t.Fatalf("next keys = %#v", cfg.Tmux.NextKeys)
 	}
 	if len(warnings) != 1 || !strings.Contains(warnings[0], "ui.rows") {
 		t.Fatalf("warnings = %#v", warnings)
@@ -134,6 +138,7 @@ func TestEffectiveTOMLFillsBuiltinDefaults(t *testing.T) {
 		`session = 'stormlight-agents'`,
 		`socket = 'stormlight-sock'`,
 		`return_keys = ['C-6', 'C-^']`,
+		`next_keys = ['M-n']`,
 		`rows = 'compact'`,
 		`level = 'info'`,
 	} {
@@ -147,9 +152,13 @@ func TestEffectiveTOMLKeepsFileValuesOverDefaults(t *testing.T) {
 	socket := ""
 	cfg := Config{
 		Defaults: Defaults{Provider: "claude", Mode: "ask", Session: "mine"},
-		Tmux:     Tmux{Socket: &socket, ReturnKeys: []string{"F12"}},
-		UI:       UI{Rows: "sideways"},
-		Log:      Log{Level: "debug"},
+		Tmux: Tmux{
+			Socket:     &socket,
+			ReturnKeys: []string{"F12"},
+			NextKeys:   []string{"F11"},
+		},
+		UI:  UI{Rows: "sideways"},
+		Log: Log{Level: "debug"},
 	}
 
 	rendered, err := cfg.EffectiveTOML("stormlight-sock", "stormlight-agents")
@@ -163,6 +172,7 @@ func TestEffectiveTOMLKeepsFileValuesOverDefaults(t *testing.T) {
 		`session = 'mine'`,
 		`socket = ''`,
 		`return_keys = ['F12']`,
+		`next_keys = ['F11']`,
 		`rows = 'sideways'`,
 		`level = 'debug'`,
 	} {

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -138,7 +138,7 @@ func TestEffectiveTOMLFillsBuiltinDefaults(t *testing.T) {
 		`session = 'stormlight-agents'`,
 		`socket = 'stormlight-sock'`,
 		`return_keys = ['C-6', 'C-^']`,
-		`next_keys = ['M-n']`,
+		`next_keys = ['C-]']`,
 		`rows = 'compact'`,
 		`level = 'info'`,
 	} {

--- a/internal/config/template.go
+++ b/internal/config/template.go
@@ -18,7 +18,7 @@ const template = `# Stormlight configuration.
 [tmux]
 # socket      = "stormlight"    # tmux -L <socket>; "" targets the default server
 # return_keys = ["C-6", "C-^"]  # single-press return-to-dashboard keys
-# next_keys   = ["M-n"]         # single-press next-agent-waiting keys
+# next_keys   = ["C-]"]         # single-press next-agent-waiting keys
 
 [ui]
 # rows = "compact"              # compact | expanded

--- a/internal/config/template.go
+++ b/internal/config/template.go
@@ -18,6 +18,7 @@ const template = `# Stormlight configuration.
 [tmux]
 # socket      = "stormlight"    # tmux -L <socket>; "" targets the default server
 # return_keys = ["C-6", "C-^"]  # single-press return-to-dashboard keys
+# next_keys   = ["M-n"]         # single-press next-agent-waiting keys
 
 [ui]
 # rows = "compact"              # compact | expanded

--- a/internal/config/template.go
+++ b/internal/config/template.go
@@ -18,7 +18,8 @@ const template = `# Stormlight configuration.
 [tmux]
 # socket      = "stormlight"    # tmux -L <socket>; "" targets the default server
 # return_keys = ["C-6", "C-^"]  # single-press return-to-dashboard keys
-# next_keys   = ["C-]"]         # single-press next-agent-waiting keys
+# next_keys     = ["C-]"]       # single-press step forward through the queue
+# previous_keys = ['C-\\']       # single-press step back through the queue
 
 [ui]
 # rows = "compact"              # compact | expanded

--- a/internal/session/runtime.go
+++ b/internal/session/runtime.go
@@ -24,6 +24,18 @@ type Runtime interface {
 	SyncWindowSizes(context.Context, int, int) error
 }
 
+// StatusPublisher is an optional runtime capability: a runtime whose
+// terminal has chrome of its own can carry Stormlight's tally on it, so the
+// count of what is working and what is waiting stays readable from inside an
+// agent rather than only from the dashboard.
+//
+// It is separate from Runtime because it is presentation, not agent
+// semantics: a runtime with nowhere to put a status line is complete without
+// it, and callers treat its absence as "nothing to show it on".
+type StatusPublisher interface {
+	PublishStatus(context.Context, agent.Stats) error
+}
+
 type DispatchRequest struct {
 	Provider  agent.Provider
 	Name      string

--- a/internal/tmux/next.go
+++ b/internal/tmux/next.go
@@ -24,7 +24,7 @@ const (
 )
 
 // SetNextKeys overrides the single-press keys that cycle the attention queue
-// (default M-n).
+// (default C-] ).
 func (r *Runtime) SetNextKeys(keys []string) {
 	r.nextKeys = keys
 }
@@ -33,7 +33,7 @@ func (r *Runtime) effectiveNextKeys() []string {
 	if len(r.nextKeys) > 0 {
 		return r.nextKeys
 	}
-	return []string{"M-n"}
+	return []string{"C-]"}
 }
 
 // nextShellCommand re-invokes Stormlight to do the picking. The queue's order

--- a/internal/tmux/next.go
+++ b/internal/tmux/next.go
@@ -7,26 +7,36 @@ import (
 
 	"github.com/trentkm/stormlight/internal/agent"
 	"github.com/trentkm/stormlight/internal/diagnostic"
-	"github.com/trentkm/stormlight/internal/session"
 )
 
 // Cycling the queue is the counterpart to the return key: instead of going
 // back to the dashboard to pick the next agent that wants you, the key hands
-// you the next one directly, in the order they started waiting.
+// you the next one directly, in the order they started waiting. The pair
+// walks it both ways, because visiting an agent does not take it out of the
+// queue — so the queue holds still and your place in it is what moves, and
+// one step too far has to be a step back rather than a lap.
 //
-// It is a root-table binding, so it reaches tmux before the agent's own TUI
-// and needs no prefix; in windows Stormlight does not own, the key is passed
-// straight through to the pane. The prefix binding is the guaranteed-safe
-// path for anyone whose agent needs the single-press key for itself.
+// They are root-table bindings, so they reach tmux before the agent's own TUI
+// and need no prefix; in windows Stormlight does not own, the key is passed
+// straight through to the pane. The prefix bindings are the guaranteed-safe
+// path for anyone whose agent needs the single-press keys for itself.
 const (
-	nextBindingNote = "Next agent waiting"
-	nextPrefixKey   = "N"
+	nextBindingNote     = "Next agent waiting"
+	previousBindingNote = "Previous agent waiting"
+	nextPrefixKey       = "N"
+	previousPrefixKey   = "P"
 )
 
-// SetNextKeys overrides the single-press keys that cycle the attention queue
-// (default C-] ).
+// SetNextKeys overrides the single-press keys that step forward through the
+// attention queue (default C-] ).
 func (r *Runtime) SetNextKeys(keys []string) {
 	r.nextKeys = keys
+}
+
+// SetPreviousKeys overrides the single-press keys that step back through the
+// attention queue (default C-\ ).
+func (r *Runtime) SetPreviousKeys(keys []string) {
+	r.previousKeys = keys
 }
 
 func (r *Runtime) effectiveNextKeys() []string {
@@ -36,6 +46,16 @@ func (r *Runtime) effectiveNextKeys() []string {
 	return []string{"C-]"}
 }
 
+func (r *Runtime) effectivePreviousKeys() []string {
+	if len(r.previousKeys) > 0 {
+		return r.previousKeys
+	}
+	// The neighbouring control character, and the neighbouring physical key:
+	// \ then ] reads back then forward in the order the hands already know.
+	// C-[ is Escape, so the bracket pair itself is not available.
+	return []string{"C-\\"}
+}
+
 // nextShellCommand re-invokes Stormlight to do the picking. The queue's order
 // depends on marks and on when each agent started waiting, which is state
 // tmux formats cannot rank, so the binding asks the binary that knows.
@@ -43,12 +63,15 @@ func (r *Runtime) effectiveNextKeys() []string {
 // The socket and session travel with it: a key binding fires with whatever
 // environment the tmux server was started with, which is not necessarily the
 // one the dashboard was launched from.
-func (r *Runtime) nextShellCommand() string {
+func (r *Runtime) nextShellCommand(step agent.QueueStep) string {
 	args := []string{r.executable}
 	if r.socket != "" {
 		args = append(args, "--tmux-socket", r.socket)
 	}
 	args = append(args, "--session", r.sessionName, "next")
+	if step == agent.QueueBack {
+		args = append(args, "--previous")
+	}
 	// Expanded by tmux before the shell sees them: the client that pressed
 	// the key, and the window — and so the agent — it was pressed in. The
 	// agent option doubles as the marker that makes this binding
@@ -63,55 +86,78 @@ func (r *Runtime) nextShellCommand() string {
 
 // nextTmuxCommand is the same invocation as a tmux command, for the places
 // tmux parses a command line rather than taking it as one argument.
-func (r *Runtime) nextTmuxCommand() string {
-	return "run-shell -b " + tmuxQuote(r.nextShellCommand())
+func (r *Runtime) nextTmuxCommand(step agent.QueueStep) string {
+	return "run-shell -b " + tmuxQuote(r.nextShellCommand(step))
 }
 
-// configureNextPrefix binds the prefix key that cycles the queue. Unlike the
-// return key this is not essential — the single-press keys carry the
+// queueDirection pairs a step with the names it wears in tmux.
+type queueDirection struct {
+	step      agent.QueueStep
+	note      string
+	prefixKey string
+	rootKeys  []string
+}
+
+func (r *Runtime) queueDirections() []queueDirection {
+	return []queueDirection{
+		{agent.QueueForward, nextBindingNote, nextPrefixKey,
+			r.effectiveNextKeys()},
+		{agent.QueueBack, previousBindingNote, previousPrefixKey,
+			r.effectivePreviousKeys()},
+	}
+}
+
+// configureNextPrefix binds the prefix keys that cycle the queue. Unlike the
+// return key these are not essential — the single-press keys carry the
 // feature — so a foreign binding is left alone with a warning rather than
 // failing the attach.
 func (r *Runtime) configureNextPrefix(ctx context.Context, listing string) {
-	if current, bound := tableBinding(listing, "prefix", nextPrefixKey); bound &&
-		!strings.Contains(current, "@stormlight_") {
-		diagnostic.Logger().Warn("foreign tmux prefix binding left in place",
-			"key", nextPrefixKey,
-			"binding", current,
-		)
-		return
-	}
-	if _, err := r.runner.Run(ctx, nil,
-		"bind-key", "-T", "prefix", "-N", nextBindingNote,
-		nextPrefixKey, "run-shell", "-b", r.nextShellCommand(),
-	); err != nil {
-		diagnostic.Logger().Warn("cannot install tmux queue binding",
-			"key", nextPrefixKey,
-			"error", err,
-		)
+	for _, direction := range r.queueDirections() {
+		if current, bound := tableBinding(
+			listing, "prefix", direction.prefixKey,
+		); bound && !strings.Contains(current, "@stormlight_") {
+			diagnostic.Logger().Warn("foreign tmux prefix binding left in place",
+				"key", direction.prefixKey,
+				"binding", current,
+			)
+			continue
+		}
+		if _, err := r.runner.Run(ctx, nil,
+			"bind-key", "-T", "prefix", "-N", direction.note,
+			direction.prefixKey, "run-shell", "-b",
+			r.nextShellCommand(direction.step),
+		); err != nil {
+			diagnostic.Logger().Warn("cannot install tmux queue binding",
+				"key", direction.prefixKey,
+				"error", err,
+			)
+		}
 	}
 }
 
 // configureNextRoot installs the single-press queue keys. Outside Stormlight's
 // own windows the key is handed to the pane untouched.
 func (r *Runtime) configureNextRoot(ctx context.Context, listing string) {
-	for _, key := range r.effectiveNextKeys() {
-		if current, bound := tableBinding(listing, "root", key); bound &&
-			!strings.Contains(current, "@stormlight_") {
-			diagnostic.Logger().Warn("foreign tmux root binding left in place",
-				"key", key,
-				"binding", current,
-			)
-			continue
-		}
-		if _, err := r.runner.Run(ctx, nil,
-			"bind-key", "-T", "root", "-N", nextBindingNote, key,
-			"if-shell", "-F", `#{==:#{@stormlight_id},}`,
-			"send-keys "+key, r.nextTmuxCommand(),
-		); err != nil {
-			diagnostic.Logger().Warn("cannot install tmux queue binding",
-				"key", key,
-				"error", err,
-			)
+	for _, direction := range r.queueDirections() {
+		for _, key := range direction.rootKeys {
+			if current, bound := tableBinding(listing, "root", key); bound &&
+				!strings.Contains(current, "@stormlight_") {
+				diagnostic.Logger().Warn("foreign tmux root binding left in place",
+					"key", key,
+					"binding", current,
+				)
+				continue
+			}
+			if _, err := r.runner.Run(ctx, nil,
+				"bind-key", "-T", "root", "-N", direction.note, key,
+				"if-shell", "-F", `#{==:#{@stormlight_id},}`,
+				"send-keys "+key, r.nextTmuxCommand(direction.step),
+			); err != nil {
+				diagnostic.Logger().Warn("cannot install tmux queue binding",
+					"key", key,
+					"error", err,
+				)
+			}
 		}
 	}
 }
@@ -125,21 +171,28 @@ type NextRequest struct {
 	Client string
 	Window string
 	Agent  string
+	Step   agent.QueueStep
 }
 
 // NextWaiting switches a client to the next agent in the attention queue.
 //
-// Arriving counts as engagement, exactly as opening a terminal from the
-// dashboard does, so the soft amber comes down behind you and the queue
-// drains as you work it. An urgent state is left standing: only answering
-// the prompt resolves it, and the cycle steps past it instead.
+// Arriving deliberately does not clear the amber. Landing in a window is not
+// an answer to what the agent is asking, and a cycle that marked rows seen on
+// the way past would empty the inbox with nothing done about it — so the
+// queue is left exactly as it was and only the human's place in it moves.
+// Attention comes down where it always has: from the dashboard, from `M`, or
+// from the agent's own next report.
 func (r *Runtime) NextWaiting(ctx context.Context, req NextRequest) error {
 	agents, err := r.ListAgents(ctx)
 	if err != nil {
 		return err
 	}
+	step := req.Step
+	if step == 0 {
+		step = agent.QueueForward
+	}
 	queue := agent.Queue(agents)
-	target, ok := agent.NextInQueue(queue, req.Agent)
+	target, ok := agent.StepInQueue(queue, req.Agent, step)
 	if !ok {
 		message := "No agents are waiting"
 		if len(queue) > 0 {
@@ -165,11 +218,9 @@ func (r *Runtime) NextWaiting(ctx context.Context, req NextRequest) error {
 		"agent_id", target.ID,
 		"window_id", target.WindowID,
 		"queue_depth", len(queue),
+		"step", int(step),
 	)
-	if target.Attention.Urgent() {
-		return nil
-	}
-	return r.Update(ctx, target.ID, session.Update{ClearAttention: true})
+	return nil
 }
 
 func (r *Runtime) carryReturnTarget(ctx context.Context, from, to string) {

--- a/internal/tmux/next.go
+++ b/internal/tmux/next.go
@@ -1,0 +1,211 @@
+package tmux
+
+import (
+	"context"
+	"fmt"
+	"strings"
+
+	"github.com/trentkm/stormlight/internal/agent"
+	"github.com/trentkm/stormlight/internal/diagnostic"
+	"github.com/trentkm/stormlight/internal/session"
+)
+
+// Cycling the queue is the counterpart to the return key: instead of going
+// back to the dashboard to pick the next agent that wants you, the key hands
+// you the next one directly, in the order they started waiting.
+//
+// It is a root-table binding, so it reaches tmux before the agent's own TUI
+// and needs no prefix; in windows Stormlight does not own, the key is passed
+// straight through to the pane. The prefix binding is the guaranteed-safe
+// path for anyone whose agent needs the single-press key for itself.
+const (
+	nextBindingNote = "Next agent waiting"
+	nextPrefixKey   = "N"
+)
+
+// SetNextKeys overrides the single-press keys that cycle the attention queue
+// (default M-n).
+func (r *Runtime) SetNextKeys(keys []string) {
+	r.nextKeys = keys
+}
+
+func (r *Runtime) effectiveNextKeys() []string {
+	if len(r.nextKeys) > 0 {
+		return r.nextKeys
+	}
+	return []string{"M-n"}
+}
+
+// nextShellCommand re-invokes Stormlight to do the picking. The queue's order
+// depends on marks and on when each agent started waiting, which is state
+// tmux formats cannot rank, so the binding asks the binary that knows.
+//
+// The socket and session travel with it: a key binding fires with whatever
+// environment the tmux server was started with, which is not necessarily the
+// one the dashboard was launched from.
+func (r *Runtime) nextShellCommand() string {
+	args := []string{r.executable}
+	if r.socket != "" {
+		args = append(args, "--tmux-socket", r.socket)
+	}
+	args = append(args, "--session", r.sessionName, "next")
+	// Expanded by tmux before the shell sees them: the client that pressed
+	// the key, and the window — and so the agent — it was pressed in. The
+	// agent option doubles as the marker that makes this binding
+	// recognisably Stormlight's own when it comes back from list-keys.
+	args = append(args,
+		"--client", "#{client_name}",
+		"--window", "#{window_id}",
+		"--agent", "#{@stormlight_id}",
+	)
+	return shellJoin(args)
+}
+
+// nextTmuxCommand is the same invocation as a tmux command, for the places
+// tmux parses a command line rather than taking it as one argument.
+func (r *Runtime) nextTmuxCommand() string {
+	return "run-shell -b " + tmuxQuote(r.nextShellCommand())
+}
+
+// configureNextPrefix binds the prefix key that cycles the queue. Unlike the
+// return key this is not essential — the single-press keys carry the
+// feature — so a foreign binding is left alone with a warning rather than
+// failing the attach.
+func (r *Runtime) configureNextPrefix(ctx context.Context, listing string) {
+	if current, bound := tableBinding(listing, "prefix", nextPrefixKey); bound &&
+		!strings.Contains(current, "@stormlight_") {
+		diagnostic.Logger().Warn("foreign tmux prefix binding left in place",
+			"key", nextPrefixKey,
+			"binding", current,
+		)
+		return
+	}
+	if _, err := r.runner.Run(ctx, nil,
+		"bind-key", "-T", "prefix", "-N", nextBindingNote,
+		nextPrefixKey, "run-shell", "-b", r.nextShellCommand(),
+	); err != nil {
+		diagnostic.Logger().Warn("cannot install tmux queue binding",
+			"key", nextPrefixKey,
+			"error", err,
+		)
+	}
+}
+
+// configureNextRoot installs the single-press queue keys. Outside Stormlight's
+// own windows the key is handed to the pane untouched.
+func (r *Runtime) configureNextRoot(ctx context.Context, listing string) {
+	for _, key := range r.effectiveNextKeys() {
+		if current, bound := tableBinding(listing, "root", key); bound &&
+			!strings.Contains(current, "@stormlight_") {
+			diagnostic.Logger().Warn("foreign tmux root binding left in place",
+				"key", key,
+				"binding", current,
+			)
+			continue
+		}
+		if _, err := r.runner.Run(ctx, nil,
+			"bind-key", "-T", "root", "-N", nextBindingNote, key,
+			"if-shell", "-F", `#{==:#{@stormlight_id},}`,
+			"send-keys "+key, r.nextTmuxCommand(),
+		); err != nil {
+			diagnostic.Logger().Warn("cannot install tmux queue binding",
+				"key", key,
+				"error", err,
+			)
+		}
+	}
+}
+
+// NextRequest names where a cycle was asked for: the tmux client that will
+// be switched, the window it was asked from, and the agent living in that
+// window. All three are optional — a bare `stormlight next` from a shell
+// inside the server still works — but without an agent there is nothing to
+// advance past, so the queue's head is the answer.
+type NextRequest struct {
+	Client string
+	Window string
+	Agent  string
+}
+
+// NextWaiting switches a client to the next agent in the attention queue.
+//
+// Arriving counts as engagement, exactly as opening a terminal from the
+// dashboard does, so the soft amber comes down behind you and the queue
+// drains as you work it. An urgent state is left standing: only answering
+// the prompt resolves it, and the cycle steps past it instead.
+func (r *Runtime) NextWaiting(ctx context.Context, req NextRequest) error {
+	agents, err := r.ListAgents(ctx)
+	if err != nil {
+		return err
+	}
+	queue := agent.Queue(agents)
+	target, ok := agent.NextInQueue(queue, req.Agent)
+	if !ok {
+		message := "No agents are waiting"
+		if len(queue) > 0 {
+			message = "No other agent is waiting"
+		}
+		return r.notify(ctx, req.Client, message)
+	}
+
+	// The window the human came from knows the way back to the dashboard;
+	// the one they are going to has to learn it, or the return key would
+	// strand them wherever the cycle stopped.
+	r.carryReturnTarget(ctx, req.Window, target.WindowID)
+
+	args := []string{"switch-client"}
+	if req.Client != "" {
+		args = append(args, "-c", req.Client)
+	}
+	args = append(args, "-t", target.WindowID)
+	if _, err := r.runner.Run(ctx, nil, args...); err != nil {
+		return fmt.Errorf("switch tmux client: %w", err)
+	}
+	diagnostic.Logger().Info("cycled to waiting agent",
+		"agent_id", target.ID,
+		"window_id", target.WindowID,
+		"queue_depth", len(queue),
+	)
+	if target.Attention.Urgent() {
+		return nil
+	}
+	return r.Update(ctx, target.ID, session.Update{ClearAttention: true})
+}
+
+func (r *Runtime) carryReturnTarget(ctx context.Context, from, to string) {
+	if from == "" || from == to {
+		return
+	}
+	target, err := r.runner.Run(ctx, nil,
+		"show-options", "-qv", "-w", "-t", from, returnTargetOption,
+	)
+	if err != nil || target == "" {
+		return
+	}
+	if _, err := r.runner.Run(ctx, nil,
+		"set-option", "-w", "-t", to, returnTargetOption, target,
+	); err != nil {
+		diagnostic.Logger().Warn("cannot carry tmux return target",
+			"window_id", to,
+			"error", err,
+		)
+	}
+}
+
+func (r *Runtime) notify(ctx context.Context, client, message string) error {
+	args := []string{"display-message"}
+	if client != "" {
+		args = append(args, "-c", client)
+	}
+	args = append(args, message)
+	_, err := r.runner.Run(ctx, nil, args...)
+	return err
+}
+
+// tmuxQuote wraps a string so tmux's own parser reads it as one argument.
+// Double quotes rather than single: tmux expands #{...} formats inside them,
+// which is how the client and window reach the command line.
+func tmuxQuote(value string) string {
+	replacer := strings.NewReplacer(`\`, `\\`, `"`, `\"`)
+	return `"` + replacer.Replace(value) + `"`
+}

--- a/internal/tmux/next_test.go
+++ b/internal/tmux/next_test.go
@@ -148,56 +148,61 @@ func TestNextWaitingCarriesTheReturnTarget(t *testing.T) {
 	}
 }
 
-// Arriving is engagement, exactly as opening a terminal from the dashboard
-// is: the soft amber comes down so the queue drains as it is worked.
-func TestNextWaitingClearsSoftAttentionOnArrival(t *testing.T) {
-	runner := &queueRunner{panes: []queuePane{
-		{id: "unseen", window: "@1", attention: agent.AttentionWaiting, attentionAt: 100},
-	}}
-	runtime := newQueueRuntime(runner)
+// Landing in a window is not an answer to what the agent is asking, so
+// cycling leaves the amber exactly as it was — a cycle that marked rows seen
+// on the way past would empty the inbox with nothing done about it.
+func TestNextWaitingLeavesAttentionAlone(t *testing.T) {
+	for _, attention := range []agent.Attention{
+		agent.AttentionWaiting, agent.AttentionQuestion,
+	} {
+		runner := &queueRunner{panes: []queuePane{
+			{id: "waiter", window: "@1", attention: attention, attentionAt: 100},
+			{id: "other", window: "@2", attention: attention, attentionAt: 200},
+		}}
+		runtime := newQueueRuntime(runner)
 
-	if err := runtime.NextWaiting(context.Background(), NextRequest{}); err != nil {
-		t.Fatal(err)
-	}
-	cleared := false
-	for _, call := range runner.calls {
-		if len(call) == 6 && call[0] == "set-option" &&
-			call[4] == "@stormlight_attention" && call[5] == "" {
-			cleared = true
+		if err := runtime.NextWaiting(context.Background(), NextRequest{}); err != nil {
+			t.Fatal(err)
 		}
-	}
-	if !cleared {
-		t.Fatalf("attention was not cleared on arrival: %#v", runner.calls)
+		for _, call := range runner.calls {
+			if len(call) == 6 && call[0] == "set-option" &&
+				call[4] == "@stormlight_attention" {
+				t.Fatalf("%s attention was written: %#v", attention, call)
+			}
+		}
 	}
 }
 
-// An urgent prompt is only resolved by answering it, so landing on one must
-// not mark it seen — and the cycle has to be able to step past it.
-func TestNextWaitingLeavesUrgentAttentionStanding(t *testing.T) {
+// The queue does not shorten as it is walked, so one step too far has to be
+// answerable with one step back.
+func TestNextWaitingStepsBack(t *testing.T) {
 	runner := &queueRunner{panes: []queuePane{
-		{id: "asked", window: "@1", attention: agent.AttentionQuestion, attentionAt: 100},
-		{id: "unseen", window: "@2", attention: agent.AttentionWaiting, attentionAt: 200},
+		{id: "first", window: "@1", attention: agent.AttentionWaiting, attentionAt: 100},
+		{id: "second", window: "@2", attention: agent.AttentionWaiting, attentionAt: 200},
+		{id: "third", window: "@3", attention: agent.AttentionQuestion, attentionAt: 300},
 	}}
 	runtime := newQueueRuntime(runner)
 
-	if err := runtime.NextWaiting(context.Background(), NextRequest{}); err != nil {
-		t.Fatal(err)
-	}
-	for _, call := range runner.calls {
-		if len(call) == 6 && call[0] == "set-option" &&
-			call[4] == "@stormlight_attention" {
-			t.Fatalf("urgent attention was written: %#v", call)
-		}
-	}
-	runner.calls = nil
 	if err := runtime.NextWaiting(context.Background(), NextRequest{
-		Window: "@1", Agent: "asked",
+		Window: "@2", Agent: "second", Step: agent.QueueBack,
 	}); err != nil {
 		t.Fatal(err)
 	}
 	if switched, _ := runner.call("switch-client"); !slices.Equal(switched,
-		[]string{"switch-client", "-t", "@2"}) {
-		t.Fatalf("cycle did not step past the urgent agent: %#v", switched)
+		[]string{"switch-client", "-t", "@1"}) {
+		t.Fatalf("back = %#v", switched)
+	}
+
+	// From outside the queue, back lands on the newest waiter.
+	runner.calls = nil
+	if err := runtime.NextWaiting(context.Background(), NextRequest{
+		Step: agent.QueueBack,
+	}); err != nil {
+		t.Fatal(err)
+	}
+	if switched, _ := runner.call("switch-client"); !slices.Equal(switched,
+		[]string{"switch-client", "-t", "@3"}) {
+		t.Fatalf("back from outside = %#v", switched)
 	}
 }
 
@@ -266,7 +271,7 @@ func TestNextShellCommandCarriesItsOwnServer(t *testing.T) {
 		socket:      "stormlight",
 		sessionName: "stormlight-agents",
 	}
-	command := runtime.nextShellCommand()
+	command := runtime.nextShellCommand(agent.QueueForward)
 	for _, want := range []string{
 		"'/usr/local/bin/stormlight'",
 		"'--tmux-socket' 'stormlight'",
@@ -280,7 +285,15 @@ func TestNextShellCommandCarriesItsOwnServer(t *testing.T) {
 			t.Fatalf("command missing %q: %s", want, command)
 		}
 	}
-	if quoted := runtime.nextTmuxCommand(); !strings.HasPrefix(
+	if strings.Contains(command, "--previous") {
+		t.Fatalf("a forward step asked to go back: %s", command)
+	}
+	if back := runtime.nextShellCommand(agent.QueueBack); !strings.Contains(
+		back, "'--previous'",
+	) {
+		t.Fatalf("a back step did not say so: %s", back)
+	}
+	if quoted := runtime.nextTmuxCommand(agent.QueueForward); !strings.HasPrefix(
 		quoted, `run-shell -b "`,
 	) || !strings.HasSuffix(quoted, `"`) {
 		t.Fatalf("tmux command = %s", quoted)

--- a/internal/tmux/next_test.go
+++ b/internal/tmux/next_test.go
@@ -1,0 +1,288 @@
+package tmux
+
+import (
+	"context"
+	"slices"
+	"strconv"
+	"strings"
+	"testing"
+
+	"github.com/trentkm/stormlight/internal/agent"
+)
+
+// queuePane is one line of the pane listing, written the way a waiting agent
+// comes back from tmux.
+type queuePane struct {
+	id          string
+	window      string
+	attention   agent.Attention
+	attentionAt int64
+	mark        agent.Mark
+	dead        bool
+}
+
+func queueLine(pane queuePane) string {
+	parts := make([]string, basePaneFieldCount+metadataFieldCount)
+	parts[0] = "stormlight-agents"
+	parts[1] = pane.window
+	parts[2] = "0"
+	parts[3] = pane.id
+	parts[4] = "%" + strings.TrimPrefix(pane.window, "@")
+	parts[10] = pane.id
+	parts[11] = "codex"
+	parts[15] = "1700000000"
+	parts[16] = string(agent.ActivityIdle)
+	parts[17] = string(pane.attention)
+	parts[18] = parts[4]
+	parts[29] = string(pane.mark)
+	if pane.attentionAt > 0 {
+		parts[30] = strconv.FormatInt(pane.attentionAt, 10)
+	}
+	if pane.dead {
+		parts[8] = "1"
+		parts[9] = "0"
+	}
+	return strings.Join(parts, fieldSeparator)
+}
+
+type queueRunner struct {
+	panes        []queuePane
+	returnTarget string
+	calls        [][]string
+}
+
+func (r *queueRunner) Run(_ context.Context, _ []byte, args ...string) (string, error) {
+	r.calls = append(r.calls, slices.Clone(args))
+	switch args[0] {
+	case "list-panes":
+		lines := make([]string, len(r.panes))
+		for index, pane := range r.panes {
+			lines[index] = queueLine(pane)
+		}
+		return strings.Join(lines, "\n"), nil
+	case "show-options":
+		if args[len(args)-1] == returnTargetOption {
+			return r.returnTarget, nil
+		}
+		return "", nil
+	}
+	return "", nil
+}
+
+func (r *queueRunner) call(name string) ([]string, bool) {
+	for _, call := range r.calls {
+		if call[0] == name {
+			return call, true
+		}
+	}
+	return nil, false
+}
+
+func newQueueRuntime(runner *queueRunner) *Runtime {
+	return &Runtime{runner: runner, sessionName: "stormlight-agents"}
+}
+
+func TestNextWaitingAdvancesInArrivalOrder(t *testing.T) {
+	runner := &queueRunner{
+		panes: []queuePane{
+			{id: "late", window: "@3", attention: agent.AttentionWaiting, attentionAt: 300},
+			{id: "early", window: "@1", attention: agent.AttentionWaiting, attentionAt: 100},
+			{id: "middle", window: "@2", attention: agent.AttentionWaiting, attentionAt: 200},
+		},
+		returnTarget: "$7",
+	}
+	runtime := newQueueRuntime(runner)
+
+	// From outside the queue, the head: whoever has been waiting longest.
+	if err := runtime.NextWaiting(context.Background(), NextRequest{
+		Client: "/dev/ttys004",
+	}); err != nil {
+		t.Fatal(err)
+	}
+	switched, ok := runner.call("switch-client")
+	if !ok || !slices.Equal(switched,
+		[]string{"switch-client", "-c", "/dev/ttys004", "-t", "@1"}) {
+		t.Fatalf("switch = %#v", switched)
+	}
+
+	// From inside it, one place along.
+	runner.calls = nil
+	if err := runtime.NextWaiting(context.Background(), NextRequest{
+		Client: "/dev/ttys004", Window: "@1", Agent: "early",
+	}); err != nil {
+		t.Fatal(err)
+	}
+	switched, _ = runner.call("switch-client")
+	if !slices.Equal(switched,
+		[]string{"switch-client", "-c", "/dev/ttys004", "-t", "@2"}) {
+		t.Fatalf("switch = %#v", switched)
+	}
+}
+
+// The window the human came from knows the way back to the dashboard; the one
+// they arrive in has to learn it, or the return key strands them.
+func TestNextWaitingCarriesTheReturnTarget(t *testing.T) {
+	runner := &queueRunner{
+		panes: []queuePane{
+			{id: "here", window: "@1", attention: agent.AttentionWaiting, attentionAt: 100},
+			{id: "there", window: "@2", attention: agent.AttentionWaiting, attentionAt: 200},
+		},
+		returnTarget: "$7",
+	}
+	runtime := newQueueRuntime(runner)
+
+	if err := runtime.NextWaiting(context.Background(), NextRequest{
+		Window: "@1", Agent: "here",
+	}); err != nil {
+		t.Fatal(err)
+	}
+	want := []string{"set-option", "-w", "-t", "@2", returnTargetOption, "$7"}
+	found := false
+	for _, call := range runner.calls {
+		if slices.Equal(call, want) {
+			found = true
+		}
+	}
+	if !found {
+		t.Fatalf("return target was not carried: %#v", runner.calls)
+	}
+}
+
+// Arriving is engagement, exactly as opening a terminal from the dashboard
+// is: the soft amber comes down so the queue drains as it is worked.
+func TestNextWaitingClearsSoftAttentionOnArrival(t *testing.T) {
+	runner := &queueRunner{panes: []queuePane{
+		{id: "unseen", window: "@1", attention: agent.AttentionWaiting, attentionAt: 100},
+	}}
+	runtime := newQueueRuntime(runner)
+
+	if err := runtime.NextWaiting(context.Background(), NextRequest{}); err != nil {
+		t.Fatal(err)
+	}
+	cleared := false
+	for _, call := range runner.calls {
+		if len(call) == 6 && call[0] == "set-option" &&
+			call[4] == "@stormlight_attention" && call[5] == "" {
+			cleared = true
+		}
+	}
+	if !cleared {
+		t.Fatalf("attention was not cleared on arrival: %#v", runner.calls)
+	}
+}
+
+// An urgent prompt is only resolved by answering it, so landing on one must
+// not mark it seen — and the cycle has to be able to step past it.
+func TestNextWaitingLeavesUrgentAttentionStanding(t *testing.T) {
+	runner := &queueRunner{panes: []queuePane{
+		{id: "asked", window: "@1", attention: agent.AttentionQuestion, attentionAt: 100},
+		{id: "unseen", window: "@2", attention: agent.AttentionWaiting, attentionAt: 200},
+	}}
+	runtime := newQueueRuntime(runner)
+
+	if err := runtime.NextWaiting(context.Background(), NextRequest{}); err != nil {
+		t.Fatal(err)
+	}
+	for _, call := range runner.calls {
+		if len(call) == 6 && call[0] == "set-option" &&
+			call[4] == "@stormlight_attention" {
+			t.Fatalf("urgent attention was written: %#v", call)
+		}
+	}
+	runner.calls = nil
+	if err := runtime.NextWaiting(context.Background(), NextRequest{
+		Window: "@1", Agent: "asked",
+	}); err != nil {
+		t.Fatal(err)
+	}
+	if switched, _ := runner.call("switch-client"); !slices.Equal(switched,
+		[]string{"switch-client", "-t", "@2"}) {
+		t.Fatalf("cycle did not step past the urgent agent: %#v", switched)
+	}
+}
+
+func TestNextWaitingSaysSoWhenTheQueueIsEmpty(t *testing.T) {
+	runner := &queueRunner{panes: []queuePane{
+		{id: "busy", window: "@1"},
+		{id: "gone", window: "@2", attention: agent.AttentionWaiting, dead: true},
+	}}
+	runtime := newQueueRuntime(runner)
+
+	if err := runtime.NextWaiting(context.Background(), NextRequest{
+		Client: "/dev/ttys004",
+	}); err != nil {
+		t.Fatal(err)
+	}
+	message, ok := runner.call("display-message")
+	if !ok || !slices.Equal(message,
+		[]string{"display-message", "-c", "/dev/ttys004", "No agents are waiting"}) {
+		t.Fatalf("message = %#v", message)
+	}
+	if _, switched := runner.call("switch-client"); switched {
+		t.Fatal("an empty queue switched the client anyway")
+	}
+}
+
+func TestNextWaitingDistinguishesTheOnlyWaitingAgent(t *testing.T) {
+	runner := &queueRunner{panes: []queuePane{
+		{id: "only", window: "@1", attention: agent.AttentionWaiting, attentionAt: 100},
+	}}
+	runtime := newQueueRuntime(runner)
+
+	if err := runtime.NextWaiting(context.Background(), NextRequest{
+		Window: "@1", Agent: "only",
+	}); err != nil {
+		t.Fatal(err)
+	}
+	message, _ := runner.call("display-message")
+	if !slices.Equal(message,
+		[]string{"display-message", "No other agent is waiting"}) {
+		t.Fatalf("message = %#v", message)
+	}
+}
+
+// A mark is the human's own note that a row wants revisiting, so it belongs
+// in the queue the same way an unseen result does.
+func TestNextWaitingIncludesMarkedAgents(t *testing.T) {
+	runner := &queueRunner{panes: []queuePane{
+		{id: "flagged", window: "@2", mark: agent.MarkAttention, attentionAt: 50},
+	}}
+	runtime := newQueueRuntime(runner)
+
+	if err := runtime.NextWaiting(context.Background(), NextRequest{}); err != nil {
+		t.Fatal(err)
+	}
+	if switched, _ := runner.call("switch-client"); !slices.Equal(switched,
+		[]string{"switch-client", "-t", "@2"}) {
+		t.Fatalf("switch = %#v", switched)
+	}
+}
+
+// The binding fires with whatever environment the tmux server was started
+// with, so the socket and session have to travel in the command line itself.
+func TestNextShellCommandCarriesItsOwnServer(t *testing.T) {
+	runtime := &Runtime{
+		executable:  "/usr/local/bin/stormlight",
+		socket:      "stormlight",
+		sessionName: "stormlight-agents",
+	}
+	command := runtime.nextShellCommand()
+	for _, want := range []string{
+		"'/usr/local/bin/stormlight'",
+		"'--tmux-socket' 'stormlight'",
+		"'--session' 'stormlight-agents'",
+		"'next'",
+		"'--client' '#{client_name}'",
+		"'--window' '#{window_id}'",
+		"'--agent' '#{@stormlight_id}'",
+	} {
+		if !strings.Contains(command, want) {
+			t.Fatalf("command missing %q: %s", want, command)
+		}
+	}
+	if quoted := runtime.nextTmuxCommand(); !strings.HasPrefix(
+		quoted, `run-shell -b "`,
+	) || !strings.HasSuffix(quoted, `"`) {
+		t.Fatalf("tmux command = %s", quoted)
+	}
+}

--- a/internal/tmux/runtime.go
+++ b/internal/tmux/runtime.go
@@ -13,6 +13,7 @@ import (
 	"slices"
 	"strconv"
 	"strings"
+	"sync"
 	"time"
 
 	"github.com/trentkm/stormlight/internal/agent"
@@ -37,9 +38,9 @@ const (
 	statusLeftBaseOption    = "@stormlight_status_left_base"
 	statusLeftPrefixOption  = "@stormlight_status_left_prefix"
 	statusVersionOption     = "@stormlight_status_version"
-	statusVersion           = "3"
+	statusVersion           = "4"
 	prefixStatusStyle       = "bg=#e5c07b,fg=#1f2328,bold"
-	prefixStatusLeft        = " PREFIX  [Q] return  [?] all keys "
+	prefixStatusLeft        = " PREFIX  [Q] return  [N] next waiting  [?] all keys "
 	// The agents session lives on the Stormlight-owned server, so its
 	// status bar carries the dashboard's identity: a deep sapphire band
 	// with the glint-and-wordmark status-left, echoing the header.
@@ -89,7 +90,7 @@ const (
 		`#{T;=/#{status-right-length}:status-right}` +
 		`#[pop-default]#[norange default]`
 	basePaneFieldCount = 10
-	metadataFieldCount = 20
+	metadataFieldCount = 21
 )
 
 var agentMetadataFields = [metadataFieldCount]string{
@@ -113,6 +114,7 @@ var agentMetadataFields = [metadataFieldCount]string{
 	"mode",
 	"transcript_path",
 	"mark",
+	"attention_at",
 }
 
 type Runtime struct {
@@ -121,6 +123,12 @@ type Runtime struct {
 	executable  string
 	socket      string
 	returnKeys  []string
+	nextKeys    []string
+
+	// statusMu guards the last tally written to the band. The dashboard
+	// publishes from its polling command, which runs off the render loop.
+	statusMu        sync.Mutex
+	publishedStatus string
 }
 
 var _ session.Runtime = (*Runtime)(nil)
@@ -160,10 +168,6 @@ func (r *Runtime) effectiveReturnKeys() []string {
 		return r.returnKeys
 	}
 	return []string{"C-6", "C-^"}
-}
-
-func (r *Runtime) statusRightHint() string {
-	return " " + r.effectiveReturnKeys()[0] + " ⏎ dashboard "
 }
 
 func (r *Runtime) ListAgents(ctx context.Context) ([]agent.Agent, error) {
@@ -240,17 +244,18 @@ func (r *Runtime) Dispatch(ctx context.Context, req session.DispatchRequest) (ag
 
 	createdAt := time.Now().UTC()
 	options := map[string]string{
-		"@stormlight_id":         id,
-		"@stormlight_provider":   string(req.Provider),
-		"@stormlight_task":       metadataValue(req.Task),
-		"@stormlight_summary":    metadataValue(req.Task),
-		"@stormlight_cwd":        cwd,
-		"@stormlight_created_at": strconv.FormatInt(createdAt.Unix(), 10),
-		"@stormlight_activity":   string(agent.ActivityStarting),
-		"@stormlight_attention":  "",
-		"@stormlight_mark":       "",
-		"@stormlight_pane":       target.paneID,
-		"@stormlight_mode":       string(req.Mode),
+		"@stormlight_id":           id,
+		"@stormlight_provider":     string(req.Provider),
+		"@stormlight_task":         metadataValue(req.Task),
+		"@stormlight_summary":      metadataValue(req.Task),
+		"@stormlight_cwd":          cwd,
+		"@stormlight_created_at":   strconv.FormatInt(createdAt.Unix(), 10),
+		"@stormlight_activity":     string(agent.ActivityStarting),
+		"@stormlight_attention":    "",
+		"@stormlight_attention_at": "",
+		"@stormlight_mark":         "",
+		"@stormlight_pane":         target.paneID,
+		"@stormlight_mode":         string(req.Mode),
 	}
 	workspaceOptions, err := encodeWorkspaceOptions(req.Workspace)
 	if err != nil {
@@ -442,6 +447,7 @@ func (r *Runtime) configureReturn(ctx context.Context, sessionName, windowID, ta
 	); err != nil {
 		return fmt.Errorf("install tmux return binding: %w", err)
 	}
+	r.configureNextPrefix(ctx, listing)
 	r.configureRootReturn(ctx)
 	if err := r.configureStatusBar(ctx, sessionName); err != nil {
 		diagnostic.Logger().Warn("tmux status bar unavailable", "error", err)
@@ -493,6 +499,7 @@ func (r *Runtime) configureRootReturn(ctx context.Context) {
 			)
 		}
 	}
+	r.configureNextRoot(ctx, listing)
 }
 
 // configureStatusBar dresses the managed session's status bar: the sapphire
@@ -524,8 +531,8 @@ func (r *Runtime) configureStatusBar(ctx context.Context, sessionName string) er
 		{"status-left", dynamicStatusLeft},
 		{"status-left-length", strconv.Itoa(
 			max(baseStatusLeftLength, len(prefixStatusLeft)))},
-		{"status-right", r.statusRightHint()},
-		{"status-right-length", strconv.Itoa(len(r.statusRightHint()))},
+		{"status-right", r.statusRight()},
+		{"status-right-length", strconv.Itoa(r.statusRightHintWidth())},
 		{"status-format[0]", statusFormat},
 	}
 	for _, option := range options {
@@ -703,6 +710,9 @@ func (r *Runtime) Update(ctx context.Context, id string, update session.Update) 
 	if strings.TrimSpace(update.Summary) != "" {
 		values["@stormlight_summary"] = metadataValue(update.Summary)
 	}
+	if stamp, restamp := attentionStamp(managedAgent, values); restamp {
+		values["@stormlight_attention_at"] = stamp
+	}
 	for key, value := range values {
 		if _, err := r.runner.Run(ctx, nil,
 			"set-option", "-w", "-t", managedAgent.WindowID, key, value,
@@ -711,6 +721,35 @@ func (r *Runtime) Update(ctx context.Context, id string, update session.Update) 
 		}
 	}
 	return nil
+}
+
+// attentionStamp decides whether an update moves an agent across the edge of
+// the amber inbox, and what the queue's ordering key becomes if it does.
+//
+// The stamp records entry, not the latest signal: an agent already pending on
+// a human keeps the time it started pending, however many summaries or
+// escalations arrive while it waits, or cycling the queue would reshuffle it
+// under the human's hand. Leaving the inbox clears the stamp, so the next
+// entry starts a fresh place in line.
+func attentionStamp(
+	before agent.Agent,
+	values map[string]string,
+) (string, bool) {
+	after := before
+	if attention, ok := values["@stormlight_attention"]; ok {
+		after.Attention = agent.Attention(attention)
+	}
+	if mark, ok := values["@stormlight_mark"]; ok {
+		after.Mark = agent.Mark(mark)
+	}
+	switch {
+	case after.NeedsAttention() == before.NeedsAttention():
+		return "", false
+	case after.NeedsAttention():
+		return formatUnixOption(time.Now().UTC()), true
+	default:
+		return "", true
+	}
 }
 
 func (r *Runtime) SetWorkspace(
@@ -930,11 +969,8 @@ func parseAgent(line string) (agent.Agent, bool) {
 	}
 
 	windowIndex, _ := strconv.Atoi(parts[2])
-	createdUnix, _ := strconv.ParseInt(core[5], 10, 64)
-	createdAt := time.Unix(createdUnix, 0).UTC()
-	if createdUnix == 0 {
-		createdAt = time.Time{}
-	}
+	createdAt := parseUnixOption(core[5])
+	attentionAt := parseUnixOption(core[20])
 	paneDead := parts[8] == "1"
 	var exitCode *int
 	if paneDead && parts[9] != "" {
@@ -969,6 +1005,7 @@ func parseAgent(line string) (agent.Agent, bool) {
 		CreatedAt:      createdAt,
 		Activity:       activity,
 		Attention:      agent.Attention(core[7]),
+		AttentionAt:    attentionAt,
 		TmuxSession:    parts[0],
 		WindowID:       parts[1],
 		WindowIndex:    windowIndex,
@@ -994,19 +1031,16 @@ func parseAgent(line string) (agent.Agent, bool) {
 }
 
 func encodeAgentOptions(managedAgent agent.Agent) (map[string]string, error) {
-	createdAt := ""
-	if !managedAgent.CreatedAt.IsZero() {
-		createdAt = strconv.FormatInt(managedAgent.CreatedAt.Unix(), 10)
-	}
 	options := map[string]string{
 		"@stormlight_id":              managedAgent.ID,
 		"@stormlight_provider":        string(managedAgent.Provider),
 		"@stormlight_task":            metadataValue(managedAgent.Task),
 		"@stormlight_summary":         metadataValue(managedAgent.Summary),
 		"@stormlight_cwd":             managedAgent.Cwd,
-		"@stormlight_created_at":      createdAt,
+		"@stormlight_created_at":      formatUnixOption(managedAgent.CreatedAt),
 		"@stormlight_activity":        string(managedAgent.Activity),
 		"@stormlight_attention":       string(managedAgent.Attention),
+		"@stormlight_attention_at":    formatUnixOption(managedAgent.AttentionAt),
 		"@stormlight_pane":            managedAgent.PaneID,
 		"@stormlight_mode":            string(managedAgent.Mode),
 		"@stormlight_transcript_path": managedAgent.TranscriptPath,
@@ -1020,6 +1054,24 @@ func encodeAgentOptions(managedAgent agent.Agent) (map[string]string, error) {
 		options[key] = value
 	}
 	return options, nil
+}
+
+// parseUnixOption reads a window option holding a Unix timestamp. An unset
+// or unparsable option is the zero time rather than 1970, so callers can
+// tell "never stamped" from "stamped at the epoch".
+func parseUnixOption(value string) time.Time {
+	seconds, err := strconv.ParseInt(value, 10, 64)
+	if err != nil || seconds == 0 {
+		return time.Time{}
+	}
+	return time.Unix(seconds, 0).UTC()
+}
+
+func formatUnixOption(value time.Time) string {
+	if value.IsZero() {
+		return ""
+	}
+	return strconv.FormatInt(value.Unix(), 10)
 }
 
 func encodeWorkspaceOptions(value workspace.Context) (map[string]string, error) {

--- a/internal/tmux/runtime.go
+++ b/internal/tmux/runtime.go
@@ -40,7 +40,7 @@ const (
 	statusVersionOption     = "@stormlight_status_version"
 	statusVersion           = "4"
 	prefixStatusStyle       = "bg=#e5c07b,fg=#1f2328,bold"
-	prefixStatusLeft        = " PREFIX  [Q] return  [N] next waiting  [?] all keys "
+	prefixStatusLeft        = " PREFIX  [Q] return  [N] next  [P] previous  [?] all keys "
 	// The agents session lives on the Stormlight-owned server, so its
 	// status bar carries the dashboard's identity: a deep sapphire band
 	// with the glint-and-wordmark status-left, echoing the header.
@@ -122,12 +122,13 @@ var agentMetadataFields = [metadataFieldCount]string{
 }
 
 type Runtime struct {
-	runner      Runner
-	sessionName string
-	executable  string
-	socket      string
-	returnKeys  []string
-	nextKeys    []string
+	runner       Runner
+	sessionName  string
+	executable   string
+	socket       string
+	returnKeys   []string
+	nextKeys     []string
+	previousKeys []string
 
 	// statusMu guards the last tally written to the band. The dashboard
 	// publishes from its polling command, which runs off the render loop.
@@ -1240,6 +1241,12 @@ func isNoServerError(err error) bool {
 
 // tableBinding finds the bind-key line for a key in `list-keys -T <table>`
 // output. Lines look like `bind-key [-r] -T <table> <key> <command...>`.
+//
+// tmux writes the listing to be pasted back into tmux, so a key containing a
+// backslash comes out doubled: C-\ prints as C-\\. Comparing raw would miss
+// it, and a miss here reads as "nobody has this key" — which is how a
+// binding someone else owns gets replaced without the warning that exists to
+// stop exactly that.
 func tableBinding(listing, table, key string) (string, bool) {
 	for _, line := range strings.Split(listing, "\n") {
 		fields := strings.Fields(line)
@@ -1247,7 +1254,8 @@ func tableBinding(listing, table, key string) (string, bool) {
 			if fields[i] != "-T" {
 				continue
 			}
-			if fields[i+1] == table && fields[i+2] == key {
+			listed := strings.ReplaceAll(fields[i+2], `\\`, `\`)
+			if fields[i+1] == table && listed == key {
 				return strings.TrimSpace(line), true
 			}
 			break

--- a/internal/tmux/runtime.go
+++ b/internal/tmux/runtime.go
@@ -70,12 +70,16 @@ const (
 	baseStatusLeft = ` #[fg=#7DCFFF#,bold]✦#[default] #{?#{@stormlight_id},` +
 		agentStatusLineage + `,#[fg=#E8EEF9#,bold]#{session_name}} `
 	// status-left is the whole bar now, so its own length cap stays out of the
-	// way; what keeps it off the return hint is the render-time truncation in
-	// dynamicStatusLeft, which subtracts the hint's width from the client's.
+	// way; what keeps it off the key hints is the render-time truncation in
+	// dynamicStatusLeft, which subtracts the right section's own width from
+	// the client's. That width is a published format rather than
+	// status-right-length, because the right section renders narrower on a
+	// narrow client and reserving its widest form would cut the agent's name
+	// short for space nothing occupies.
 	baseStatusLeftLength = 400
 	dynamicStatusStyle   = `#{?client_prefix,#{E:@stormlight_status_style_prefix},#{E:@stormlight_status_style_base}}`
 	dynamicStatusLeft    = `#{?client_prefix,#{E:@stormlight_status_left_prefix},` +
-		`#{T;=/#{e|-:#{client_width},#{status-right-length}}:@stormlight_status_left_base}}`
+		`#{T;=/#{e|-:#{client_width},#{E:@stormlight_status_width}}:@stormlight_status_left_base}}`
 	// Stormlight's windows are its agents, and the dashboard is where you
 	// choose between them — listing them again on every agent's status bar
 	// only pushes the lineage of the one you are actually in off the band. So
@@ -531,8 +535,11 @@ func (r *Runtime) configureStatusBar(ctx context.Context, sessionName string) er
 		{"status-left", dynamicStatusLeft},
 		{"status-left-length", strconv.Itoa(
 			max(baseStatusLeftLength, len(prefixStatusLeft)))},
+		// Seeded so the bar is coherent before the first tally lands: with
+		// no counters the right section is just the key hints.
+		{statusWidthOption, strconv.Itoa(r.statusRightWidth(""))},
 		{"status-right", r.statusRight()},
-		{"status-right-length", strconv.Itoa(r.statusRightHintWidth())},
+		{"status-right-length", strconv.Itoa(r.statusRightWidth(""))},
 		{"status-format[0]", statusFormat},
 	}
 	for _, option := range options {

--- a/internal/tmux/runtime_test.go
+++ b/internal/tmux/runtime_test.go
@@ -45,6 +45,7 @@ func TestParseAgent(t *testing.T) {
 		"auto",
 		"/tmp/claude/session.jsonl",
 		"attention",
+		"1700000600",
 	}
 	line := strings.Join(parts, fieldSeparator)
 
@@ -76,6 +77,9 @@ func TestParseAgent(t *testing.T) {
 	}
 	if managedAgent.Mark != agent.MarkAttention {
 		t.Fatalf("mark = %q", managedAgent.Mark)
+	}
+	if managedAgent.AttentionAt.Unix() != 1700000600 {
+		t.Fatalf("attention stamp = %v", managedAgent.AttentionAt)
 	}
 }
 
@@ -289,8 +293,9 @@ func TestAttachOutsideTmuxReturnsInteractiveCommand(t *testing.T) {
 		{"list-keys", "-T", "prefix"},
 		{"bind-key", "-T", "prefix", "-N", "Return from Stormlight", "Q",
 			"run-shell", "-C", returnBindingFormat},
+		nextPrefixCall(runtime),
 	}
-	wantCalls = append(wantCalls, rootReturnCalls()...)
+	wantCalls = append(wantCalls, rootReturnCalls(runtime)...)
 	wantCalls = append(wantCalls, statusBarCalls("stormlight-agents")...)
 	wantCalls = append(wantCalls,
 		[]string{"set-option", "-w", "-t", "@1", "@stormlight_return_target", ""},
@@ -341,8 +346,9 @@ func TestAttachInsideTmuxSwitchesCurrentClient(t *testing.T) {
 				{"list-keys", "-T", "prefix"},
 				{"bind-key", "-T", "prefix", "-N", "Return from Stormlight", "Q",
 					"run-shell", "-C", returnBindingFormat},
+				nextPrefixCall(runtime),
 			}
-			wantCalls = append(wantCalls, rootReturnCalls()...)
+			wantCalls = append(wantCalls, rootReturnCalls(runtime)...)
 			wantCalls = append(wantCalls, statusBarCalls("stormlight-agents")...)
 			wantCalls = append(wantCalls,
 				[]string{"set-option", "-w", "-t", "@1", "@stormlight_return_target", "$7"},
@@ -407,8 +413,9 @@ func TestAttachRefreshesStormlightOwnedReturnBinding(t *testing.T) {
 		{"list-keys", "-T", "prefix"},
 		{"bind-key", "-T", "prefix", "-N", "Return from Stormlight", "Q",
 			"run-shell", "-C", returnBindingFormat},
+		nextPrefixCall(runtime),
 	}
-	wantCalls = append(wantCalls, rootReturnCalls()...)
+	wantCalls = append(wantCalls, rootReturnCalls(runtime)...)
 	wantCalls = append(wantCalls, statusBarCalls("stormlight-agents")...)
 	wantCalls = append(wantCalls,
 		[]string{"set-option", "-w", "-t", "@1", "@stormlight_return_target", ""},
@@ -438,7 +445,7 @@ func TestAttachSkipsForeignRootBindingsWithoutFailing(t *testing.T) {
 			boundKeys = append(boundKeys, call[5])
 		}
 	}
-	want := []string{"C-^", returnMouseKey}
+	want := []string{"C-^", returnMouseKey, "M-n"}
 	if !slices.Equal(boundKeys, want) {
 		t.Fatalf("root keys bound = %#v, want %#v", boundKeys, want)
 	}
@@ -530,6 +537,62 @@ func TestUpdateRestoresMissingStormlightWindowMetadata(t *testing.T) {
 	if written["@stormlight_attention"] != "" {
 		t.Fatalf("attention was not cleared: %q", written["@stormlight_attention"])
 	}
+}
+
+// The queue's order is when each agent started waiting, so the stamp is
+// written on the way into the amber inbox and cleared on the way out — and
+// left alone by everything in between, or a summary arriving mid-wait would
+// send the agent to the back of a line it never left.
+func TestUpdateStampsEntryAndExitFromTheAttentionQueue(t *testing.T) {
+	stamped := func(pane string, update session.Update) (string, bool) {
+		runner := &captureRunner{
+			agentLine:    pane,
+			stormlightID: "capture-id",
+		}
+		runtime := &Runtime{runner: runner}
+		if err := runtime.Update(context.Background(), "capture-id", update); err != nil {
+			t.Fatal(err)
+		}
+		for _, call := range runner.calls {
+			if len(call) == 6 && call[0] == "set-option" &&
+				call[4] == "@stormlight_attention_at" {
+				return call[5], true
+			}
+		}
+		return "", false
+	}
+
+	value, written := stamped(captureAgentLine(false), session.Update{
+		Attention: agent.AttentionWaiting,
+	})
+	if !written || value == "" {
+		t.Fatalf("entry was not stamped: %q (%v)", value, written)
+	}
+
+	waiting := waitingAgentLine("1700000600")
+	if value, written := stamped(waiting, session.Update{
+		Summary: "still going",
+	}); written {
+		t.Fatalf("a summary restamped a waiting agent: %q", value)
+	}
+	if value, written := stamped(waiting, session.Update{
+		Attention: agent.AttentionQuestion,
+	}); written {
+		t.Fatalf("an escalation restamped a waiting agent: %q", value)
+	}
+	if value, written := stamped(waiting, session.Update{
+		ClearAttention: true,
+	}); !written || value != "" {
+		t.Fatalf("exit stamp = %q (%v)", value, written)
+	}
+}
+
+// waitingAgentLine is the capture agent already in the amber inbox.
+func waitingAgentLine(attentionAt string) string {
+	parts := strings.Split(captureAgentLine(false), fieldSeparator)
+	parts[17] = string(agent.AttentionWaiting)
+	parts[30] = attentionAt
+	return strings.Join(parts, fieldSeparator)
 }
 
 func TestSetWorkspaceResolvesRuntimeHandleFromAgentID(t *testing.T) {
@@ -761,20 +824,20 @@ func statusBarCalls(sessionName string) [][]string {
 		{"set-option", "-t", sessionName, "@stormlight_status_style_prefix",
 			"bg=#e5c07b,fg=#1f2328,bold"},
 		{"set-option", "-t", sessionName, "@stormlight_status_left_prefix",
-			" PREFIX  [Q] return  [?] all keys "},
+			prefixStatusLeft},
 		{"set-option", "-t", sessionName, statusVersionOption, statusVersion},
 		{"set-option", "-t", sessionName, "status-style", dynamicStatusStyle},
 		{"set-option", "-t", sessionName, "status-left", dynamicStatusLeft},
 		{"set-option", "-t", sessionName, "status-left-length",
 			strconv.Itoa(baseStatusLeftLength)},
-		{"set-option", "-t", sessionName, "status-right", (&Runtime{}).statusRightHint()},
+		{"set-option", "-t", sessionName, "status-right", (&Runtime{}).statusRight()},
 		{"set-option", "-t", sessionName, "status-right-length",
-			strconv.Itoa(len((&Runtime{}).statusRightHint()))},
+			strconv.Itoa((&Runtime{}).statusRightHintWidth())},
 		{"set-option", "-t", sessionName, "status-format[0]", statusFormat},
 	}
 }
 
-func rootReturnCalls() [][]string {
+func rootReturnCalls(runtime *Runtime) [][]string {
 	calls := [][]string{{"list-keys", "-T", "root"}}
 	for _, binding := range []struct{ key, passthrough string }{
 		{"C-6", "send-keys C-6"},
@@ -788,7 +851,26 @@ func rootReturnCalls() [][]string {
 			binding.key, "run-shell", "-C", format,
 		})
 	}
-	return calls
+	return append(calls, rootNextCalls(runtime)...)
+}
+
+// rootNextCalls is the single-press queue key, installed alongside the
+// return keys off the same root-table listing.
+func rootNextCalls(runtime *Runtime) [][]string {
+	return [][]string{{
+		"bind-key", "-T", "root", "-N", nextBindingNote, "M-n",
+		"if-shell", "-F", `#{==:#{@stormlight_id},}`,
+		"send-keys M-n", runtime.nextTmuxCommand(),
+	}}
+}
+
+// nextPrefixCall is the prefix-table queue key, installed off the same
+// prefix listing the return key is checked against.
+func nextPrefixCall(runtime *Runtime) []string {
+	return []string{
+		"bind-key", "-T", "prefix", "-N", nextBindingNote, nextPrefixKey,
+		"run-shell", "-b", runtime.nextShellCommand(),
+	}
 }
 
 func assertCalls(t *testing.T, got, want [][]string) {

--- a/internal/tmux/runtime_test.go
+++ b/internal/tmux/runtime_test.go
@@ -445,7 +445,7 @@ func TestAttachSkipsForeignRootBindingsWithoutFailing(t *testing.T) {
 			boundKeys = append(boundKeys, call[5])
 		}
 	}
-	want := []string{"C-^", returnMouseKey, "M-n"}
+	want := []string{"C-^", returnMouseKey, "C-]"}
 	if !slices.Equal(boundKeys, want) {
 		t.Fatalf("root keys bound = %#v, want %#v", boundKeys, want)
 	}
@@ -458,6 +458,13 @@ func TestAttachSkipsForeignRootBindingsWithoutFailing(t *testing.T) {
 // here instead of being discovered on someone's screen.
 func TestStatusFormatsEscapeStyleCommas(t *testing.T) {
 	for name, format := range map[string]string{
+		// The summary is a conditional now, so an unescaped comma in a
+		// style tag inside it ends the branch and takes the rest of the bar
+		// with it — the loud tier's #,bold is exactly that shape.
+		"statusSummary": (&Runtime{}).statusSummary(agent.Stats{
+			Working: 1, Waiting: 1, Urgent: 1, Idle: 1,
+		}),
+		"statusRight":            (&Runtime{}).statusRight(),
 		"agentStatusLineage":     agentStatusLineage,
 		"statusWorkspaceSegment": statusWorkspaceSegment,
 		"statusTailSegment":      statusTailSegment,
@@ -830,9 +837,11 @@ func statusBarCalls(sessionName string) [][]string {
 		{"set-option", "-t", sessionName, "status-left", dynamicStatusLeft},
 		{"set-option", "-t", sessionName, "status-left-length",
 			strconv.Itoa(baseStatusLeftLength)},
+		{"set-option", "-t", sessionName, statusWidthOption,
+			strconv.Itoa((&Runtime{}).statusRightWidth(""))},
 		{"set-option", "-t", sessionName, "status-right", (&Runtime{}).statusRight()},
 		{"set-option", "-t", sessionName, "status-right-length",
-			strconv.Itoa((&Runtime{}).statusRightHintWidth())},
+			strconv.Itoa((&Runtime{}).statusRightWidth(""))},
 		{"set-option", "-t", sessionName, "status-format[0]", statusFormat},
 	}
 }
@@ -858,9 +867,9 @@ func rootReturnCalls(runtime *Runtime) [][]string {
 // return keys off the same root-table listing.
 func rootNextCalls(runtime *Runtime) [][]string {
 	return [][]string{{
-		"bind-key", "-T", "root", "-N", nextBindingNote, "M-n",
+		"bind-key", "-T", "root", "-N", nextBindingNote, "C-]",
 		"if-shell", "-F", `#{==:#{@stormlight_id},}`,
-		"send-keys M-n", runtime.nextTmuxCommand(),
+		"send-keys C-]", runtime.nextTmuxCommand(),
 	}}
 }
 

--- a/internal/tmux/runtime_test.go
+++ b/internal/tmux/runtime_test.go
@@ -293,8 +293,8 @@ func TestAttachOutsideTmuxReturnsInteractiveCommand(t *testing.T) {
 		{"list-keys", "-T", "prefix"},
 		{"bind-key", "-T", "prefix", "-N", "Return from Stormlight", "Q",
 			"run-shell", "-C", returnBindingFormat},
-		nextPrefixCall(runtime),
 	}
+	wantCalls = append(wantCalls, nextPrefixCalls(runtime)...)
 	wantCalls = append(wantCalls, rootReturnCalls(runtime)...)
 	wantCalls = append(wantCalls, statusBarCalls("stormlight-agents")...)
 	wantCalls = append(wantCalls,
@@ -346,8 +346,8 @@ func TestAttachInsideTmuxSwitchesCurrentClient(t *testing.T) {
 				{"list-keys", "-T", "prefix"},
 				{"bind-key", "-T", "prefix", "-N", "Return from Stormlight", "Q",
 					"run-shell", "-C", returnBindingFormat},
-				nextPrefixCall(runtime),
 			}
+			wantCalls = append(wantCalls, nextPrefixCalls(runtime)...)
 			wantCalls = append(wantCalls, rootReturnCalls(runtime)...)
 			wantCalls = append(wantCalls, statusBarCalls("stormlight-agents")...)
 			wantCalls = append(wantCalls,
@@ -413,8 +413,8 @@ func TestAttachRefreshesStormlightOwnedReturnBinding(t *testing.T) {
 		{"list-keys", "-T", "prefix"},
 		{"bind-key", "-T", "prefix", "-N", "Return from Stormlight", "Q",
 			"run-shell", "-C", returnBindingFormat},
-		nextPrefixCall(runtime),
 	}
+	wantCalls = append(wantCalls, nextPrefixCalls(runtime)...)
 	wantCalls = append(wantCalls, rootReturnCalls(runtime)...)
 	wantCalls = append(wantCalls, statusBarCalls("stormlight-agents")...)
 	wantCalls = append(wantCalls,
@@ -445,7 +445,7 @@ func TestAttachSkipsForeignRootBindingsWithoutFailing(t *testing.T) {
 			boundKeys = append(boundKeys, call[5])
 		}
 	}
-	want := []string{"C-^", returnMouseKey, "C-]"}
+	want := []string{"C-^", returnMouseKey, "C-]", `C-\`}
 	if !slices.Equal(boundKeys, want) {
 		t.Fatalf("root keys bound = %#v, want %#v", boundKeys, want)
 	}
@@ -866,20 +866,30 @@ func rootReturnCalls(runtime *Runtime) [][]string {
 // rootNextCalls is the single-press queue key, installed alongside the
 // return keys off the same root-table listing.
 func rootNextCalls(runtime *Runtime) [][]string {
-	return [][]string{{
-		"bind-key", "-T", "root", "-N", nextBindingNote, "C-]",
-		"if-shell", "-F", `#{==:#{@stormlight_id},}`,
-		"send-keys C-]", runtime.nextTmuxCommand(),
-	}}
+	calls := make([][]string, 0, 2)
+	for _, direction := range runtime.queueDirections() {
+		key := direction.rootKeys[0]
+		calls = append(calls, []string{
+			"bind-key", "-T", "root", "-N", direction.note, key,
+			"if-shell", "-F", `#{==:#{@stormlight_id},}`,
+			"send-keys " + key, runtime.nextTmuxCommand(direction.step),
+		})
+	}
+	return calls
 }
 
 // nextPrefixCall is the prefix-table queue key, installed off the same
 // prefix listing the return key is checked against.
-func nextPrefixCall(runtime *Runtime) []string {
-	return []string{
-		"bind-key", "-T", "prefix", "-N", nextBindingNote, nextPrefixKey,
-		"run-shell", "-b", runtime.nextShellCommand(),
+func nextPrefixCalls(runtime *Runtime) [][]string {
+	calls := make([][]string, 0, 2)
+	for _, direction := range runtime.queueDirections() {
+		calls = append(calls, []string{
+			"bind-key", "-T", "prefix", "-N", direction.note,
+			direction.prefixKey, "run-shell", "-b",
+			runtime.nextShellCommand(direction.step),
+		})
 	}
+	return calls
 }
 
 func assertCalls(t *testing.T, got, want [][]string) {
@@ -936,6 +946,7 @@ func TestTableBindingFindsKeyInTableListing(t *testing.T) {
 	listing := "bind-key    -T prefix !       break-pane\n" +
 		"bind-key -r -T prefix Up      select-pane -U\n" +
 		"bind-key    -T prefix Q       run-shell -C \"#{?…}\"\n" +
+		"bind-key    -T root   C-\\\\    send-keys C-\\\\\n" +
 		"bind-key    -T root   Q       send-keys Q"
 
 	binding, bound := tableBinding(listing, "prefix", "Q")
@@ -948,6 +959,11 @@ func TestTableBindingFindsKeyInTableListing(t *testing.T) {
 	if binding, bound := tableBinding(listing, "prefix", "Up"); !bound ||
 		!strings.Contains(binding, "select-pane") {
 		t.Fatalf("repeat-flag binding = %q, bound = %v", binding, bound)
+	}
+	// tmux doubles a backslash in the listing so the line can be pasted back
+	// in; a raw comparison misses it and reads as nobody owning the key.
+	if _, bound := tableBinding(listing, "root", `C-\`); !bound {
+		t.Fatal("escaped backslash key was not recognised")
 	}
 	if binding, bound := tableBinding(listing, "root", "Q"); !bound ||
 		!strings.Contains(binding, "send-keys") {

--- a/internal/tmux/status.go
+++ b/internal/tmux/status.go
@@ -205,12 +205,17 @@ func (r *Runtime) statusRight() string {
 	return statusSummaryFormat + r.statusRightKeys()
 }
 
-// statusRightKeys names the two ways out of an agent: back to the dashboard,
-// and on to whoever is waiting next.
+// statusRightKeys names the ways out of an agent: back to the dashboard, and
+// either way along the queue. The two queue keys share one label — spelling
+// both out costs more of the band than the direction is worth, and they sit
+// in the order they move, back on the left.
 func (r *Runtime) statusRightKeys() string {
+	queue := "#[fg=" + statusKeyColor + "]" +
+		r.effectivePreviousKeys()[0] + " " + r.effectiveNextKeys()[0] +
+		"#[fg=" + statusLabelColor + "] ↻ queue#[default]"
 	return "  " +
 		statusKeyHint(r.effectiveReturnKeys()[0], "⏎ dashboard") + "  " +
-		statusKeyHint(r.effectiveNextKeys()[0], "↻ next") + " "
+		queue + " "
 }
 
 func statusKeyHint(key, label string) string {

--- a/internal/tmux/status.go
+++ b/internal/tmux/status.go
@@ -5,8 +5,8 @@ import (
 	"fmt"
 	"strconv"
 	"strings"
-	"unicode/utf8"
 
+	"github.com/charmbracelet/x/ansi"
 	"github.com/trentkm/stormlight/internal/agent"
 )
 
@@ -31,6 +31,31 @@ const (
 	statusWaitingColor = "#E5C07B"
 	statusIdleColor    = "#8FA6CC"
 	statusLabelColor   = "#8FA6CC"
+	// The keys are chrome, not news: the cap carries the band's full
+	// brightness because it is the thing you press, and the word explaining
+	// it recedes, so the counters stay what the eye lands on.
+	statusKeyColor     = "#C8D6F2"
+	statusDividerColor = "#55698F"
+	// statusDivider closes the tally. Two sections of small text with no
+	// rule between them read as one run, which is how a count of agents
+	// ended up looking like part of a key hint.
+	statusDivider = "  #[fg=" + statusDividerColor + "]│"
+	// statusWidthOption holds the columns the right section will print at
+	// the client's current width, so status-left yields exactly that much
+	// and no more. It is a format rather than a number because the right
+	// section is not one width: see statusSummary.
+	statusWidthOption = "@stormlight_status_width"
+	// statusLineageMinWidth is what the left keeps before the counters may
+	// spell themselves out. The bar's first job is naming where you are, so
+	// the words are what yields: below this much room for the lineage the
+	// counters fall back to glyph and number, which the dashboard header is
+	// the legend for. The key hints have no such fallback and never drop.
+	//
+	// The figure is what a full lineage occupies — the glint, two capped
+	// segments, their separators, and a name — because status-left is
+	// truncated from the right, so anything short comes out of the agent's
+	// own name, which is the one thing on the bar that never drops.
+	statusLineageMinWidth = 48
 )
 
 // statusCount is one counter on the band: the glyph the dashboard paints for
@@ -43,17 +68,45 @@ type statusCount struct {
 	loud  bool
 }
 
-// statusSummary renders the tally for the right of the band, and the columns
-// it occupies.
+// statusSummary renders the tally for the right of the band.
 //
 // The vocabulary is the dashboard header's, down to the glyphs and the
 // order, so the two read as one instrument rather than two reports of the
 // same thing. Empty tiers are left out — a bar that says "0 waiting" spends
 // columns to say nothing — and a session with no agents in it renders
-// nothing at all.
-func statusSummary(stats agent.Stats) (string, int) {
+// nothing at all, divider included, so the keys are not left hanging off a
+// rule with nothing behind it.
+func (r *Runtime) statusSummary(stats agent.Stats) string {
+	return statusByWidth(
+		r.statusWordsMinWidth(stats),
+		statusCounters(stats, true),
+		statusCounters(stats, false),
+	)
+}
+
+// statusWordsMinWidth is the client width at which the counters can afford
+// their words: what the spelled-out right section takes, plus the lineage's
+// floor. It is computed per tally rather than fixed, because a bar carrying
+// one counter has room for words long before a bar carrying four does.
+func (r *Runtime) statusWordsMinWidth(stats agent.Stats) int {
+	return r.statusRightWidth(statusCounters(stats, true)) +
+		statusLineageMinWidth
+}
+
+// statusByWidth picks between two renderings at the client's width. tmux
+// evaluates it per client, which matters: two terminals of different sizes
+// can share a session, and the option is written once for both.
+func statusByWidth(threshold int, wide, narrow string) string {
+	if wide == narrow {
+		return wide
+	}
+	return "#{?#{e|>=:#{client_width}," + strconv.Itoa(threshold) +
+		"}," + wide + "," + narrow + "}"
+}
+
+func statusCounters(stats agent.Stats, words bool) string {
 	if stats.Total() == 0 {
-		return "", 0
+		return ""
 	}
 	counts := []statusCount{{
 		glyph: "●", value: stats.Working,
@@ -83,13 +136,11 @@ func statusSummary(stats agent.Stats) (string, int) {
 	}
 
 	var format strings.Builder
-	width := 0
+	format.WriteString(" ")
 	for index, count := range counts {
 		if index > 0 {
 			format.WriteString("  ")
-			width += 2
 		}
-		text := fmt.Sprintf("%d %s", count.value, count.label)
 		labelColor := statusLabelColor
 		emphasis := ""
 		if count.loud {
@@ -99,21 +150,23 @@ func statusSummary(stats agent.Stats) (string, int) {
 			// string is one edit away from living inside one.
 			emphasis = "#,bold"
 		}
+		text := strconv.Itoa(count.value)
+		if words {
+			text += " " + count.label
+		}
 		format.WriteString("#[fg=" + count.color + emphasis + "]" + count.glyph)
 		format.WriteString("#[fg=" + labelColor + emphasis + "] " + text)
-		width += utf8.RuneCountInString(count.glyph) + 1 + utf8.RuneCountInString(text)
 	}
 	// tmux attributes latch until something clears them; without this the
-	// return hint would inherit whichever tier happened to render last.
-	format.WriteString("#[default]")
-	return " " + format.String(), width + 1
+	// key hints would inherit whichever tier happened to render last.
+	return format.String() + statusDivider + "#[default]"
 }
 
 // PublishStatus writes the agent tally onto the managed session's status
 // bar. It is a no-op when the tally has not moved, so the dashboard can call
 // it on every poll and only the changes reach tmux.
 func (r *Runtime) PublishStatus(ctx context.Context, stats agent.Stats) error {
-	summary, width := statusSummary(stats)
+	summary := r.statusSummary(stats)
 	r.statusMu.Lock()
 	unchanged := summary == r.publishedStatus
 	r.statusMu.Unlock()
@@ -129,7 +182,9 @@ func (r *Runtime) PublishStatus(ctx context.Context, stats agent.Stats) error {
 	}
 	options := [][2]string{
 		{statusSummaryOption, summary},
-		{"status-right-length", strconv.Itoa(width + r.statusRightHintWidth())},
+		{statusWidthOption, r.statusWidth(stats)},
+		{"status-right-length", strconv.Itoa(
+			r.statusRightWidth(statusCounters(stats, true)))},
 	}
 	for _, option := range options {
 		if _, err := r.runner.Run(ctx, nil,
@@ -144,16 +199,54 @@ func (r *Runtime) PublishStatus(ctx context.Context, stats agent.Stats) error {
 	return nil
 }
 
-// statusRight is the whole right section: the tally, then the standing hint
-// for the key that leads back to the dashboard.
+// statusRight is the whole right section: the tally, then the standing hints
+// for the keys that leave this window.
 func (r *Runtime) statusRight() string {
-	return statusSummaryFormat + r.statusRightHint()
+	return statusSummaryFormat + r.statusRightKeys()
 }
 
-func (r *Runtime) statusRightHint() string {
-	return " " + r.effectiveReturnKeys()[0] + " ⏎ dashboard "
+// statusRightKeys names the two ways out of an agent: back to the dashboard,
+// and on to whoever is waiting next.
+func (r *Runtime) statusRightKeys() string {
+	return "  " +
+		statusKeyHint(r.effectiveReturnKeys()[0], "⏎ dashboard") + "  " +
+		statusKeyHint(r.effectiveNextKeys()[0], "↻ next") + " "
 }
 
-func (r *Runtime) statusRightHintWidth() int {
-	return utf8.RuneCountInString(r.statusRightHint())
+func statusKeyHint(key, label string) string {
+	return "#[fg=" + statusKeyColor + "]" + key +
+		"#[fg=" + statusLabelColor + "] " + label + "#[default]"
+}
+
+// statusWidth is the budget status-left yields to the right section, as a
+// format tmux resolves per client. status-right-length cannot serve: it is a
+// cap on the widest form, and reserving that on a narrow client would cut
+// the agent's own name short for space nothing occupies.
+func (r *Runtime) statusWidth(stats agent.Stats) string {
+	return statusByWidth(
+		r.statusWordsMinWidth(stats),
+		strconv.Itoa(r.statusRightWidth(statusCounters(stats, true))),
+		strconv.Itoa(r.statusRightWidth(statusCounters(stats, false))),
+	)
+}
+
+// statusRightWidth is the columns a rendering of the right section prints.
+// It is measured rather than counted: #[...] tags cost bytes and no columns.
+func (r *Runtime) statusRightWidth(counters string) int {
+	return formatWidth(counters) + formatWidth(r.statusRightKeys())
+}
+
+func formatWidth(format string) int {
+	var text strings.Builder
+	for index := 0; index < len(format); index++ {
+		if format[index] == '#' && index+1 < len(format) &&
+			format[index+1] == '[' {
+			if end := strings.IndexByte(format[index:], ']'); end >= 0 {
+				index += end
+				continue
+			}
+		}
+		text.WriteByte(format[index])
+	}
+	return ansi.StringWidth(text.String())
 }

--- a/internal/tmux/status.go
+++ b/internal/tmux/status.go
@@ -1,0 +1,159 @@
+package tmux
+
+import (
+	"context"
+	"fmt"
+	"strconv"
+	"strings"
+	"unicode/utf8"
+
+	"github.com/trentkm/stormlight/internal/agent"
+)
+
+// The status summary is the dashboard's header counters, shown on the band
+// of the managed session so the tally is readable from inside an agent. An
+// agent's window is where a human spends the minutes between glances at the
+// dashboard, and the question that sends them back — is anything else
+// waiting on me? — should not need a trip to find out.
+//
+// It is a session option that Stormlight writes rather than a format tmux
+// evaluates: the counts follow the same precedence the dashboard's row
+// glyphs do, marks included, which is inference no format language can
+// carry. status-right expands the option with #{E:...} so the styling
+// inside it applies.
+const (
+	statusSummaryOption = "@stormlight_status_summary"
+	statusSummaryFormat = "#{E:" + statusSummaryOption + "}"
+	// The band is a fixed sapphire whatever the terminal's background, so
+	// these are literal rather than resolved from internal/theme: they are
+	// the palette's dark-terminal entries, chosen against this band.
+	statusWorkingColor = "#61AFEF"
+	statusWaitingColor = "#E5C07B"
+	statusIdleColor    = "#8FA6CC"
+	statusLabelColor   = "#8FA6CC"
+)
+
+// statusCount is one counter on the band: the glyph the dashboard paints for
+// that state, the count, and the word for it.
+type statusCount struct {
+	glyph string
+	value int
+	label string
+	color string
+	loud  bool
+}
+
+// statusSummary renders the tally for the right of the band, and the columns
+// it occupies.
+//
+// The vocabulary is the dashboard header's, down to the glyphs and the
+// order, so the two read as one instrument rather than two reports of the
+// same thing. Empty tiers are left out — a bar that says "0 waiting" spends
+// columns to say nothing — and a session with no agents in it renders
+// nothing at all.
+func statusSummary(stats agent.Stats) (string, int) {
+	if stats.Total() == 0 {
+		return "", 0
+	}
+	counts := []statusCount{{
+		glyph: "●", value: stats.Working,
+		label: "working", color: statusWorkingColor,
+	}}
+	if stats.Waiting > 0 {
+		counts = append(counts, statusCount{
+			glyph: "○", value: stats.Waiting,
+			label: "waiting", color: statusWaitingColor,
+		})
+	}
+	if stats.Urgent > 0 {
+		label := "need input"
+		if stats.Urgent == 1 {
+			label = "needs input"
+		}
+		counts = append(counts, statusCount{
+			glyph: "!", value: stats.Urgent,
+			label: label, color: statusWaitingColor, loud: true,
+		})
+	}
+	if stats.Idle > 0 {
+		counts = append(counts, statusCount{
+			glyph: "○", value: stats.Idle,
+			label: "idle", color: statusIdleColor,
+		})
+	}
+
+	var format strings.Builder
+	width := 0
+	for index, count := range counts {
+		if index > 0 {
+			format.WriteString("  ")
+			width += 2
+		}
+		text := fmt.Sprintf("%d %s", count.value, count.label)
+		labelColor := statusLabelColor
+		emphasis := ""
+		if count.loud {
+			labelColor = count.color
+			// A comma inside #[...] ends the enclosing conditional branch
+			// unless it is escaped; status-right holds none today, but this
+			// string is one edit away from living inside one.
+			emphasis = "#,bold"
+		}
+		format.WriteString("#[fg=" + count.color + emphasis + "]" + count.glyph)
+		format.WriteString("#[fg=" + labelColor + emphasis + "] " + text)
+		width += utf8.RuneCountInString(count.glyph) + 1 + utf8.RuneCountInString(text)
+	}
+	// tmux attributes latch until something clears them; without this the
+	// return hint would inherit whichever tier happened to render last.
+	format.WriteString("#[default]")
+	return " " + format.String(), width + 1
+}
+
+// PublishStatus writes the agent tally onto the managed session's status
+// bar. It is a no-op when the tally has not moved, so the dashboard can call
+// it on every poll and only the changes reach tmux.
+func (r *Runtime) PublishStatus(ctx context.Context, stats agent.Stats) error {
+	summary, width := statusSummary(stats)
+	r.statusMu.Lock()
+	unchanged := summary == r.publishedStatus
+	r.statusMu.Unlock()
+	if unchanged {
+		return nil
+	}
+	// A session nobody has attached to yet is undressed, and writing the
+	// summary onto tmux's default bar would put Stormlight's counters in a
+	// stranger's chrome. Dressing it here means the band is right from the
+	// first agent, not from the first visit.
+	if err := r.configureStatusBar(ctx, r.sessionName); err != nil {
+		return err
+	}
+	options := [][2]string{
+		{statusSummaryOption, summary},
+		{"status-right-length", strconv.Itoa(width + r.statusRightHintWidth())},
+	}
+	for _, option := range options {
+		if _, err := r.runner.Run(ctx, nil,
+			"set-option", "-t", r.sessionName, option[0], option[1],
+		); err != nil {
+			return fmt.Errorf("publish %s: %w", option[0], err)
+		}
+	}
+	r.statusMu.Lock()
+	r.publishedStatus = summary
+	r.statusMu.Unlock()
+	return nil
+}
+
+// statusRight is the whole right section: the tally, then the standing hint
+// for the key that leads back to the dashboard.
+func (r *Runtime) statusRight() string {
+	return statusSummaryFormat + r.statusRightHint()
+}
+
+func (r *Runtime) statusRightHint() string {
+	return " " + r.effectiveReturnKeys()[0] + " ⏎ dashboard "
+}
+
+func (r *Runtime) statusRightHintWidth() int {
+	return utf8.RuneCountInString(r.statusRightHint())
+}

--- a/internal/tmux/status_test.go
+++ b/internal/tmux/status_test.go
@@ -12,26 +12,61 @@ import (
 )
 
 func TestStatusSummarySpeaksTheHeadersLanguage(t *testing.T) {
-	summary, _ := statusSummary(agent.Stats{
-		Working: 3, Waiting: 2, Urgent: 1, Idle: 4,
-	})
-	text := visibleText(summary)
+	stats := agent.Stats{Working: 3, Waiting: 2, Urgent: 1, Idle: 4}
+	text := visibleText(statusCounters(stats, true))
 	for _, want := range []string{
 		"● 3 working", "○ 2 waiting", "! 1 needs input", "○ 4 idle",
 	} {
 		if !strings.Contains(text, want) {
-			t.Fatalf("summary missing %q: %q", want, summary)
+			t.Fatalf("counters missing %q: %q", want, text)
 		}
 	}
-	if !strings.HasSuffix(summary, "#[default]") {
-		t.Fatalf("summary does not reset its styling: %q", summary)
+	if !strings.HasSuffix(statusCounters(stats, true), "#[default]") {
+		t.Fatalf("counters do not reset their styling: %q", text)
+	}
+}
+
+// A narrow client keeps the glyph and the number and drops the word: the
+// glyph is the dashboard's own and the header is its legend, while the key
+// hints have no such fallback, so they are what the columns go to.
+func TestStatusSummaryShedsWordsOnNarrowClients(t *testing.T) {
+	stats := agent.Stats{Working: 3, Waiting: 2}
+	narrow := visibleText(statusCounters(stats, false))
+	if strings.Contains(narrow, "working") || strings.Contains(narrow, "waiting") {
+		t.Fatalf("narrow counters kept their words: %q", narrow)
+	}
+	for _, want := range []string{"● 3", "○ 2"} {
+		if !strings.Contains(narrow, want) {
+			t.Fatalf("narrow counters missing %q: %q", want, narrow)
+		}
+	}
+
+	runtime := &Runtime{}
+	wide := runtime.statusRightWidth(statusCounters(stats, true))
+	// The words are affordable only once the lineage still has its floor
+	// left over — a fixed threshold crushes the agent's name exactly at the
+	// width where a four-tier tally spells itself out.
+	threshold := runtime.statusWordsMinWidth(stats)
+	if threshold != wide+statusLineageMinWidth {
+		t.Fatalf("threshold = %d, want %d", threshold, wide+statusLineageMinWidth)
+	}
+	summary := runtime.statusSummary(stats)
+	if !strings.HasPrefix(summary,
+		"#{?#{e|>=:#{client_width},"+strconv.Itoa(threshold)+"},") {
+		t.Fatalf("summary does not switch on the client width: %q", summary)
+	}
+	// The budget status-left yields has to switch on the same width, or the
+	// name would be cut for space the narrow form never takes.
+	if want := statusByWidth(threshold, strconv.Itoa(wide),
+		strconv.Itoa(runtime.statusRightWidth(statusCounters(stats, false)))); runtime.statusWidth(stats) != want {
+		t.Fatalf("width budget = %q, want %q", runtime.statusWidth(stats), want)
 	}
 }
 
 // Empty tiers spend columns to say nothing, and the working count is the one
 // the dashboard header always shows.
 func TestStatusSummaryOmitsEmptyTiers(t *testing.T) {
-	summary, _ := statusSummary(agent.Stats{Working: 1})
+	summary := statusCounters(agent.Stats{Working: 1}, true)
 	if strings.Contains(summary, "waiting") ||
 		strings.Contains(summary, "idle") ||
 		strings.Contains(summary, "input") {
@@ -40,20 +75,49 @@ func TestStatusSummaryOmitsEmptyTiers(t *testing.T) {
 	if !strings.Contains(visibleText(summary), "● 1 working") {
 		t.Fatalf("summary = %q", summary)
 	}
-	if summary, width := statusSummary(agent.Stats{}); summary != "" || width != 0 {
-		t.Fatalf("empty session summary = %q (%d columns)", summary, width)
+	if summary := (&Runtime{}).statusSummary(agent.Stats{}); summary != "" {
+		t.Fatalf("empty session summary = %q", summary)
 	}
 }
 
 // The width is what status-left is truncated against, so it counts printed
-// columns rather than the bytes tmux markup takes to say them.
-func TestStatusSummaryWidthCountsColumnsNotMarkup(t *testing.T) {
-	summary, width := statusSummary(agent.Stats{Working: 2, Urgent: 1})
-	if got := len(summary); got <= width {
-		t.Fatalf("markup was counted as columns: %d bytes, %d columns", got, width)
+// columns rather than the bytes tmux markup takes to say them — a right
+// section measured in bytes cuts the agent's own name short for space
+// nothing occupies.
+func TestStatusRightWidthCountsColumnsNotMarkup(t *testing.T) {
+	runtime := &Runtime{}
+	summary := statusCounters(agent.Stats{Working: 2, Urgent: 1}, true)
+	width := runtime.statusRightWidth(summary)
+	printed := visibleWidth(summary) + visibleWidth(runtime.statusRightKeys())
+	if width != printed {
+		t.Fatalf("width = %d, want %d", width, printed)
 	}
-	if got := visibleWidth(summary); got != width {
-		t.Fatalf("width = %d, want %d (%q)", width, got, summary)
+	if bytes := len(summary) + len(runtime.statusRightKeys()); bytes <= width {
+		t.Fatalf("markup was counted as columns: %d bytes, %d columns", bytes, width)
+	}
+}
+
+// The counters and the key hints are two different kinds of thing — one is
+// news, the other standing chrome — and with nothing between them they read
+// as one run of small text.
+func TestStatusRightSeparatesTheTallyFromTheKeys(t *testing.T) {
+	runtime := &Runtime{}
+	for _, words := range []bool{true, false} {
+		counters := statusCounters(agent.Stats{Working: 1}, words)
+		if !strings.HasSuffix(visibleText(counters), "│") {
+			t.Fatalf("tally does not close with a divider: %q", counters)
+		}
+	}
+	keys := visibleText(runtime.statusRightKeys())
+	for _, want := range []string{"C-6 ⏎ dashboard", "C-] ↻ next"} {
+		if !strings.Contains(keys, want) {
+			t.Fatalf("key hints missing %q: %q", want, keys)
+		}
+	}
+	// With no agents there is no tally, so there is no rule to hang the
+	// keys off either.
+	if runtime.statusSummary(agent.Stats{}) != "" {
+		t.Fatal("an empty session still drew a divider")
 	}
 }
 
@@ -65,12 +129,14 @@ func TestPublishStatusWritesTheTallyOnce(t *testing.T) {
 	if err := runtime.PublishStatus(context.Background(), stats); err != nil {
 		t.Fatal(err)
 	}
-	summary, width := statusSummary(stats)
 	want := [][]string{
 		{"show-options", "-qv", "-t", "stormlight-agents", statusVersionOption},
-		{"set-option", "-t", "stormlight-agents", statusSummaryOption, summary},
+		{"set-option", "-t", "stormlight-agents", statusSummaryOption,
+			runtime.statusSummary(stats)},
+		{"set-option", "-t", "stormlight-agents", statusWidthOption,
+			runtime.statusWidth(stats)},
 		{"set-option", "-t", "stormlight-agents", "status-right-length",
-			strconv.Itoa(width + runtime.statusRightHintWidth())},
+			strconv.Itoa(runtime.statusRightWidth(statusCounters(stats, true)))},
 	}
 	assertCalls(t, runner.calls, want)
 
@@ -83,7 +149,7 @@ func TestPublishStatusWritesTheTallyOnce(t *testing.T) {
 	if err := runtime.PublishStatus(context.Background(), agent.Stats{Working: 2}); err != nil {
 		t.Fatal(err)
 	}
-	if len(runner.calls) != len(want)+3 {
+	if len(runner.calls) != len(want)+4 {
 		t.Fatalf("a changed tally was not published: %#v", runner.calls)
 	}
 }

--- a/internal/tmux/status_test.go
+++ b/internal/tmux/status_test.go
@@ -1,0 +1,132 @@
+package tmux
+
+import (
+	"context"
+	"slices"
+	"strconv"
+	"strings"
+	"testing"
+
+	"github.com/charmbracelet/x/ansi"
+	"github.com/trentkm/stormlight/internal/agent"
+)
+
+func TestStatusSummarySpeaksTheHeadersLanguage(t *testing.T) {
+	summary, _ := statusSummary(agent.Stats{
+		Working: 3, Waiting: 2, Urgent: 1, Idle: 4,
+	})
+	text := visibleText(summary)
+	for _, want := range []string{
+		"● 3 working", "○ 2 waiting", "! 1 needs input", "○ 4 idle",
+	} {
+		if !strings.Contains(text, want) {
+			t.Fatalf("summary missing %q: %q", want, summary)
+		}
+	}
+	if !strings.HasSuffix(summary, "#[default]") {
+		t.Fatalf("summary does not reset its styling: %q", summary)
+	}
+}
+
+// Empty tiers spend columns to say nothing, and the working count is the one
+// the dashboard header always shows.
+func TestStatusSummaryOmitsEmptyTiers(t *testing.T) {
+	summary, _ := statusSummary(agent.Stats{Working: 1})
+	if strings.Contains(summary, "waiting") ||
+		strings.Contains(summary, "idle") ||
+		strings.Contains(summary, "input") {
+		t.Fatalf("summary carried an empty tier: %q", summary)
+	}
+	if !strings.Contains(visibleText(summary), "● 1 working") {
+		t.Fatalf("summary = %q", summary)
+	}
+	if summary, width := statusSummary(agent.Stats{}); summary != "" || width != 0 {
+		t.Fatalf("empty session summary = %q (%d columns)", summary, width)
+	}
+}
+
+// The width is what status-left is truncated against, so it counts printed
+// columns rather than the bytes tmux markup takes to say them.
+func TestStatusSummaryWidthCountsColumnsNotMarkup(t *testing.T) {
+	summary, width := statusSummary(agent.Stats{Working: 2, Urgent: 1})
+	if got := len(summary); got <= width {
+		t.Fatalf("markup was counted as columns: %d bytes, %d columns", got, width)
+	}
+	if got := visibleWidth(summary); got != width {
+		t.Fatalf("width = %d, want %d (%q)", width, got, summary)
+	}
+}
+
+func TestPublishStatusWritesTheTallyOnce(t *testing.T) {
+	runner := &captureRunner{feedbackVersion: statusVersion}
+	runtime := &Runtime{runner: runner, sessionName: "stormlight-agents"}
+	stats := agent.Stats{Working: 1, Waiting: 2}
+
+	if err := runtime.PublishStatus(context.Background(), stats); err != nil {
+		t.Fatal(err)
+	}
+	summary, width := statusSummary(stats)
+	want := [][]string{
+		{"show-options", "-qv", "-t", "stormlight-agents", statusVersionOption},
+		{"set-option", "-t", "stormlight-agents", statusSummaryOption, summary},
+		{"set-option", "-t", "stormlight-agents", "status-right-length",
+			strconv.Itoa(width + runtime.statusRightHintWidth())},
+	}
+	assertCalls(t, runner.calls, want)
+
+	// The dashboard publishes on every poll; only movement reaches tmux.
+	if err := runtime.PublishStatus(context.Background(), stats); err != nil {
+		t.Fatal(err)
+	}
+	assertCalls(t, runner.calls, want)
+
+	if err := runtime.PublishStatus(context.Background(), agent.Stats{Working: 2}); err != nil {
+		t.Fatal(err)
+	}
+	if len(runner.calls) != len(want)+3 {
+		t.Fatalf("a changed tally was not published: %#v", runner.calls)
+	}
+}
+
+// A session nobody has visited yet has tmux's own bar; the counters belong in
+// Stormlight's chrome, so publishing dresses it first.
+func TestPublishStatusDressesAnUnvisitedSession(t *testing.T) {
+	runner := &captureRunner{}
+	runtime := &Runtime{runner: runner, sessionName: "stormlight-agents"}
+
+	if err := runtime.PublishStatus(context.Background(), agent.Stats{Working: 1}); err != nil {
+		t.Fatal(err)
+	}
+	dressed := false
+	for _, call := range runner.calls {
+		if slices.Equal(call, []string{
+			"set-option", "-t", "stormlight-agents", "status-format[0]", statusFormat,
+		}) {
+			dressed = true
+		}
+	}
+	if !dressed {
+		t.Fatalf("status bar was not dressed before publishing: %#v", runner.calls)
+	}
+}
+
+func visibleWidth(format string) int {
+	return ansi.StringWidth(visibleText(format))
+}
+
+// visibleText is what a terminal prints of a tmux format: the text with
+// every #[...] tag removed.
+func visibleText(format string) string {
+	var text strings.Builder
+	for index := 0; index < len(format); index++ {
+		if format[index] == '#' && index+1 < len(format) && format[index+1] == '[' {
+			end := strings.IndexByte(format[index:], ']')
+			if end >= 0 {
+				index += end
+				continue
+			}
+		}
+		text.WriteByte(format[index])
+	}
+	return text.String()
+}

--- a/internal/tmux/status_test.go
+++ b/internal/tmux/status_test.go
@@ -109,7 +109,8 @@ func TestStatusRightSeparatesTheTallyFromTheKeys(t *testing.T) {
 		}
 	}
 	keys := visibleText(runtime.statusRightKeys())
-	for _, want := range []string{"C-6 ⏎ dashboard", "C-] ↻ next"} {
+	// The queue keys share one label and sit in the order they move.
+	for _, want := range []string{"C-6 ⏎ dashboard", `C-\ C-] ↻ queue`} {
 		if !strings.Contains(keys, want) {
 			t.Fatalf("key hints missing %q: %q", want, keys)
 		}

--- a/internal/ui/agents.go
+++ b/internal/ui/agents.go
@@ -340,56 +340,15 @@ const (
 	tierUrgent
 )
 
-func attentionTierOf(urgent, waiting int) attentionTier {
+func attentionTierOf(stats agent.Stats) attentionTier {
 	switch {
-	case urgent > 0:
+	case stats.Urgent > 0:
 		return tierUrgent
-	case waiting > 0:
+	case stats.Waiting > 0:
 		return tierWaiting
 	default:
 		return tierNone
 	}
-}
-
-// workspaceStats counts a workspace's agents into the same triage buckets the
-// rows use, marks included: a corrected row is corrected in the counters too,
-// or the summary would keep reporting the reading the human overruled.
-func workspaceStats(agents []agent.Agent) (active, urgent, waiting int) {
-	for _, managedAgent := range agents {
-		if agentCountsActive(managedAgent) {
-			active++
-		}
-		if !managedAgent.ProcessLive {
-			// A dead pane can't be waiting on anyone; its exit status is
-			// the story.
-			continue
-		}
-		switch managedAgent.EffectiveMark() {
-		case agent.MarkWorking:
-			// The human said it is still going; nothing is pending on them.
-			continue
-		case agent.MarkAttention:
-			waiting++
-			continue
-		}
-		switch {
-		case managedAgent.Attention.Urgent():
-			urgent++
-		case managedAgent.Attention == agent.AttentionWaiting:
-			waiting++
-		}
-	}
-	return active, urgent, waiting
-}
-
-// agentCountsActive reports whether an agent belongs in the "active" tally —
-// running by Stormlight's reading, or by the human's.
-func agentCountsActive(managedAgent agent.Agent) bool {
-	if managedAgent.EffectiveMark() == agent.MarkWorking {
-		return true
-	}
-	return managedAgent.Activity == agent.ActivityWorking ||
-		managedAgent.Activity == agent.ActivityStarting
 }
 
 func agentLocation(managedAgent agent.Agent) string {

--- a/internal/ui/flows_test.go
+++ b/internal/ui/flows_test.go
@@ -655,9 +655,9 @@ func TestMarkedRowsReportTheMarkAndClearWhenSeen(t *testing.T) {
 		t.Fatalf("attention row = %q", row)
 	}
 
-	active, urgent, waiting := workspaceStats([]agent.Agent{working, attention})
-	if active != 1 || urgent != 0 || waiting != 1 {
-		t.Fatalf("stats: active=%d urgent=%d waiting=%d", active, urgent, waiting)
+	stats := agent.Count([]agent.Agent{working, attention})
+	if stats.Working != 1 || stats.Urgent != 0 || stats.Waiting != 1 {
+		t.Fatalf("stats = %+v", stats)
 	}
 
 	ws := workspace.DirectoryContext("/workspace/marks")

--- a/internal/ui/input_test.go
+++ b/internal/ui/input_test.go
@@ -1675,7 +1675,8 @@ func TestWorkspaceShimmerSweepsWithStableWidth(t *testing.T) {
 	group := workspaceGroup{
 		context: value,
 		agents: []agent.Agent{{
-			Activity: agent.ActivityWorking,
+			Activity:    agent.ActivityWorking,
+			ProcessLive: true,
 		}},
 	}
 

--- a/internal/ui/layout.go
+++ b/internal/ui/layout.go
@@ -12,12 +12,13 @@ import (
 	tea "charm.land/bubbletea/v2"
 	"charm.land/lipgloss/v2"
 	"github.com/charmbracelet/x/ansi"
+	"github.com/trentkm/stormlight/internal/agent"
 	"github.com/trentkm/stormlight/internal/theme"
 )
 
 func (m Model) renderHeader() string {
 	width := max(1, m.width-1)
-	working, urgent, waiting := workspaceStats(m.agents)
+	stats := agent.Count(m.agents)
 	// No chrome: the wordmark's own gradient is the identity, floating on
 	// the terminal background with the counters at the far edge.
 	left := renderWordmark(m.shimmerPhaseOrRest())
@@ -26,15 +27,15 @@ func (m Model) renderHeader() string {
 	// legend for everything below it.
 	counts := []string{
 		renderHeaderCount("●", colorWorking(), false,
-			fmt.Sprintf("%d working", working)),
+			fmt.Sprintf("%d working", stats.Working)),
 	}
-	if waiting > 0 {
+	if stats.Waiting > 0 {
 		counts = append(counts, renderHeaderCount("○", colorWaiting(), false,
-			fmt.Sprintf("%d waiting", waiting)))
+			fmt.Sprintf("%d waiting", stats.Waiting)))
 	}
-	if urgent > 0 {
-		attentionLabel := fmt.Sprintf("%d need input", urgent)
-		if urgent == 1 {
+	if stats.Urgent > 0 {
+		attentionLabel := fmt.Sprintf("%d need input", stats.Urgent)
+		if stats.Urgent == 1 {
 			attentionLabel = "1 needs input"
 		}
 		counts = append(counts,

--- a/internal/ui/model.go
+++ b/internal/ui/model.go
@@ -859,12 +859,7 @@ func marksResultSeen(key string, active pane) bool {
 }
 
 func (m Model) anyAgentsActive() bool {
-	for _, managedAgent := range m.agents {
-		if agentCountsActive(managedAgent) {
-			return true
-		}
-	}
-	return false
+	return agent.Count(m.agents).Working > 0
 }
 
 // shimmerPhaseOrRest returns the sweep phase while the shimmer is running

--- a/internal/ui/state.go
+++ b/internal/ui/state.go
@@ -117,12 +117,12 @@ func (m *Model) applySort() {
 		})
 	case sortByAttention:
 		slices.SortStableFunc(m.groups, func(a, b workspaceGroup) int {
-			_, urgentA, waitingA := workspaceStats(a.agents)
-			_, urgentB, waitingB := workspaceStats(b.agents)
-			if d := urgentB - urgentA; d != 0 {
+			statsA := agent.Count(a.agents)
+			statsB := agent.Count(b.agents)
+			if d := statsB.Urgent - statsA.Urgent; d != 0 {
 				return d
 			}
-			return waitingB - waitingA
+			return statsB.Waiting - statsA.Waiting
 		})
 	}
 }

--- a/internal/ui/workspaces.go
+++ b/internal/ui/workspaces.go
@@ -12,6 +12,7 @@ import (
 	tea "charm.land/bubbletea/v2"
 	"charm.land/lipgloss/v2"
 	"github.com/charmbracelet/x/ansi"
+	"github.com/trentkm/stormlight/internal/agent"
 	"github.com/trentkm/stormlight/internal/workspace"
 )
 
@@ -122,7 +123,7 @@ func (m Model) renderWorkspaceRow(
 	width int,
 	danger bool,
 ) string {
-	active, urgent, waiting := workspaceStats(group.agents)
+	stats := agent.Count(group.agents)
 	contentWidth := max(1, width-1)
 	// What the name actually asks for, floored so a long one still yields
 	// ground to the chips rather than shouldering them off the row.
@@ -131,7 +132,7 @@ func (m Model) renderWorkspaceRow(
 		min(10, max(1, contentWidth/2)),
 	)
 	chips := fitCountChips(
-		workspaceCountChips(active, urgent, waiting, len(group.agents)),
+		workspaceCountChips(stats, len(group.agents)),
 		max(1, contentWidth-lipgloss.Width("  ")-1),
 		nameNeed,
 	)
@@ -159,7 +160,7 @@ func (m Model) renderWorkspaceRow(
 	// selected row's marker column supplies the other, and the quiet path
 	// adds its own, so the subtitle never shifts with selection.
 	bottomContent := " " + workspaceDetail(group.context, max(1, contentWidth-2))
-	tier := attentionTierOf(urgent, waiting)
+	tier := attentionTierOf(stats)
 	if focused || danger {
 		return renderSelectedWorkspaceRow(
 			" ",
@@ -170,7 +171,7 @@ func (m Model) renderWorkspaceRow(
 			width,
 			focused,
 			m.expandedRows(),
-			active > 0,
+			stats.Working > 0,
 			tier,
 			m.shimmerPhaseOrRest(),
 			rowThemeFor(danger),
@@ -186,7 +187,7 @@ func (m Model) renderWorkspaceRow(
 			Foreground(colorWaiting()).
 			Bold(true).
 			Render(name)
-	case active > 0:
+	case stats.Working > 0:
 		renderedName = shimmerText(name, m.shimmerPhaseOrRest(), nil)
 	}
 	top := gutter +
@@ -215,22 +216,22 @@ type countChip struct {
 // workspaceCountChips orders the tiers loudest first. A workspace with
 // nothing pending reports its population instead, in the muted dot the agent
 // rows use for a state worth no alarm — including the honest "· 0".
-func workspaceCountChips(active, urgent, waiting, total int) []countChip {
+func workspaceCountChips(stats agent.Stats, total int) []countChip {
 	chips := make([]countChip, 0, 3)
-	if urgent > 0 {
+	if stats.Urgent > 0 {
 		chips = append(chips, countChip{
-			"!", urgent,
+			"!", stats.Urgent,
 			lipgloss.NewStyle().Foreground(colorWaiting()).Bold(true),
 		})
 	}
-	if waiting > 0 {
+	if stats.Waiting > 0 {
 		chips = append(chips, countChip{
-			"○", waiting, lipgloss.NewStyle().Foreground(colorWaiting()),
+			"○", stats.Waiting, lipgloss.NewStyle().Foreground(colorWaiting()),
 		})
 	}
-	if active > 0 {
+	if stats.Working > 0 {
 		chips = append(chips, countChip{
-			"●", active, lipgloss.NewStyle().Foreground(colorWorking()),
+			"●", stats.Working, lipgloss.NewStyle().Foreground(colorWorking()),
 		})
 	}
 	if len(chips) == 0 {

--- a/main.go
+++ b/main.go
@@ -475,6 +475,9 @@ func newService(socket, sessionName string, cfg config.Config) (*app.Service, er
 	if len(cfg.Tmux.NextKeys) > 0 {
 		runtime.SetNextKeys(cfg.Tmux.NextKeys)
 	}
+	if len(cfg.Tmux.PreviousKeys) > 0 {
+		runtime.SetPreviousKeys(cfg.Tmux.PreviousKeys)
+	}
 	registry := provider.NewRegistryWithSpecs(providerSpecs(cfg))
 	return app.NewService(runtime, registry, workspace.NewRegistry()), nil
 }
@@ -728,13 +731,15 @@ func newNextCommand(socket, sessionName *string, cfg config.Config) *cobra.Comma
 	var client string
 	var window string
 	var agentID string
+	var previous bool
 
 	command := &cobra.Command{
 		Use:   "next",
 		Short: "Switch to the next agent waiting on you",
 		Long: "Hand the terminal the next agent in the attention queue, " +
-			"oldest first. From inside an agent the queue advances past it; " +
-			"from anywhere else it starts at the head.",
+			"oldest first. From inside an agent the queue steps past it; " +
+			"from anywhere else it starts at the end it came from. Visiting " +
+			"an agent leaves its attention exactly as it was.",
 		RunE: func(cmd *cobra.Command, args []string) error {
 			service, err := newService(*socket, *sessionName, cfg)
 			if err != nil {
@@ -744,10 +749,15 @@ func newNextCommand(socket, sessionName *string, cfg config.Config) *cobra.Comma
 			if !ok {
 				return fmt.Errorf("the queue needs a tmux runtime")
 			}
+			step := agent.QueueForward
+			if previous {
+				step = agent.QueueBack
+			}
 			return runtime.NextWaiting(cmd.Context(), tmux.NextRequest{
 				Client: client,
 				Window: window,
 				Agent:  agentID,
+				Step:   step,
 			})
 		},
 	}
@@ -756,7 +766,9 @@ func newNextCommand(socket, sessionName *string, cfg config.Config) *cobra.Comma
 	command.Flags().StringVar(&window, "window", "",
 		"tmux window the request came from")
 	command.Flags().StringVar(&agentID, "agent", "",
-		"agent the request came from; the queue advances past it")
+		"agent the request came from; the queue steps past it")
+	command.Flags().BoolVar(&previous, "previous", false,
+		"step back through the queue instead of forward")
 	return command
 }
 

--- a/main.go
+++ b/main.go
@@ -131,6 +131,7 @@ func newRootCommand() *cobra.Command {
 		newStopCommand(&socket, &sessionName, cfg),
 		newDeleteCommand(&socket, &sessionName, cfg),
 		newMarkCommand(&socket, &sessionName, cfg),
+		newNextCommand(&socket, &sessionName, cfg),
 		newEventCommand(&socket, &sessionName, cfg),
 		newProviderEventCommand(&socket, &sessionName, cfg),
 		newLogsCommand(&logFile),
@@ -471,6 +472,9 @@ func newService(socket, sessionName string, cfg config.Config) (*app.Service, er
 	if len(cfg.Tmux.ReturnKeys) > 0 {
 		runtime.SetReturnKeys(cfg.Tmux.ReturnKeys)
 	}
+	if len(cfg.Tmux.NextKeys) > 0 {
+		runtime.SetNextKeys(cfg.Tmux.NextKeys)
+	}
 	registry := provider.NewRegistryWithSpecs(providerSpecs(cfg))
 	return app.NewService(runtime, registry, workspace.NewRegistry()), nil
 }
@@ -714,6 +718,46 @@ func newMarkCommand(socket, sessionName *string, cfg config.Config) *cobra.Comma
 			return service.SetMark(cmd.Context(), args[0], mark)
 		},
 	}
+}
+
+// newNextCommand is what the tmux queue keys invoke. The ordering it applies
+// depends on marks and on when each agent started waiting — inference tmux
+// formats cannot rank — so the binding calls back into the binary that keeps
+// that record rather than trying to express it as a format.
+func newNextCommand(socket, sessionName *string, cfg config.Config) *cobra.Command {
+	var client string
+	var window string
+	var agentID string
+
+	command := &cobra.Command{
+		Use:   "next",
+		Short: "Switch to the next agent waiting on you",
+		Long: "Hand the terminal the next agent in the attention queue, " +
+			"oldest first. From inside an agent the queue advances past it; " +
+			"from anywhere else it starts at the head.",
+		RunE: func(cmd *cobra.Command, args []string) error {
+			service, err := newService(*socket, *sessionName, cfg)
+			if err != nil {
+				return err
+			}
+			runtime, ok := service.Runtime().(*tmux.Runtime)
+			if !ok {
+				return fmt.Errorf("the queue needs a tmux runtime")
+			}
+			return runtime.NextWaiting(cmd.Context(), tmux.NextRequest{
+				Client: client,
+				Window: window,
+				Agent:  agentID,
+			})
+		},
+	}
+	command.Flags().StringVar(&client, "client", "",
+		"tmux client to switch (default: the current one)")
+	command.Flags().StringVar(&window, "window", "",
+		"tmux window the request came from")
+	command.Flags().StringVar(&agentID, "agent", "",
+		"agent the request came from; the queue advances past it")
+	return command
 }
 
 func newEventCommand(socket, sessionName *string, cfg config.Config) *cobra.Command {


### PR DESCRIPTION
An agent's window is where the minutes between glances at the dashboard are
actually spent, and two questions kept sending people back to it: *is anything
else waiting on me*, and *which one next*. Both are now answered without
leaving.

## The tally on the bar (#85)

The right of the managed session's status bar carries the dashboard's own
counters — working, waiting, needing input, idle — in the same glyphs and words
the header uses:

```
 ✦ stormlight › alpha        ● 1 working  ○ 1 waiting  ! 1 needs input  C-6 ⏎ dashboard
```

It is a session option Stormlight writes rather than a format tmux evaluates:
the tiers follow the precedence the row glyphs do, marks included, which is
inference no format language carries. It is published from the application
service's listing — a listing is the only thing that notices a pane dying — and
a tally that has not moved is not rewritten, so a polling dashboard costs
nothing.

The issue asks for *waiting / active / idle*; the bar says **working** where
the issue says active, because that is the word the dashboard header already
uses for the same number, and two names for one count is worse than either
name.

That tally also had two derivations to begin with — the header's and the
workspace rows' — and now has one, in `internal/agent`. The buckets partition
the agents instead of overlapping, so they add up to what they describe: an
agent lands where its own row glyph says it does, and a dead pane counts as
exited rather than as still working.

## The queue (#84)

`M-n` hands you the next agent waiting, oldest first; the prefix `N` does the
same for anyone whose agent TUI needs the single-press key. Both are
configurable (`tmux.next_keys`).

The queue is arrival order — when an agent started waiting, not when it was
dispatched — recorded by a new `@stormlight_attention_at` stamp written on the
way into the amber inbox and cleared on the way out. It records entry, not the
latest signal, so a summary or an escalation arriving mid-wait does not send an
agent to the back of a line it never left.

Arriving clears soft attention exactly as opening a terminal from the dashboard
does, so the queue drains as it is worked. Urgent attention stays — only
answering a question or an approval resolves it — so instead of clearing it the
cycle steps past, which is why the key advances from where you are rather than
always returning the head. The window you arrive in inherits the return target
of the one you left, or the return key would strand you wherever the cycle
stopped.

The binding re-invokes Stormlight through a new `next` subcommand rather than
expressing the choice as a tmux format, for the same reason the tally is
written rather than computed. Outside Stormlight's own windows the key passes
straight through to the pane, and a foreign binding on either key is left alone
with a warning — unlike the return key, the queue is not how you escape an
agent.

## Verification

Beyond the unit tests, end to end on an isolated server (tmux 3.7b): three
agents, two raised into the queue two seconds apart. The bar rendered
`● 1 working  ○ 1 waiting  ! 1 needs input` at 80 columns beside the lineage;
`M-n` typed by a real client walked head, next, then reported no other agent
waiting while leaving the open question amber; and in a window without
`@stormlight_id` the same key arrived at the pane as `^[n`.

Fixes #85
Fixes #84