### PR TITLE
Make the queue hints answer to the mouse themselves

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,7 +57,9 @@ report. Press the tmux prefix followed by `Q` to return to the dashboard, or
 `N` and `P` for the same queue. Stormlight installs these bindings only when
 the keys are unbound or already owned by Stormlight. While the prefix is
 active, the managed session highlights the tmux status bar and shows `Q` for
-return, `N` and `P` for the queue, and `?` for the full tmux key list.
+return, `N` and `P` for the queue, and `?` for the full tmux key list. Both
+queue hints on the bar are clickable and do what they say; the rest of the
+bar returns to the dashboard.
 Closing the dashboard removes only its temporary session; agents keep
 running on the Stormlight server.
 

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -157,6 +157,16 @@ the choice as a tmux format: the order depends on marks and on when each
 agent entered the queue, which is inference no format language carries. The
 window arrived in inherits the return target of the one left behind.
 
+Each queue hint on the bar carries a tmux user range, so a click on it does
+what it says rather than inheriting the return region that surrounds it. A
+click is dispatched on `#{mouse_status_range}`, which is a different key
+(`MouseDown1Status`) from the one the return region answers to
+(`MouseDown1StatusRight`), so the two coexist. Two tmux details are load
+bearing: a range name is stored in a fixed 16-byte field and silently cut, so
+two names sharing a long prefix arrive identical and match neither branch;
+and a range is recorded one column right of where its text is drawn, so each
+range opens on the space before its hint to land on the glyphs.
+
 Arriving deliberately does not clear attention. Landing in a window answers
 nothing the agent is asking, and a cycle that marked rows seen on the way
 past would empty the inbox with nothing done about it. So the queue holds

--- a/internal/tmux/next.go
+++ b/internal/tmux/next.go
@@ -160,6 +160,73 @@ func (r *Runtime) configureNextRoot(ctx context.Context, listing string) {
 			}
 		}
 	}
+	r.configureNextMouse(ctx, listing)
+}
+
+// queueMouseKey is the click tmux reports for a user range on the status
+// line. It is a different key from MouseDown1StatusRight, which is what the
+// rest of the right section still answers to, so the two coexist: the return
+// region keeps its meaning and only the hints that claim a range of their own
+// are peeled off it.
+const queueMouseKey = "MouseDown1Status"
+
+// statusClickPassthrough is what a click means when it is not on one of
+// Stormlight's hints: select the window it landed on, which is what a click
+// on a window range has always meant.
+const statusClickPassthrough = "select-window -t="
+
+// tmuxStatusClickDefaults are tmux's own bindings for this key. Unlike every
+// other key Stormlight claims, this one is bound out of the box — so "already
+// bound" cannot stand for "somebody owns this", and a guard that reads it
+// that way declines to install and leaves the hints inert.
+var tmuxStatusClickDefaults = []string{"select-window -t=", "switch-client -t ="}
+
+// queueMouseFormat dispatches a status-line click on the range it landed in.
+// Anything that is not one of Stormlight's hints — including every click in a
+// window Stormlight does not own — keeps the meaning tmux gives it.
+func (r *Runtime) queueMouseFormat() string {
+	return `#{?#{==:#{@stormlight_id},},` + statusClickPassthrough +
+		`,#{?#{==:#{mouse_status_range},` + queueForwardRange + `},` +
+		r.nextTmuxCommand(agent.QueueForward) +
+		`,#{?#{==:#{mouse_status_range},` + queueBackRange + `},` +
+		r.nextTmuxCommand(agent.QueueBack) +
+		`,` + statusClickPassthrough + `}}}`
+}
+
+// replaceableStatusClick reports whether the current binding is one
+// Stormlight may take over: its own, or the default tmux ships.
+func replaceableStatusClick(binding string) bool {
+	if strings.Contains(binding, "@stormlight_") {
+		return true
+	}
+	compact := strings.Join(strings.Fields(binding), "")
+	for _, standard := range tmuxStatusClickDefaults {
+		if strings.HasSuffix(compact, strings.ReplaceAll(standard, " ", "")) {
+			return true
+		}
+	}
+	return false
+}
+
+// configureNextMouse makes the queue hints clickable.
+func (r *Runtime) configureNextMouse(ctx context.Context, listing string) {
+	if current, bound := tableBinding(listing, "root", queueMouseKey); bound &&
+		!replaceableStatusClick(current) {
+		diagnostic.Logger().Warn("foreign tmux root binding left in place",
+			"key", queueMouseKey,
+			"binding", current,
+		)
+		return
+	}
+	if _, err := r.runner.Run(ctx, nil,
+		"bind-key", "-T", "root", "-N", nextBindingNote,
+		queueMouseKey, "run-shell", "-C", r.queueMouseFormat(),
+	); err != nil {
+		diagnostic.Logger().Warn("cannot install tmux queue binding",
+			"key", queueMouseKey,
+			"error", err,
+		)
+	}
 }
 
 // NextRequest names where a cycle was asked for: the tmux client that will

--- a/internal/tmux/next_test.go
+++ b/internal/tmux/next_test.go
@@ -299,3 +299,45 @@ func TestNextShellCommandCarriesItsOwnServer(t *testing.T) {
 		t.Fatalf("tmux command = %s", quoted)
 	}
 }
+
+// A click on the bar has to be told apart by the range it landed in: the
+// return region and the queue hints share one status line, and dispatching
+// on the key alone is what made a hint reading "queue" go to the dashboard.
+func TestQueueMouseFormatDispatchesOnTheRange(t *testing.T) {
+	runtime := &Runtime{
+		executable:  "/usr/local/bin/stormlight",
+		sessionName: "stormlight-agents",
+	}
+	format := runtime.queueMouseFormat()
+	for _, want := range []string{
+		"#{==:#{mouse_status_range}," + queueForwardRange + "}",
+		"#{==:#{mouse_status_range}," + queueBackRange + "}",
+		"'--previous'",
+		// A click anywhere else on the bar keeps tmux's own meaning.
+		"select-window -t=",
+	} {
+		if !strings.Contains(format, want) {
+			t.Fatalf("mouse format missing %q: %s", want, format)
+		}
+	}
+}
+
+// MouseDown1Status is the one key Stormlight claims that tmux already binds,
+// so "already bound" cannot mean "somebody owns this" — reading it that way
+// declines to install and leaves the hints inert.
+func TestStatusClickReplacesTmuxOwnDefault(t *testing.T) {
+	for _, standard := range []string{
+		"bind-key  -T root MouseDown1Status  switch-client -t =",
+		"bind-key  -T root MouseDown1Status  select-window -t=",
+	} {
+		if !replaceableStatusClick(standard) {
+			t.Fatalf("tmux's own default was treated as foreign: %q", standard)
+		}
+	}
+	if !replaceableStatusClick(`run-shell -C "#{?#{==:#{@stormlight_id},}..."`) {
+		t.Fatal("Stormlight's own binding was treated as foreign")
+	}
+	if replaceableStatusClick("bind-key -T root MouseDown1Status display-panes") {
+		t.Fatal("a binding somebody chose was overwritten")
+	}
+}

--- a/internal/tmux/runtime.go
+++ b/internal/tmux/runtime.go
@@ -38,7 +38,7 @@ const (
 	statusLeftBaseOption    = "@stormlight_status_left_base"
 	statusLeftPrefixOption  = "@stormlight_status_left_prefix"
 	statusVersionOption     = "@stormlight_status_version"
-	statusVersion           = "4"
+	statusVersion           = "5"
 	prefixStatusStyle       = "bg=#e5c07b,fg=#1f2328,bold"
 	prefixStatusLeft        = " PREFIX  [Q] return  [N] next  [P] previous  [?] all keys "
 	// The agents session lives on the Stormlight-owned server, so its

--- a/internal/tmux/runtime_test.go
+++ b/internal/tmux/runtime_test.go
@@ -445,7 +445,7 @@ func TestAttachSkipsForeignRootBindingsWithoutFailing(t *testing.T) {
 			boundKeys = append(boundKeys, call[5])
 		}
 	}
-	want := []string{"C-^", returnMouseKey, "C-]", `C-\`}
+	want := []string{"C-^", returnMouseKey, "C-]", `C-\`, queueMouseKey}
 	if !slices.Equal(boundKeys, want) {
 		t.Fatalf("root keys bound = %#v, want %#v", boundKeys, want)
 	}
@@ -860,7 +860,11 @@ func rootReturnCalls(runtime *Runtime) [][]string {
 			binding.key, "run-shell", "-C", format,
 		})
 	}
-	return append(calls, rootNextCalls(runtime)...)
+	calls = append(calls, rootNextCalls(runtime)...)
+	return append(calls, []string{
+		"bind-key", "-T", "root", "-N", nextBindingNote,
+		queueMouseKey, "run-shell", "-C", runtime.queueMouseFormat(),
+	})
 }
 
 // rootNextCalls is the single-press queue key, installed alongside the

--- a/internal/tmux/status.go
+++ b/internal/tmux/status.go
@@ -45,6 +45,17 @@ const (
 	// and no more. It is a format rather than a number because the right
 	// section is not one width: see statusSummary.
 	statusWidthOption = "@stormlight_status_width"
+	// The names the queue hints answer to when clicked, read back through
+	// #{mouse_status_range}.
+	//
+	// tmux keeps a user range name in a fixed 16-byte field, so anything
+	// past 15 characters is silently cut. Two names sharing a prefix longer
+	// than that arrive identical and the comparison that tells them apart
+	// matches neither — the click then falls through to the default and
+	// looks exactly like the binding never fired.
+	queueRangeMaxLength = 15
+	queueForwardRange   = "sl-queue-next"
+	queueBackRange      = "sl-queue-prev"
 	// statusLineageMinWidth is what the left keeps before the counters may
 	// spell themselves out. The bar's first job is naming where you are, so
 	// the words are what yields: below this much room for the lineage the
@@ -209,13 +220,38 @@ func (r *Runtime) statusRight() string {
 // either way along the queue. The two queue keys share one label — spelling
 // both out costs more of the band than the direction is worth, and they sit
 // in the order they move, back on the left.
+//
+// Each queue hint carries a tmux user range, so a click on it does what it
+// says. Without one the whole right section is a single `range=right`, and
+// the hints inherit whatever that region means — which is how a hint reading
+// "queue" came to send people to the dashboard.
 func (r *Runtime) statusRightKeys() string {
-	queue := "#[fg=" + statusKeyColor + "]" +
-		r.effectivePreviousKeys()[0] + " " + r.effectiveNextKeys()[0] +
-		"#[fg=" + statusLabelColor + "] ↻ queue#[default]"
+	back := statusRange(queueBackRange,
+		" #[fg="+statusKeyColor+"]"+r.effectivePreviousKeys()[0])
+	forward := statusRange(queueForwardRange,
+		" #[fg="+statusKeyColor+"]"+r.effectiveNextKeys()[0]+
+			"#[fg="+statusLabelColor+"] ↻ queue")
 	return "  " +
-		statusKeyHint(r.effectiveReturnKeys()[0], "⏎ dashboard") + "  " +
-		queue + " "
+		statusKeyHint(r.effectiveReturnKeys()[0], "⏎ dashboard") + " " +
+		back + forward + "#[default] "
+}
+
+// statusRange marks a span of the bar as its own mouse target.
+//
+// The span opens on the space before the hint rather than on the hint
+// itself, because tmux records a status range one column to the right of
+// where it draws the text — measured on 3.7, the same single column in two
+// unrelated layouts. A range that opens at the glyph therefore answers for
+// the column after it, and the first character of each key cap would do the
+// neighbouring hint's job: clicking the C of C-] would step backwards.
+// Opening a column early cancels that, and if tmux ever stops adding the
+// column the error is the same one column in the other direction.
+//
+// The span closes by reopening range=right rather than with #[norange]:
+// everything around these hints belongs to the return region, and a bare
+// norange would leave dead columns that answer to nothing.
+func statusRange(name, content string) string {
+	return "#[range=user|" + name + "]" + content + "#[range=right]"
 }
 
 func statusKeyHint(key, label string) string {

--- a/internal/tmux/status_test.go
+++ b/internal/tmux/status_test.go
@@ -115,6 +115,23 @@ func TestStatusRightSeparatesTheTallyFromTheKeys(t *testing.T) {
 			t.Fatalf("key hints missing %q: %q", want, keys)
 		}
 	}
+	// Each queue hint claims a mouse range of its own, and hands the region
+	// back to the return range afterwards so no column answers to nothing.
+	format := runtime.statusRightKeys()
+	for _, want := range []string{
+		"#[range=user|" + queueBackRange + "]",
+		"#[range=user|" + queueForwardRange + "]",
+	} {
+		if !strings.Contains(format, want) {
+			t.Fatalf("key hints missing %q: %q", want, format)
+		}
+	}
+	if strings.Contains(format, "#[norange]") {
+		t.Fatalf("a hint left dead columns behind it: %q", format)
+	}
+	if count := strings.Count(format, "#[range=right]"); count != 2 {
+		t.Fatalf("ranges reopened %d times, want 2: %q", count, format)
+	}
 	// With no agents there is no tally, so there is no rule to hang the
 	// keys off either.
 	if runtime.statusSummary(agent.Stats{}) != "" {
@@ -196,4 +213,19 @@ func visibleText(format string) string {
 		text.WriteByte(format[index])
 	}
 	return text.String()
+}
+
+// tmux stores a user range name in a fixed 16-byte field and cuts the rest
+// without complaint. Two names that survive the cut identically dispatch as
+// one range, which reads exactly like the binding never fired.
+func TestQueueRangeNamesSurviveTmuxTruncation(t *testing.T) {
+	for _, name := range []string{queueForwardRange, queueBackRange} {
+		if len(name) > queueRangeMaxLength {
+			t.Fatalf("range name %q is %d bytes, over tmux's %d",
+				name, len(name), queueRangeMaxLength)
+		}
+	}
+	if queueForwardRange == queueBackRange {
+		t.Fatal("the two queue ranges are indistinguishable")
+	}
 }


### PR DESCRIPTION
The whole right of the status bar was one `range=right`, and the mouse key that region answers to returns to the dashboard. So the hint reading `queue` sent people to the dashboard — the words said one thing and the click did its neighbour's job.

Each queue hint now carries a tmux user range of its own. A click in one arrives as `MouseDown1Status` carrying `#{mouse_status_range}` — a different key from the `MouseDown1StatusRight` the return region answers to, so the two coexist. Only the spans that claim a range are peeled off the return region; everything else on the bar still goes back to the dashboard, and outside Stormlight's own windows the click keeps the meaning tmux gives it.

## Three tmux details that had to be measured

Each one failed silently, and each cost a round of probing against a real attached client.

**A user range name is cut at 15 bytes.** tmux stores it in a fixed 16-byte field. `stormlight-queue-next` and `stormlight-queue-previous` both came back as `stormlight-queu`, so the comparison that tells the directions apart matched neither and every click fell through to the default. The names are short now, with a test pinning them against the limit.

**`MouseDown1Status` is bound out of the box.** It's the only key Stormlight claims that tmux already binds (`switch-client -t =` on 3.7). The guard that protects a user's bindings read "already bound" as "somebody owns this", declined to install, and left the hints inert — logging a warning that named tmux itself as the foreigner. tmux's own defaults are now recognised as replaceable, and the behaviour is preserved in the fallback branch regardless.

**A range is recorded one column right of where its text is drawn.** Same single column in two unrelated layouts on 3.7. A range opening at the glyph answers for the column *after* it, so clicking the `C` of `C-]` stepped backwards. Each range now opens on the space before its hint, which cancels it; if tmux ever stops adding the column, the error is the same one column the other way.

## Verification

Clicking every column of a real bar in an attached client, with the map printed against the drawn glyphs:

```
col 104 ' '  -> (no move)     ← return region
col 105 'C'  -> gamma         ┐
col 106 '-'  -> gamma         │ C-\  steps back
col 107 '\'  -> gamma         │
col 108 ' '  -> gamma         ┘
col 109 'C'  -> beta          ┐
col 110 '-'  -> beta          │
...                           │ C-] ↻ queue steps forward
col 120 ' '  -> beta          ┘
```

Back from outside the queue lands on the tail (`gamma`, the newest waiter) and forward on the head (`beta`) — the same rule the keys follow.

Fixes #87