### PR TITLE
Give the terminal whole frames, not half-drawn ones

### DIFF
--- a/internal/tmux/config.go
+++ b/internal/tmux/config.go
@@ -23,6 +23,16 @@ set -s escape-time 10
 set -s focus-events on
 set -s extended-keys on
 set -as terminal-features 'xterm*:extkeys'
+# Draw whole frames, not the strokes that make them. Without synchronized
+# output tmux hands a redraw to the terminal as it produces it, so a full
+# repaint is rendered mid-flight and the cursor is seen walking the screen
+# before it lands. tmux uses it whenever the client's terminfo carries Sync,
+# which real terminals do — but a Stormlight client attached from inside
+# another tmux sees TERM=tmux-256color, whose terminfo has no Sync and whose
+# built-in feature list omits it, so exactly that arrangement lost the
+# guarantee. Claiming it for every terminal is safe: a terminal that does not
+# implement DECSET 2026 ignores the sequence, which is today's behavior.
+set -as terminal-features ',*:sync'
 set -g history-limit 50000
 set -g mouse on
 # Yazi and other overlays probe the real terminal through tmux passthrough
@@ -31,7 +41,12 @@ set -g mouse on
 # that lands mid-probe on whichever pane the popup sits over; enabling it
 # server-wide from boot removes the race and also lets image protocols
 # through.
-set -g allow-passthrough all
+#
+# "on" and not "all": "all" extends the bypass to panes the client is not
+# showing, and a bypass is a write straight to the terminal — an agent in a
+# background window can then move the cursor or paint over the agent being
+# read. Popups, which is what this exists for, pass through under "on".
+set -g allow-passthrough on
 `
 
 // serverOptions mirrors the option lines in serverConfig that must also
@@ -39,8 +54,16 @@ set -g allow-passthrough all
 // server start, and the appliance server outlives Stormlight upgrades as
 // long as any agent keeps it alive.
 var serverOptions = [][2]string{
-	{"allow-passthrough", "all"},
+	{"allow-passthrough", "on"},
 }
+
+// serverFeatures mirrors serverConfig's terminal-features lines, which the
+// same upgrade problem reaches. They append rather than assign, so asserting
+// them on a live server has to be idempotent — every dashboard launch would
+// otherwise grow the array by one entry for as long as the server lives. A
+// client already attached keeps the features it opened with; the next one to
+// attach, which is the client that walks into an agent, gets these.
+var serverFeatures = []string{"*:sync"}
 
 // EnsureServerConfig writes Stormlight's tmux configuration into the given
 // directory and returns its path. The file is rewritten every time so

--- a/internal/tmux/config_test.go
+++ b/internal/tmux/config_test.go
@@ -23,6 +23,24 @@ func TestEnsureServerConfigWritesManagedConfig(t *testing.T) {
 	}
 }
 
+// The boot config and the live-apply list are two halves of one statement:
+// a fresh server reads the file, a running one gets the options asserted. A
+// value declared in only one of them reaches only half the servers.
+func TestServerConfigAndOptionsAgree(t *testing.T) {
+	for _, option := range serverOptions {
+		line := "set -g " + option[0] + " " + option[1]
+		if !strings.Contains(serverConfig, line) {
+			t.Fatalf("serverConfig is missing %q", line)
+		}
+	}
+	for _, feature := range serverFeatures {
+		line := "set -as terminal-features '," + feature + "'"
+		if !strings.Contains(serverConfig, line) {
+			t.Fatalf("serverConfig is missing %q", line)
+		}
+	}
+}
+
 func TestEnsureServerConfigOverwritesDrift(t *testing.T) {
 	directory := t.TempDir()
 	path, err := EnsureServerConfig(directory)

--- a/internal/tmux/runtime.go
+++ b/internal/tmux/runtime.go
@@ -10,6 +10,7 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
+	"slices"
 	"strconv"
 	"strings"
 	"time"
@@ -799,14 +800,56 @@ func (r *Runtime) ApplyServerOptions(ctx context.Context) error {
 		if _, err := r.runner.Run(ctx, nil,
 			"set-option", "-g", option[0], option[1],
 		); err != nil {
-			if strings.Contains(err.Error(), "no server running") ||
-				strings.Contains(err.Error(), "failed to connect to server") {
+			if isNoServerError(err) {
 				return nil
 			}
 			return fmt.Errorf("apply server option %s: %w", option[0], err)
 		}
 	}
+	return r.applyServerFeatures(ctx)
+}
+
+// applyServerFeatures appends serverFeatures to a running server's
+// terminal-features, skipping any the server already carries.
+func (r *Runtime) applyServerFeatures(ctx context.Context) error {
+	current, err := r.runner.Run(ctx, nil, "show-options", "-s", "terminal-features")
+	if err != nil {
+		if isNoServerError(err) {
+			return nil
+		}
+		return fmt.Errorf("read terminal features: %w", err)
+	}
+	declared := declaredFeatures(current)
+	for _, feature := range serverFeatures {
+		if slices.Contains(declared, feature) {
+			continue
+		}
+		// The leading comma is the separator tmux splits the appended value
+		// on; without it the entry reads as one more feature of the previous
+		// terminal pattern.
+		if _, err := r.runner.Run(ctx, nil,
+			"set-option", "-sa", "terminal-features", ","+feature,
+		); err != nil {
+			return fmt.Errorf("apply terminal feature %s: %w", feature, err)
+		}
+	}
 	return nil
+}
+
+// declaredFeatures reads the values out of `show-options -s
+// terminal-features`, whose lines look like `terminal-features[0] xterm*:RGB`.
+// Whole entries are compared, never substrings: "xterm*:sync" contains
+// "*:sync" while promising it to nothing but xterm.
+func declaredFeatures(listing string) []string {
+	var values []string
+	for _, line := range strings.Split(listing, "\n") {
+		_, value, found := strings.Cut(strings.TrimSpace(line), " ")
+		if !found {
+			continue
+		}
+		values = append(values, strings.Trim(strings.TrimSpace(value), `"'`))
+	}
+	return values
 }
 
 type windowTarget struct {

--- a/internal/tmux/runtime_test.go
+++ b/internal/tmux/runtime_test.go
@@ -568,7 +568,9 @@ func TestApplyServerOptionsAssertsPassthroughOnLiveServer(t *testing.T) {
 	if err := runtime.ApplyServerOptions(context.Background()); err != nil {
 		t.Fatal(err)
 	}
-	want := []string{"set-option", "-g", "allow-passthrough", "all"}
+	// "on" and not "all": under "all" a pane the client is not showing may
+	// write straight to the terminal.
+	want := []string{"set-option", "-g", "allow-passthrough", "on"}
 	found := false
 	for _, call := range runner.calls {
 		if slices.Equal(call, want) {
@@ -577,6 +579,79 @@ func TestApplyServerOptionsAssertsPassthroughOnLiveServer(t *testing.T) {
 	}
 	if !found {
 		t.Fatalf("allow-passthrough was not asserted: %#v", runner.calls)
+	}
+}
+
+func TestApplyServerOptionsAppendsSyncOnLiveServer(t *testing.T) {
+	runner := &captureRunner{
+		terminalFeatures: "terminal-features[0] xterm*:clipboard:cstyle\n" +
+			"terminal-features[1] *:RGB\n",
+	}
+	runtime, err := NewRuntime(runner, "stormlight-agents")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := runtime.ApplyServerOptions(context.Background()); err != nil {
+		t.Fatal(err)
+	}
+	want := []string{"set-option", "-sa", "terminal-features", ",*:sync"}
+	found := false
+	for _, call := range runner.calls {
+		if slices.Equal(call, want) {
+			found = true
+		}
+	}
+	if !found {
+		t.Fatalf("sync feature was not appended: %#v", runner.calls)
+	}
+}
+
+// A server that already carries the feature is left alone: the option
+// appends, so re-asserting it on every dashboard launch would grow the array
+// for as long as the server lives.
+func TestApplyServerOptionsLeavesDeclaredFeaturesAlone(t *testing.T) {
+	runner := &captureRunner{
+		terminalFeatures: "terminal-features[0] xterm*:clipboard\n" +
+			"terminal-features[1] *:sync\n",
+	}
+	runtime, err := NewRuntime(runner, "stormlight-agents")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := runtime.ApplyServerOptions(context.Background()); err != nil {
+		t.Fatal(err)
+	}
+	for _, call := range runner.calls {
+		if slices.Contains(call, "terminal-features") &&
+			slices.Contains(call, "set-option") {
+			t.Fatalf("terminal-features was appended twice: %#v", call)
+		}
+	}
+}
+
+// A pattern that ends in the feature is not the feature: "xterm*:sync"
+// promises synchronized output to xterm and nothing else, so a client on
+// tmux-256color still needs the entry Stormlight declares.
+func TestApplyServerOptionsMatchesWholeFeatureEntries(t *testing.T) {
+	runner := &captureRunner{
+		terminalFeatures: "terminal-features[0] xterm*:sync\n",
+	}
+	runtime, err := NewRuntime(runner, "stormlight-agents")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := runtime.ApplyServerOptions(context.Background()); err != nil {
+		t.Fatal(err)
+	}
+	want := []string{"set-option", "-sa", "terminal-features", ",*:sync"}
+	found := false
+	for _, call := range runner.calls {
+		if slices.Equal(call, want) {
+			found = true
+		}
+	}
+	if !found {
+		t.Fatalf("xterm*:sync was read as *:sync: %#v", runner.calls)
 	}
 }
 
@@ -628,7 +703,10 @@ type captureRunner struct {
 	rootBinding     string
 	feedbackVersion string
 	clientLine      string
-	calls           [][]string
+	// terminalFeatures is what show-options reports for the server's
+	// terminal-features array, one `terminal-features[N] value` per line.
+	terminalFeatures string
+	calls            [][]string
 }
 
 func (r *captureRunner) Run(_ context.Context, _ []byte, args ...string) (string, error) {
@@ -665,6 +743,8 @@ func (r *captureRunner) Run(_ context.Context, _ []byte, args ...string) (string
 			return r.feedbackVersion, nil
 		case "@stormlight_id":
 			return r.stormlightID, nil
+		case "terminal-features":
+			return r.terminalFeatures, nil
 		}
 		return "", nil
 	}


### PR DESCRIPTION
Fixes #62.

Two ways the Stormlight tmux server let stray writes reach the terminal while an agent was being read. Both look like the reported symptom: the block cursor jumping to random spots on the screen and coming back.

### Synchronized output was lost when Stormlight's tmux ran inside another tmux

tmux wraps a redraw in DECSET 2026 only when the client's terminfo carries `Sync`. A real terminal has it — `xterm-ghostty` does — but a Stormlight client attached from inside another tmux sees `TERM=tmux-256color`, whose terminfo has no `Sync`, and tmux's built-in feature list for a tmux host omits it too. So in exactly that arrangement every full repaint went out stroke by stroke and the terminal rendered the cursor walking the screen before it landed.

Declaring the feature on Stormlight's own server restores it. Measured on a nested client driving six full redraws:

| | sync blocks | cursor moves inside sync |
|---|---|---|
| before | 0 | 0 of 82 |
| after | 6 of 6 redraws | all of them |

Claiming `*:sync` for every terminal is safe: one that does not implement DECSET 2026 ignores the sequence, which is today's behavior.

### `allow-passthrough all` let background panes write to the terminal

`all` extends the escape-sequence bypass to panes the client is not showing, and a bypass is a write straight to the terminal — so any agent in a background window could move the cursor or paint over the agent being read. `on` keeps the bypass for the visible pane and for popups, which is what it was turned on for (Yazi's terminal probe times out without it), and closes the rest.

Measured with a background pane writing a cursor move plus text through passthrough, and separately with a popup doing the same:

| | background pane reaches terminal | popup passthrough |
|---|---|---|
| `all` | 5 of 5 | works |
| `on` | 0 of 5 | works |

### Notes

Both values are asserted on running servers as well as written into the boot config, since the appliance server outlives upgrades. `terminal-features` appends rather than assigns, so the live assertion first reads what the server declares and skips what is already there — otherwise every dashboard launch would grow the array for the life of the server. Entries are compared whole, never as substrings: `xterm*:sync` promises synchronized output to xterm and nothing else.

Verified end to end against a server booted from the shipped config, with the popup and background-pane cases above rerun on it.