### PR TITLE
Re-resolve Stormlight's own path when the binary is deleted

### DIFF
--- a/internal/selfpath/selfpath.go
+++ b/internal/selfpath/selfpath.go
@@ -4,7 +4,9 @@ package selfpath
 import (
 	"fmt"
 	"os"
+	"os/exec"
 	"path/filepath"
+	"strings"
 )
 
 // Resolve returns a path to the running executable that will still start
@@ -23,15 +25,62 @@ import (
 // build run out of a worktree must keep its own path even though an
 // installed `stormlight` shadows it on PATH, or end-to-end runs would
 // silently exercise the installed binary instead of the one under test.
+//
+// Once the running binary has actually been deleted that preference has
+// nothing left to protect, and the identity check cannot run at all — there
+// is no file to compare a candidate against. Rather than hand back a path
+// that starts nothing, fall back to whatever PATH offers under the same name.
 func Resolve() (string, error) {
 	executable, err := os.Executable()
 	if err != nil {
 		return "", fmt.Errorf("resolve Stormlight executable: %w", err)
 	}
+	return resolve(executable)
+}
+
+// resolve is Resolve with the running executable supplied, so the answer for
+// a binary that no longer exists can be exercised without deleting the test
+// binary out from under the test.
+func resolve(executable string) (string, error) {
 	if alias, ok := stableAlias(executable); ok {
 		return alias, nil
 	}
-	return executable, nil
+	if _, err := os.Stat(executable); err == nil {
+		return executable, nil
+	}
+	name := filepath.Base(strings.TrimSuffix(executable, deletedSuffix))
+	if launcher, ok := launcherOnPath(name); ok {
+		return launcher, nil
+	}
+	return "", fmt.Errorf(
+		"the Stormlight binary this process was started from no longer exists (%s) and no %s is on PATH",
+		executable, name,
+	)
+}
+
+// deletedSuffix is what Linux appends when os.Executable reads
+// /proc/self/exe for a binary that has since been unlinked. Left in place it
+// turns the PATH lookup into a search for a program nobody has installed.
+const deletedSuffix = " (deleted)"
+
+// launcherOnPath finds a same-named executable on PATH to stand in for a
+// binary that is gone. The name and the executable bit are the whole test:
+// os.SameFile cannot decide this one, since the file it would compare
+// against is exactly what has been deleted. That is weaker than stableAlias
+// and is reached only when the alternative is a path that cannot start
+// anything at all.
+func launcherOnPath(name string) (string, bool) {
+	found, err := exec.LookPath(name)
+	if err != nil {
+		return "", false
+	}
+	// A relative PATH entry resolves against this process's directory, and
+	// the answer is written into tmux commands that run from somewhere else.
+	absolute, err := filepath.Abs(found)
+	if err != nil {
+		return "", false
+	}
+	return absolute, true
 }
 
 // stableAlias finds the first entry on PATH naming the same file as

--- a/internal/selfpath/selfpath_test.go
+++ b/internal/selfpath/selfpath_test.go
@@ -85,6 +85,77 @@ func TestResolveSkipsShadowingBinaryOfTheSameName(t *testing.T) {
 	}
 }
 
+// Tearing down a finished worktree deletes the development build a running
+// dashboard was started from, and every path it writes into tmux then names
+// a file the shell cannot run (#90). The installed launcher is the answer
+// once there is no longer a build to protect.
+func TestResolveFallsBackToPathWhenTheBinaryIsGone(t *testing.T) {
+	root := t.TempDir()
+	worktree := filepath.Join(root, "worktree", "stormlight")
+	installed := filepath.Join(root, "local", "bin", "stormlight")
+	writeBinary(t, installed)
+	t.Setenv("PATH", filepath.Dir(installed))
+
+	resolved, err := resolve(worktree)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if resolved != installed {
+		t.Fatalf("resolve = %q, want %q", resolved, installed)
+	}
+}
+
+// Linux reads os.Executable from /proc/self/exe, which marks an unlinked
+// binary rather than reporting the bare path. Carried into the lookup, the
+// marker asks PATH for a program named "stormlight (deleted)".
+func TestResolveIgnoresTheLinuxDeletedMarker(t *testing.T) {
+	root := t.TempDir()
+	installed := filepath.Join(root, "local", "bin", "stormlight")
+	writeBinary(t, installed)
+	t.Setenv("PATH", filepath.Dir(installed))
+
+	resolved, err := resolve(filepath.Join(root, "worktree", "stormlight (deleted)"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if resolved != installed {
+		t.Fatalf("resolve = %q, want %q", resolved, installed)
+	}
+}
+
+// With the binary gone and nothing on PATH to stand in for it, there is no
+// path worth returning — every caller writes the answer somewhere a shell
+// will try to run it.
+func TestResolveFailsWhenNothingCanStartStormlight(t *testing.T) {
+	root := t.TempDir()
+	t.Setenv("PATH", filepath.Join(root, "empty"))
+
+	resolved, err := resolve(filepath.Join(root, "worktree", "stormlight"))
+	if err == nil {
+		t.Fatalf("resolve = %q, want an error", resolved)
+	}
+}
+
+// A build that still exists keeps its own path even though an installed
+// binary of the same name sits on PATH — the fallback is for deletion, not
+// for shadowing.
+func TestResolveKeepsALiveBuildOverThePathFallback(t *testing.T) {
+	root := t.TempDir()
+	worktree := filepath.Join(root, "worktree", "stormlight")
+	writeBinary(t, worktree)
+	installed := filepath.Join(root, "local", "bin", "stormlight")
+	writeBinary(t, installed)
+	t.Setenv("PATH", filepath.Dir(installed))
+
+	resolved, err := resolve(worktree)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if resolved != worktree {
+		t.Fatalf("resolve = %q, want %q", resolved, worktree)
+	}
+}
+
 // With nothing on PATH to prefer, the running executable is the answer.
 func TestResolveFallsBackToTheRunningExecutable(t *testing.T) {
 	t.Setenv("PATH", "")

--- a/internal/tmux/next.go
+++ b/internal/tmux/next.go
@@ -64,7 +64,7 @@ func (r *Runtime) effectivePreviousKeys() []string {
 // environment the tmux server was started with, which is not necessarily the
 // one the dashboard was launched from.
 func (r *Runtime) nextShellCommand(step agent.QueueStep) string {
-	args := []string{r.executable}
+	args := []string{r.bindingPath()}
 	if r.socket != "" {
 		args = append(args, "--tmux-socket", r.socket)
 	}

--- a/internal/tmux/next_test.go
+++ b/internal/tmux/next_test.go
@@ -2,6 +2,8 @@ package tmux
 
 import (
 	"context"
+	"os"
+	"path/filepath"
 	"slices"
 	"strconv"
 	"strings"
@@ -266,14 +268,20 @@ func TestNextWaitingIncludesMarkedAgents(t *testing.T) {
 // The binding fires with whatever environment the tmux server was started
 // with, so the socket and session have to travel in the command line itself.
 func TestNextShellCommandCarriesItsOwnServer(t *testing.T) {
+	// A real file, because the binding re-resolves a path that has stopped
+	// naming one rather than writing it into a key binding.
+	installed := filepath.Join(t.TempDir(), "stormlight")
+	if err := os.WriteFile(installed, []byte("#!/bin/sh\n"), 0o755); err != nil {
+		t.Fatal(err)
+	}
 	runtime := &Runtime{
-		executable:  "/usr/local/bin/stormlight",
+		executable:  installed,
 		socket:      "stormlight",
 		sessionName: "stormlight-agents",
 	}
 	command := runtime.nextShellCommand(agent.QueueForward)
 	for _, want := range []string{
-		"'/usr/local/bin/stormlight'",
+		"'" + installed + "'",
 		"'--tmux-socket' 'stormlight'",
 		"'--session' 'stormlight-agents'",
 		"'next'",

--- a/internal/tmux/runtime.go
+++ b/internal/tmux/runtime.go
@@ -124,11 +124,17 @@ var agentMetadataFields = [metadataFieldCount]string{
 type Runtime struct {
 	runner       Runner
 	sessionName  string
-	executable   string
 	socket       string
 	returnKeys   []string
 	nextKeys     []string
 	previousKeys []string
+
+	// executableMu guards the path Stormlight re-invokes itself by, which
+	// launchPath re-resolves when the file behind it disappears. Dispatch
+	// runs off the dashboard's command goroutines while key bindings are
+	// installed on attach, so both can reach it at once.
+	executableMu sync.Mutex
+	executable   string
 
 	// statusMu guards the last tally written to the band. The dashboard
 	// publishes from its polling command, which runs off the render loop.
@@ -155,6 +161,45 @@ func NewRuntime(runner Runner, sessionName string) (*Runtime, error) {
 		runtime.socket = source.Socket()
 	}
 	return runtime, nil
+}
+
+// launchPath returns the path to write into a tmux command line. The value
+// resolved at startup names a file that can die while the dashboard is still
+// running — a Homebrew upgrade deletes the versioned binary, and removing a
+// finished worktree deletes a development build — and tmux would then hand
+// the dead path to a shell, which reports an unknown command into a pane
+// nobody is watching. Re-checking at the moment of use keeps that window
+// down to nothing.
+//
+// The current path comes back even on failure, so callers that have no way
+// to report an error still have the best answer available rather than an
+// empty string.
+func (r *Runtime) launchPath() (string, error) {
+	r.executableMu.Lock()
+	defer r.executableMu.Unlock()
+	if _, err := os.Stat(r.executable); err == nil {
+		return r.executable, nil
+	}
+	resolved, err := selfpath.Resolve()
+	if err != nil {
+		return r.executable, err
+	}
+	r.executable = resolved
+	return resolved, nil
+}
+
+// bindingPath is launchPath for the tmux key bindings, which are installed
+// best-effort and have nowhere to surface an error. A binding naming a
+// missing binary is no worse than the binding being dropped, so the stale
+// path stays and the warning carries the news.
+func (r *Runtime) bindingPath() string {
+	path, err := r.launchPath()
+	if err != nil {
+		diagnostic.Logger().Warn("cannot resolve the Stormlight binary for a tmux binding",
+			"error", err,
+		)
+	}
+	return path
 }
 
 // SetReturnKeys overrides the single-press return-to-dashboard keys
@@ -234,6 +279,15 @@ func (r *Runtime) Dispatch(ctx context.Context, req session.DispatchRequest) (ag
 	if err != nil {
 		return agent.Agent{}, fmt.Errorf("create agent id: %w", err)
 	}
+
+	// Resolved before anything is created: an agent whose window exists but
+	// whose pane died on a shell error is worse than no agent at all, since
+	// the dashboard lists it as though it had started.
+	executable, err := r.launchPath()
+	if err != nil {
+		return agent.Agent{}, err
+	}
+
 	// A user-chosen name becomes the tmux window name verbatim, so it goes
 	// through the same whitespace collapse as Rename — a newline or tab in
 	// a window name confuses every tmux format string that prints it.
@@ -286,7 +340,7 @@ func (r *Runtime) Dispatch(ctx context.Context, req session.DispatchRequest) (ag
 		return agent.Agent{}, err
 	}
 	commandArgs := []string{
-		r.executable,
+		executable,
 	}
 	if r.socket != "" {
 		commandArgs = append(commandArgs, "--tmux-socket", r.socket)

--- a/internal/tmux/runtime_test.go
+++ b/internal/tmux/runtime_test.go
@@ -3,6 +3,7 @@ package tmux
 import (
 	"context"
 	"errors"
+	"path/filepath"
 	"slices"
 	"strconv"
 	"strings"
@@ -155,10 +156,46 @@ func TestDispatchNamesTheWindow(t *testing.T) {
 	}
 }
 
+// The path resolved when the dashboard started names a file that can be
+// deleted while it is still running — tearing down a finished worktree does
+// exactly that to a development build. Writing it into the window command
+// anyway leaves the pane holding a shell error and no agent (#90).
+func TestDispatchReresolvesADeletedExecutable(t *testing.T) {
+	deleted := filepath.Join(t.TempDir(), "worktree", "stormlight")
+	runner := &dispatchRunner{}
+	runtime := &Runtime{
+		runner:      runner,
+		sessionName: "stormlight",
+		executable:  deleted,
+	}
+
+	if _, err := runtime.Dispatch(context.Background(), session.DispatchRequest{
+		Provider: agent.ProviderClaude,
+		Task:     "Fix the OAuth callback",
+		Cwd:      t.TempDir(),
+		Launch:   session.Launch{Path: "/usr/bin/claude"},
+	}); err != nil {
+		t.Fatal(err)
+	}
+
+	if runner.paneCommand == "" {
+		t.Fatal("no command was given to the pane")
+	}
+	if strings.Contains(runner.paneCommand, deleted) {
+		t.Fatalf("pane command still names the deleted binary: %q", runner.paneCommand)
+	}
+	// The re-resolution is cached, so a second dispatch does not pay for it
+	// and the runtime no longer holds a path nothing can start.
+	if runtime.executable == deleted {
+		t.Fatal("runtime kept the deleted path")
+	}
+}
+
 // dispatchRunner answers just enough tmux for Dispatch and records the name
-// the new window was created with.
+// the new window was created with and the command its pane was given.
 type dispatchRunner struct {
-	windowName string
+	windowName  string
+	paneCommand string
 }
 
 func (r *dispatchRunner) Run(_ context.Context, _ []byte, args ...string) (string, error) {
@@ -173,6 +210,8 @@ func (r *dispatchRunner) Run(_ context.Context, _ []byte, args ...string) (strin
 			r.windowName = args[index+1]
 		}
 		return "@7" + fieldSeparator + "%7", nil
+	case "respawn-pane":
+		r.paneCommand = args[len(args)-1]
 	}
 	return "", nil
 }


### PR DESCRIPTION
A dashboard writes the path it was started from into every tmux window command
it dispatches. Tearing down a finished worktree deletes that file out from
under a still-running dashboard, and the next dispatch handed the shell a path
naming nothing — the pane died with `fish: Unknown command: .../worktrees/<branch>/stormlight`
and the agent never started, while the dashboard reported a successful launch.

`selfpath.Resolve` was written for this shape of problem — its doc comment
describes the Homebrew upgrade that deletes the versioned binary — but the
fallback only worked while the file still existed. `stableAlias` opens by
stat-ing the executable so it has something to compare candidates against, so a
deleted binary failed that stat and the dead path came straight back, with a
working `~/.local/bin/stormlight` sitting on `PATH` unexamined.

## What changed

- **`selfpath`** takes the PATH launcher on name alone once the executable is
  confirmed gone. `os.SameFile` cannot decide a file that is not there, and the
  alternative is returning a path that starts nothing. When nothing on `PATH`
  answers to the name, it now fails rather than handing back a dead path. The
  Linux `" (deleted)"` marker `/proc/self/exe` appends is stripped before the
  lookup, or the search is for a program nobody installed.
- **Resolution moved to the moment of use.** Resolving once at startup leaves an
  unbounded gap before the answer is written into tmux, which is exactly the gap
  the deletion falls into. `Dispatch` resolves before creating a window, so a
  failure surfaces in the dashboard instead of as shell noise in a pane nobody is
  watching; the queue key bindings re-resolve as they are installed. A live
  worktree build still keeps its own path — the fallback is for deletion, not
  shadowing.

## Verification

`go test ./...` passes. Beyond the unit tests, a harness that deletes its own
binary and then dispatches through a real tmux server confirms the behaviour
end to end on macOS — `os.Executable` still reports the old path after the
unlink, and the dispatched window comes up live instead of dead:

```
dashboard started from: .../e2e/wt/stormlight
worktree torn down; the running dashboard's binary is gone
dispatched window @1 pane %1
@1 0 stormlight verify the deleted-binary fallback
```

Fixes #90