### PR TITLE
Let agents outlive the tmux server that holds them

### DIFF
--- a/README.md
+++ b/README.md
@@ -304,12 +304,13 @@ always a deliberate act and never resumes work by itself.
 Not everything can come back, and the listing says which and why rather than
 dropping the row:
 
-- **An agent that never reported a turn** has no transcript, so there is no
-  conversation to reopen. Re-running its original task from scratch is a
-  different and far more dangerous act than the one restore promises.
-- **Codex agents** cannot be reopened yet ([#92](https://github.com/trentkm/stormlight/issues/92)),
-  and neither can custom provider specs — reopening a conversation is a
-  capability a provider adapter declares, and only Claude declares it today.
+- **An agent that never reported a turn** has no session id and no
+  transcript, so there is no conversation to reopen. Re-running its original
+  task from scratch is a different and far more dangerous act than the one
+  restore promises.
+- **Custom provider specs** cannot be reopened — reopening a conversation is
+  a capability a provider adapter declares, and a spec declares how to start
+  a conversation, not how to reopen one. Claude and Codex both declare it.
 - **An agent whose working directory is gone** — the worktree was torn down
   while the agent was still in it — has nowhere to come back to.
 

--- a/README.md
+++ b/README.md
@@ -25,6 +25,8 @@ preserving the checkout or worktree each agent is using.
 - Each agent is one tagged tmux window in the `stormlight-agents` session.
 - The dashboard can exit without stopping any agent.
 - Metadata is stored as tmux window options, not inferred from window names.
+- A record of the roster is kept on disk so agents outlive the tmux server,
+  and restoring one reopens its conversation without resuming its work.
 - Provider adapters construct commands; tmux lifecycle is provider-neutral.
 - Agent runtimes and dashboard presentation surfaces are separate interfaces.
 - Workspace resolvers are provider-neutral and external resolvers are supported.
@@ -157,6 +159,7 @@ stormlight rename <id> "focused test fixer"
 stormlight mark <id> attention
 stormlight stop <id>
 stormlight delete <id>
+stormlight restore
 stormlight logs
 ```
 
@@ -195,6 +198,7 @@ IDs may be shortened as long as the prefix remains unambiguous.
 | `m` | Mark the selected agent in progress or needs-attention (your own reading, overriding Stormlight's) |
 | `M` | Mark the selected agent — or workspace — seen |
 | `K` | Workspace info popup (resolver, roots, metadata) |
+| `Ctrl-r` | Restore agents remembered from before the tmux server was lost |
 | `?` | Full keybinding reference |
 | `r` / `Ctrl-l` | Refresh |
 | `q` | Close the dashboard |
@@ -265,6 +269,55 @@ chooses the directory you are in.
 The Spanreed pane retains provider terminal colors while removing startup
 chrome and the inactive prompt/status area for Claude and Codex. Shell agent
 output remains unfiltered.
+
+## Resurrect
+
+Everything Stormlight knows about an agent lives in tmux window options, next
+to the process it describes. That is the right home while the server is up and
+the wrong one the moment it is not: a reboot, a `kill-server`, or an OOM takes
+the roster with it — not only the processes, which were always going to die,
+but the record of which workspace each agent was in, what it was asked to do,
+and which of them was waiting on an answer.
+
+The providers keep their side. A Claude conversation is still sitting in its
+transcript file. So Stormlight keeps a record of its own, in
+`~/.local/state/stormlight/session.json` beside the workspace catalog, written
+whenever the roster changes. After the server is gone:
+
+```bash
+stormlight restore          # what is remembered, and what can come back
+stormlight restore --all    # bring all of it back
+stormlight restore <id>...  # or name them
+stormlight restore --forget <id>...
+```
+
+The dashboard offers the same thing on `Ctrl-r`, and offers it unprompted when
+it starts to an empty roster and a record that is not.
+
+**Restore brings the agent back, not the turn.** Each restored agent reopens
+its own conversation and idles at its composer — same id, same workspace, same
+task, and still holding its place in the amber inbox if it was waiting on you
+when the server died. Nothing starts working. A machine that reboots overnight
+must not wake up to a dozen agents spending tokens unattended, so restoring is
+always a deliberate act and never resumes work by itself.
+
+Not everything can come back, and the listing says which and why rather than
+dropping the row:
+
+- **An agent that never reported a turn** has no transcript, so there is no
+  conversation to reopen. Re-running its original task from scratch is a
+  different and far more dangerous act than the one restore promises.
+- **Codex agents** cannot be reopened yet ([#92](https://github.com/trentkm/stormlight/issues/92)),
+  and neither can custom provider specs — reopening a conversation is a
+  capability a provider adapter declares, and only Claude declares it today.
+- **An agent whose working directory is gone** — the worktree was torn down
+  while the agent was still in it — has nowhere to come back to.
+
+An empty agent list is never taken as "there are no agents" on its own. The
+managed tmux session is the arbiter: while it exists its windows are the
+truth and the record follows them, and while it does not the record is
+authoritative and nothing may overwrite it. That is what keeps a listing taken
+one second after the server died from erasing the very thing it is for.
 
 ## Workspaces
 

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -259,12 +259,16 @@ stands and a listing may not touch it. Deletion is therefore recorded
 explicitly at the point of deletion, rather than inferred later from an
 absence that could mean either thing.
 
-The second is what restoring may do. `provider.Resumer` maps a transcript path
-to a launch that reopens the conversation, and that launch carries no prompt:
-a restored agent idles at its composer. An agent with no transcript is not
+The second is what restoring may do. A provider adapter's `Resume` maps a
+session id — the one the agent's hooks reported, or failing that the one the
+provider's transcript naming encodes — to a launch that reopens the
+conversation, and that launch carries no prompt: a restored agent idles at
+its composer. An agent with no session id and no transcript is not
 restorable at all, because there is nothing to reopen and re-dispatching its
 original task would be a materially different act performed under the same
-name.
+name. The same adapter surface serves the dashboard's session history
+browser, which reopens conversations recorded in the append-only session
+log long after their windows are deleted.
 
 A future daemon may still add an append-only event journal, for agents that
 run remotely rather than merely survive a restart.

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -239,11 +239,35 @@ takes it down. Like attention, a mark stops applying once the pane is dead.
 
 ## Persistence
 
-The current implementation uses tmux options as the source of truth because
-managed processes cannot outlive the tmux server. The workspace catalog is an
-atomic JSON file independent of tmux, as are the dashboard's column
-preferences. A future daemon may add an append-only event journal for agents
-that survive tmux restarts or run remotely.
+tmux options are the source of truth for a running roster, because managed
+processes cannot outlive the tmux server. The workspace catalog is an atomic
+JSON file independent of tmux, as are the dashboard's column preferences.
+
+Alongside them, `internal/resurrect` keeps `session.json` — a mirror of the
+roster written on every reconciling listing, so the record outlives the server
+that holds the truth. It is a mirror rather than a second source of truth:
+nothing reads it while tmux is up, and a restore rebuilds windows from it
+rather than reconciling against it.
+
+Two rules keep the mirror honest.
+
+The first is when it may be written. An empty listing is ambiguous — it reads
+identically whether the last agent was deleted or the whole session died — so
+the runtime is asked (`session.Restorer.RosterLive`) whether its listing is
+authoritative before any save. A missing managed session means the record
+stands and a listing may not touch it. Deletion is therefore recorded
+explicitly at the point of deletion, rather than inferred later from an
+absence that could mean either thing.
+
+The second is what restoring may do. `provider.Resumer` maps a transcript path
+to a launch that reopens the conversation, and that launch carries no prompt:
+a restored agent idles at its composer. An agent with no transcript is not
+restorable at all, because there is nothing to reopen and re-dispatching its
+original task would be a materially different act performed under the same
+name.
+
+A future daemon may still add an append-only event journal, for agents that
+run remotely rather than merely survive a restart.
 
 ## Workspace boundary
 

--- a/internal/app/restore.go
+++ b/internal/app/restore.go
@@ -1,0 +1,309 @@
+package app
+
+// Keeping the agent roster on disk, and building it back from there.
+// See #91 and internal/resurrect.
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"os"
+	"slices"
+	"strings"
+
+	"github.com/trentkm/stormlight/internal/agent"
+	"github.com/trentkm/stormlight/internal/diagnostic"
+	"github.com/trentkm/stormlight/internal/resurrect"
+	"github.com/trentkm/stormlight/internal/session"
+)
+
+// RestoreResult is what became of one entry a restore was asked to bring
+// back. Failures are reported per entry rather than aborting the run: one
+// agent whose worktree was torn down is no reason to abandon the other nine.
+type RestoreResult struct {
+	Entry resurrect.Entry
+	Agent agent.Agent
+	Err   error
+}
+
+// SnapshotPath names the file the roster is recorded in.
+func (s *Service) SnapshotPath() string {
+	if s.store == nil {
+		return ""
+	}
+	return s.store.Path()
+}
+
+// restorer reports the runtime's restore capability, if it has one. A
+// runtime that cannot lose its roster has nothing to record and nothing to
+// build back.
+func (s *Service) restorer() (session.Restorer, bool) {
+	if s.store == nil {
+		return nil, false
+	}
+	restorer, ok := s.runtime.(session.Restorer)
+	return restorer, ok
+}
+
+// snapshot records the roster, but only when the runtime says its listing is
+// authoritative. An empty listing from a runtime whose session is gone means
+// "everything was lost", and writing that as "there are no agents" would
+// destroy the record at the one moment it matters.
+func (s *Service) snapshot(ctx context.Context, agents []agent.Agent) {
+	restorer, ok := s.restorer()
+	if !ok {
+		return
+	}
+	live, err := restorer.RosterLive(ctx)
+	if err != nil {
+		diagnostic.Logger().Debug("roster authority unknown", "error", err)
+		return
+	}
+	if !live {
+		return
+	}
+	if err := s.store.Save(restorer.SessionName(), agents); err != nil {
+		diagnostic.Logger().Warn("agent snapshot not saved", "error", err)
+	}
+}
+
+// resnapshot re-reads the roster and records it. State changes arrive from
+// provider hooks in processes that never list anything, so the listing the
+// dashboard would eventually do is not one to wait for — an agent that
+// started waiting for an answer at 3am should be waiting for it after the
+// reboot too.
+func (s *Service) resnapshot(ctx context.Context) {
+	if _, ok := s.restorer(); !ok {
+		return
+	}
+	// Deliberately the service's own listing rather than the runtime's: it is
+	// the one that backfills workspaces and overlays catalog display names, and
+	// a record written from the barer listing would differ from the one the
+	// dashboard's poll writes — leaving the two paths rewriting the file past
+	// each other forever.
+	if _, err := s.ListAgents(ctx); err != nil {
+		diagnostic.Logger().Debug("roster unavailable for snapshot", "error", err)
+	}
+}
+
+// RestoreCandidates weighs every remembered agent against the world as it is
+// now: which are already running, which providers can reopen a conversation,
+// which transcripts and directories still exist.
+//
+// Entries that cannot come back keep their place in the list with the reason
+// attached. A restore screen that quietly drops rows is how a human concludes
+// an agent never existed.
+func (s *Service) RestoreCandidates(
+	ctx context.Context,
+) ([]resurrect.Candidate, error) {
+	if s.store == nil {
+		return nil, nil
+	}
+	snapshot, err := s.store.Load()
+	if err != nil {
+		return nil, err
+	}
+	if len(snapshot.Agents) == 0 {
+		return nil, nil
+	}
+
+	live := map[string]bool{}
+	if agents, listErr := s.runtime.ListAgents(ctx); listErr == nil {
+		for _, managedAgent := range agents {
+			live[managedAgent.ID] = true
+		}
+	}
+
+	_, restorable := s.restorer()
+	candidates := make([]resurrect.Candidate, 0, len(snapshot.Agents))
+	for _, entry := range snapshot.Agents {
+		candidates = append(candidates, resurrect.Candidate{
+			Entry:  entry,
+			Live:   live[entry.ID],
+			Reason: s.restoreObstacle(entry, restorable),
+		})
+	}
+	return candidates, nil
+}
+
+// entrySessionID resolves the conversation id an entry holds: the recorded
+// session id when the agent's hooks reported one, else whatever the
+// provider's transcript naming gives back — the fallback that keeps entries
+// recorded before session-id capture restorable.
+func (s *Service) entrySessionID(entry resurrect.Entry) string {
+	return s.providers.SessionID(
+		entry.Provider,
+		entry.SessionID,
+		entry.TranscriptPath,
+	)
+}
+
+// restoreObstacle names why an entry cannot be brought back, or returns an
+// empty string if it can.
+func (s *Service) restoreObstacle(entry resurrect.Entry, restorable bool) string {
+	if !restorable {
+		return "this runtime cannot restore agents"
+	}
+	if !s.providers.CanResume(entry.Provider) {
+		return fmt.Sprintf(
+			"%s cannot reopen a conversation",
+			s.providers.Label(entry.Provider),
+		)
+	}
+	if strings.TrimSpace(entry.TranscriptPath) == "" {
+		return "no transcript: the agent never reported a turn"
+	}
+	if _, err := os.Stat(entry.TranscriptPath); err != nil {
+		return "the transcript is gone"
+	}
+	if s.entrySessionID(entry) == "" {
+		return "the transcript does not name a conversation"
+	}
+	info, err := os.Stat(entry.Cwd)
+	if err != nil || !info.IsDir() {
+		return "the working directory is gone"
+	}
+	return ""
+}
+
+// Restore brings back the named agents, or every restorable one when no id is
+// named. Ids may be shortened the way every other command accepts them.
+func (s *Service) Restore(ctx context.Context, ids ...string) ([]RestoreResult, error) {
+	candidates, err := s.RestoreCandidates(ctx)
+	if err != nil {
+		return nil, err
+	}
+	chosen, err := selectCandidates(candidates, ids)
+	if err != nil {
+		return nil, err
+	}
+	results := make([]RestoreResult, 0, len(chosen))
+	for _, candidate := range chosen {
+		restored, restoreErr := s.restoreOne(ctx, candidate.Entry)
+		results = append(results, RestoreResult{
+			Entry: candidate.Entry,
+			Agent: restored,
+			Err:   restoreErr,
+		})
+	}
+	s.resnapshot(ctx)
+	return results, nil
+}
+
+func (s *Service) restoreOne(
+	ctx context.Context,
+	entry resurrect.Entry,
+) (agent.Agent, error) {
+	restorer, ok := s.restorer()
+	if !ok {
+		return agent.Agent{}, errors.New("this runtime cannot restore agents")
+	}
+	sessionID := s.entrySessionID(entry)
+	if sessionID == "" {
+		return agent.Agent{}, fmt.Errorf(
+			"%s transcript %q does not name a conversation",
+			s.providers.Label(entry.Provider),
+			entry.TranscriptPath,
+		)
+	}
+	launch, err := s.providers.Resume(entry.Provider, sessionID, entry.Mode)
+	if err != nil {
+		return agent.Agent{}, err
+	}
+	restored, err := restorer.Restore(ctx, session.RestoreRequest{
+		Agent: agent.Agent{
+			ID:             entry.ID,
+			Provider:       entry.Provider,
+			Name:           entry.Name,
+			Task:           entry.Task,
+			Summary:        entry.Summary,
+			Cwd:            entry.Cwd,
+			CreatedAt:      entry.CreatedAt,
+			Attention:      entry.Attention,
+			AttentionAt:    entry.AttentionAt,
+			Mark:           entry.Mark,
+			Mode:           entry.Mode,
+			SessionID:      sessionID,
+			TranscriptPath: entry.TranscriptPath,
+			Workspace:      entry.Workspace,
+		},
+		Launch: launch,
+	})
+	if err != nil {
+		return agent.Agent{}, err
+	}
+	diagnostic.Logger().Info("agent restored",
+		"agent_id", restored.ID,
+		"provider", restored.Provider,
+		"window_id", restored.WindowID,
+	)
+	return restored, nil
+}
+
+// Forget drops agents from the record without touching anything running.
+// It is how a human closes the book on an agent whose window died with its
+// server and whose conversation they do not want back.
+func (s *Service) Forget(_ context.Context, ids ...string) error {
+	if s.store == nil || len(ids) == 0 {
+		return nil
+	}
+	snapshot, err := s.store.Load()
+	if err != nil {
+		return err
+	}
+	resolved := make([]string, 0, len(ids))
+	for _, id := range ids {
+		entry, found := snapshot.Find(id)
+		if !found {
+			return fmt.Errorf("no remembered agent %q", id)
+		}
+		resolved = append(resolved, entry.ID)
+	}
+	return s.store.Forget(resolved...)
+}
+
+// selectCandidates resolves the ids a restore names, defaulting to every
+// entry that can come back. Naming an entry that cannot is an error rather
+// than a silent skip: the human asked for that agent specifically and
+// deserves to hear why they are not getting it.
+func selectCandidates(
+	candidates []resurrect.Candidate,
+	ids []string,
+) ([]resurrect.Candidate, error) {
+	if len(ids) == 0 {
+		return resurrect.Restorable(candidates), nil
+	}
+	chosen := make([]resurrect.Candidate, 0, len(ids))
+	for _, id := range ids {
+		index := slices.IndexFunc(candidates, func(c resurrect.Candidate) bool {
+			return c.Entry.ID == id
+		})
+		if index < 0 {
+			matches := 0
+			for position, candidate := range candidates {
+				if strings.HasPrefix(candidate.Entry.ID, id) {
+					index, matches = position, matches+1
+				}
+			}
+			if matches > 1 {
+				return nil, fmt.Errorf("agent id %q is ambiguous", id)
+			}
+		}
+		if index < 0 {
+			return nil, fmt.Errorf("no remembered agent %q", id)
+		}
+		candidate := candidates[index]
+		switch {
+		case candidate.Live:
+			return nil, fmt.Errorf("agent %s is already running", candidate.Entry.ID)
+		case candidate.Reason != "":
+			return nil, fmt.Errorf(
+				"agent %s cannot be restored: %s",
+				candidate.Entry.ID,
+				candidate.Reason,
+			)
+		}
+		chosen = append(chosen, candidate)
+	}
+	return chosen, nil
+}

--- a/internal/app/restore_test.go
+++ b/internal/app/restore_test.go
@@ -1,0 +1,387 @@
+package app
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/trentkm/stormlight/internal/agent"
+	"github.com/trentkm/stormlight/internal/history"
+	"github.com/trentkm/stormlight/internal/provider"
+	"github.com/trentkm/stormlight/internal/resurrect"
+	"github.com/trentkm/stormlight/internal/session"
+	"github.com/trentkm/stormlight/internal/workspace"
+)
+
+// restoringRuntime is a runtime that can lose its roster, and says so.
+type restoringRuntime struct {
+	session.Runtime
+	agents     []agent.Agent
+	rosterLive bool
+	restored   []session.RestoreRequest
+	deleted    []string
+}
+
+func (r *restoringRuntime) ListAgents(context.Context) ([]agent.Agent, error) {
+	return r.agents, nil
+}
+
+func (r *restoringRuntime) SetWorkspace(
+	context.Context,
+	string,
+	workspace.Context,
+) error {
+	return nil
+}
+
+func (r *restoringRuntime) Delete(_ context.Context, id string) error {
+	r.deleted = append(r.deleted, id)
+	r.agents = nil
+	return nil
+}
+
+func (r *restoringRuntime) SessionName() string { return "agents" }
+
+func (r *restoringRuntime) RosterLive(context.Context) (bool, error) {
+	return r.rosterLive, nil
+}
+
+func (r *restoringRuntime) Restore(
+	_ context.Context,
+	req session.RestoreRequest,
+) (agent.Agent, error) {
+	r.restored = append(r.restored, req)
+	restored := req.Agent
+	restored.WindowID = "@restored"
+	restored.ProcessLive = true
+	return restored, nil
+}
+
+// stubClaude puts an executable named `claude` on PATH. Resolving a launch
+// looks the binary up, and CI has no coding agents installed — so the test
+// supplies one rather than asserting only what runs on a developer's laptop.
+func stubClaude(t *testing.T) {
+	t.Helper()
+	directory := t.TempDir()
+	path := filepath.Join(directory, "claude")
+	if err := os.WriteFile(path, []byte("#!/bin/sh\nexit 0\n"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	t.Setenv("PATH", directory)
+}
+
+// transcriptFixture writes a Claude-shaped transcript so an entry naming it
+// looks as restorable as a real one does.
+func transcriptFixture(t *testing.T, sessionID string) string {
+	t.Helper()
+	path := filepath.Join(t.TempDir(), sessionID+".jsonl")
+	if err := os.WriteFile(path, []byte("{}\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	return path
+}
+
+func serviceFixture(
+	t *testing.T,
+	runtime session.Runtime,
+) (*Service, *resurrect.Store) {
+	t.Helper()
+	store := resurrect.NewStoreAt(
+		filepath.Join(t.TempDir(), "state", "session.json"))
+	service := NewServiceWithCatalog(
+		runtime,
+		provider.NewRegistry(),
+		workspace.NewRegistry(),
+		workspace.NewCatalogAt(filepath.Join(t.TempDir(), "workspaces.json")),
+		history.NewLogAt(filepath.Join(t.TempDir(), "sessions.jsonl")),
+	).Remembering(store)
+	return service, store
+}
+
+func liveAgent(t *testing.T, id string) agent.Agent {
+	t.Helper()
+	return agent.Agent{
+		ID:             id,
+		Provider:       agent.ProviderClaude,
+		Name:           "cl-" + id,
+		Task:           "keep going",
+		Cwd:            t.TempDir(),
+		CreatedAt:      time.Unix(1700000000, 0).UTC(),
+		Mode:           agent.ModeAuto,
+		Attention:      agent.AttentionQuestion,
+		AttentionAt:    time.Unix(1700000100, 0).UTC(),
+		TranscriptPath: transcriptFixture(t, "5f2b8c14-0000-4000-8000-000000000001"),
+		ProcessLive:    true,
+	}
+}
+
+func TestListingRecordsTheRoster(t *testing.T) {
+	runtime := &restoringRuntime{
+		agents:     []agent.Agent{liveAgent(t, "a1")},
+		rosterLive: true,
+	}
+	service, store := serviceFixture(t, runtime)
+	if _, err := service.ListAgents(context.Background()); err != nil {
+		t.Fatal(err)
+	}
+	snapshot, err := store.Load()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(snapshot.Agents) != 1 || snapshot.Agents[0].ID != "a1" {
+		t.Fatalf("the listing was not recorded: %#v", snapshot.Agents)
+	}
+	if snapshot.Session != "agents" {
+		t.Fatalf("session = %q, want the runtime's own name", snapshot.Session)
+	}
+}
+
+// The whole point of the record. An empty listing from a runtime whose
+// session is gone means "everything was lost", and writing that as "there
+// are no agents" would destroy the file at the one moment it matters.
+func TestAnEmptyListingFromALostSessionLeavesTheRecordAlone(t *testing.T) {
+	runtime := &restoringRuntime{
+		agents:     []agent.Agent{liveAgent(t, "a1")},
+		rosterLive: true,
+	}
+	service, store := serviceFixture(t, runtime)
+	if _, err := service.ListAgents(context.Background()); err != nil {
+		t.Fatal(err)
+	}
+
+	runtime.agents = nil
+	runtime.rosterLive = false
+	if _, err := service.ListAgents(context.Background()); err != nil {
+		t.Fatal(err)
+	}
+	snapshot, err := store.Load()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(snapshot.Agents) != 1 {
+		t.Fatalf("the record was erased by a lost session: %#v", snapshot.Agents)
+	}
+}
+
+// A session that is genuinely there and genuinely empty is the other half:
+// the record has to follow it down, or deleting your last agent would leave
+// it offering to restore forever.
+func TestAnEmptyListingFromALiveSessionEmptiesTheRecord(t *testing.T) {
+	runtime := &restoringRuntime{
+		agents:     []agent.Agent{liveAgent(t, "a1")},
+		rosterLive: true,
+	}
+	service, store := serviceFixture(t, runtime)
+	if _, err := service.ListAgents(context.Background()); err != nil {
+		t.Fatal(err)
+	}
+	runtime.agents = nil
+	if _, err := service.ListAgents(context.Background()); err != nil {
+		t.Fatal(err)
+	}
+	snapshot, err := store.Load()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(snapshot.Agents) != 0 {
+		t.Fatalf("a live empty session left agents behind: %#v", snapshot.Agents)
+	}
+}
+
+func TestDeleteForgetsTheAgent(t *testing.T) {
+	runtime := &restoringRuntime{
+		agents:     []agent.Agent{liveAgent(t, "a1")},
+		rosterLive: true,
+	}
+	service, store := serviceFixture(t, runtime)
+	if _, err := service.ListAgents(context.Background()); err != nil {
+		t.Fatal(err)
+	}
+	if err := service.Delete(context.Background(), "a1"); err != nil {
+		t.Fatal(err)
+	}
+	snapshot, err := store.Load()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(snapshot.Agents) != 0 {
+		t.Fatalf("a deleted agent is still remembered: %#v", snapshot.Agents)
+	}
+}
+
+func TestRestoreCandidatesExplainWhatCannotComeBack(t *testing.T) {
+	runtime := &restoringRuntime{rosterLive: true}
+	service, store := serviceFixture(t, runtime)
+
+	live := liveAgent(t, "resumable")
+	noTranscript := liveAgent(t, "silent")
+	noTranscript.TranscriptPath = ""
+	otherProvider := liveAgent(t, "codex")
+	otherProvider.Provider = agent.ProviderCodex
+	goneDirectory := liveAgent(t, "orphan")
+	goneDirectory.Cwd = filepath.Join(t.TempDir(), "torn-down-worktree")
+	running := liveAgent(t, "running")
+
+	if err := store.Save("agents", []agent.Agent{
+		live, noTranscript, otherProvider, goneDirectory, running,
+	}); err != nil {
+		t.Fatal(err)
+	}
+	runtime.agents = []agent.Agent{running}
+
+	candidates, err := service.RestoreCandidates(context.Background())
+	if err != nil {
+		t.Fatal(err)
+	}
+	reasons := map[string]resurrect.Candidate{}
+	for _, candidate := range candidates {
+		reasons[candidate.Entry.ID] = candidate
+	}
+	if len(reasons) != 5 {
+		t.Fatalf("candidates dropped rows instead of explaining them: %#v", candidates)
+	}
+	if !reasons["resumable"].Restorable() {
+		t.Errorf("a Claude agent with a transcript was not restorable: %#v",
+			reasons["resumable"])
+	}
+	if reasons["silent"].Reason == "" {
+		t.Error("an agent with no transcript was offered as restorable")
+	}
+	if reasons["codex"].Reason == "" {
+		t.Error("a provider that cannot resume was offered as restorable")
+	}
+	if reasons["orphan"].Reason == "" {
+		t.Error("an agent whose directory is gone was offered as restorable")
+	}
+	if !reasons["running"].Live || reasons["running"].Restorable() {
+		t.Errorf("a running agent was offered for restore: %#v", reasons["running"])
+	}
+}
+
+func TestRestorePreservesIdentityAndCarriesNoPrompt(t *testing.T) {
+	stubClaude(t)
+	runtime := &restoringRuntime{rosterLive: true}
+	service, store := serviceFixture(t, runtime)
+	remembered := liveAgent(t, "a1")
+	if err := store.Save("agents", []agent.Agent{remembered}); err != nil {
+		t.Fatal(err)
+	}
+
+	results, err := service.Restore(context.Background())
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(results) != 1 || results[0].Err != nil {
+		t.Fatalf("restore failed: %#v", results)
+	}
+	if len(runtime.restored) != 1 {
+		t.Fatalf("the runtime was asked to restore %d agents", len(runtime.restored))
+	}
+	request := runtime.restored[0]
+	switch {
+	case request.Agent.ID != "a1":
+		t.Errorf("id = %q; a restored agent must keep its identity", request.Agent.ID)
+	case !request.Agent.CreatedAt.Equal(remembered.CreatedAt):
+		t.Errorf("created_at = %v, want %v",
+			request.Agent.CreatedAt, remembered.CreatedAt)
+	case request.Agent.Attention != agent.AttentionQuestion:
+		t.Errorf("attention = %q; a question left unanswered stays unanswered",
+			request.Agent.Attention)
+	case !request.Agent.AttentionAt.Equal(remembered.AttentionAt):
+		t.Errorf("attention_at = %v; the queue's ordering key must survive",
+			request.Agent.AttentionAt)
+	}
+
+	// The launch must reopen the conversation and stop there. A trailing
+	// prompt would make a reboot start twelve turns nobody asked for.
+	last := request.Launch.Args[len(request.Launch.Args)-1]
+	if last != "--resume=5f2b8c14-0000-4000-8000-000000000001" {
+		t.Fatalf("resume launch ends with %q, want a bare --resume", last)
+	}
+	if request.Agent.Task != "" && last == request.Agent.Task {
+		t.Fatal("the resume launch carried the original task as a prompt")
+	}
+}
+
+func TestRestoreRefusesToNameAnAgentItCannotBringBack(t *testing.T) {
+	runtime := &restoringRuntime{rosterLive: true}
+	service, store := serviceFixture(t, runtime)
+	silent := liveAgent(t, "silent")
+	silent.TranscriptPath = ""
+	if err := store.Save("agents", []agent.Agent{silent}); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := service.Restore(context.Background(), "silent"); err == nil {
+		t.Fatal("restoring an agent with no transcript reported success")
+	}
+	if len(runtime.restored) != 0 {
+		t.Fatal("the runtime was asked to restore an unrestorable agent")
+	}
+}
+
+func TestRestoreOfEverythingSkipsWhatCannotComeBack(t *testing.T) {
+	stubClaude(t)
+	runtime := &restoringRuntime{rosterLive: true}
+	service, store := serviceFixture(t, runtime)
+	silent := liveAgent(t, "silent")
+	silent.TranscriptPath = ""
+	if err := store.Save("agents", []agent.Agent{
+		liveAgent(t, "a1"), silent,
+	}); err != nil {
+		t.Fatal(err)
+	}
+	results, err := service.Restore(context.Background())
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(results) != 1 || results[0].Entry.ID != "a1" {
+		t.Fatalf("a bulk restore did not skip the unrestorable one: %#v", results)
+	}
+}
+
+func TestForgetRejectsAnUnknownAgent(t *testing.T) {
+	service, store := serviceFixture(t, &restoringRuntime{rosterLive: true})
+	if err := store.Save("agents", []agent.Agent{liveAgent(t, "a1")}); err != nil {
+		t.Fatal(err)
+	}
+	if err := service.Forget(context.Background(), "nope"); err == nil {
+		t.Fatal("forgetting an unknown agent reported success")
+	}
+	if err := service.Forget(context.Background(), "a1"); err != nil {
+		t.Fatal(err)
+	}
+	snapshot, err := store.Load()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(snapshot.Agents) != 0 {
+		t.Fatalf("forget left the agent behind: %#v", snapshot.Agents)
+	}
+}
+
+// A runtime with no restore capability must not be asked to remember: the
+// snapshot would describe a roster nothing can rebuild.
+func TestARuntimeThatCannotRestoreIsNotRecorded(t *testing.T) {
+	service, store := serviceFixture(t, &recordingRuntime{
+		agents: []agent.Agent{{ID: "a1", Cwd: t.TempDir()}},
+	})
+	if _, err := service.ListAgents(context.Background()); err != nil {
+		t.Fatal(err)
+	}
+	snapshot, err := store.Load()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(snapshot.Agents) != 0 {
+		t.Fatalf("a runtime with no restore path was recorded: %#v", snapshot.Agents)
+	}
+	candidates, err := service.RestoreCandidates(context.Background())
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(candidates) != 0 {
+		t.Fatalf("candidates from a runtime that cannot restore: %#v", candidates)
+	}
+}

--- a/internal/app/service.go
+++ b/internal/app/service.go
@@ -13,6 +13,7 @@ import (
 	"github.com/trentkm/stormlight/internal/diagnostic"
 	"github.com/trentkm/stormlight/internal/history"
 	"github.com/trentkm/stormlight/internal/provider"
+	"github.com/trentkm/stormlight/internal/resurrect"
 	"github.com/trentkm/stormlight/internal/session"
 	"github.com/trentkm/stormlight/internal/workspace"
 )
@@ -32,7 +33,14 @@ type Service struct {
 	providers  *provider.Registry
 	workspaces *workspace.Registry
 	catalog    *workspace.Catalog
-	sessions   *history.Log
+	// sessions is the permanent conversation log: every session id the
+	// providers ever reported, kept so a conversation can be reopened long
+	// after its window is gone.
+	sessions *history.Log
+	// store keeps the roster on disk so it outlives the runtime hosting it.
+	// A nil store is a service that does not remember, which is what tests
+	// and one-shot commands want.
+	store *resurrect.Store
 
 	// resolved caches catalog-path resolution (one git spawn per path per
 	// call otherwise); the dashboard polls fast, directories change slowly.
@@ -90,6 +98,15 @@ func NewServiceWithCatalog(
 	}
 }
 
+// Remembering gives the service a snapshot store, which is what turns a
+// roster into something that survives its runtime. It is opt-in because
+// remembering means writing to the user's state directory, and a service
+// built for a test or a single query has no business doing that.
+func (s *Service) Remembering(store *resurrect.Store) *Service {
+	s.store = store
+	return s
+}
+
 func (s *Service) ListAgents(ctx context.Context) ([]agent.Agent, error) {
 	agents, err := s.runtime.ListAgents(ctx)
 	if err != nil {
@@ -129,6 +146,7 @@ func (s *Service) ListAgents(ctx context.Context) ([]agent.Agent, error) {
 		agents[index].Workspace = contexts[index]
 	}
 	s.publishStatus(ctx, agents)
+	s.snapshot(ctx, agents)
 	return agents, nil
 }
 
@@ -179,6 +197,7 @@ func (s *Service) Dispatch(ctx context.Context, req DispatchRequest) (agent.Agen
 			"error", err,
 		)
 	}
+	s.resnapshot(ctx)
 	return managedAgent, nil
 }
 
@@ -372,20 +391,38 @@ func (s *Service) Interrupt(ctx context.Context, id string) error {
 // ClearAttention marks an agent's notification as seen, taking down a
 // manual attention mark with it — both mean the same thing to the human.
 func (s *Service) ClearAttention(ctx context.Context, id string) error {
-	return s.runtime.Update(ctx, id, session.Update{ClearAttention: true})
+	return s.Update(ctx, id, session.Update{ClearAttention: true})
 }
 
 // SetMark records the human's own reading of an agent's state, overriding
 // what Stormlight inferred. agent.MarkNone removes an existing mark.
 func (s *Service) SetMark(ctx context.Context, id string, mark agent.Mark) error {
-	return s.runtime.Update(ctx, id, session.Update{
+	return s.Update(ctx, id, session.Update{
 		Mark:      mark,
 		ClearMark: mark == agent.MarkNone,
 	})
 }
 
+// Delete removes an agent and forgets it. Deleting is the human saying they
+// are done with this one, and that has to be recorded here — a later listing
+// cannot tell an agent someone dismissed from one whose window went down with
+// its server, and guessing wrong either resurrects the dead or buries the
+// living.
 func (s *Service) Delete(ctx context.Context, id string) error {
-	return s.runtime.Delete(ctx, id)
+	managedAgent, findErr := s.find(ctx, id)
+	if err := s.runtime.Delete(ctx, id); err != nil {
+		return err
+	}
+	if s.store != nil && findErr == nil {
+		if err := s.store.Forget(managedAgent.ID); err != nil {
+			diagnostic.Logger().Warn("agent not forgotten",
+				"agent_id", managedAgent.ID,
+				"error", err,
+			)
+		}
+	}
+	s.resnapshot(ctx)
+	return nil
 }
 
 func (s *Service) Update(ctx context.Context, id string, update session.Update) error {
@@ -393,6 +430,7 @@ func (s *Service) Update(ctx context.Context, id string, update session.Update) 
 		return err
 	}
 	s.recordHistory(ctx, id)
+	s.resnapshot(ctx)
 	return nil
 }
 
@@ -402,7 +440,7 @@ func (s *Service) Update(ctx context.Context, id string, update session.Update) 
 // id, the one field that makes a record worth keeping. Best-effort by
 // design: history is a byproduct of the update, never a reason to fail it.
 func (s *Service) recordHistory(ctx context.Context, id string) {
-	agents, err := s.runtime.ListAgents(ctx)
+	managedAgent, err := s.find(ctx, id)
 	if err != nil {
 		diagnostic.Logger().Warn("session history listing failed",
 			"agent_id", id,
@@ -410,33 +448,27 @@ func (s *Service) recordHistory(ctx context.Context, id string) {
 		)
 		return
 	}
-	for _, managedAgent := range agents {
-		if managedAgent.ID != id && !strings.HasPrefix(managedAgent.ID, id) {
-			continue
-		}
-		if managedAgent.SessionID == "" {
-			return
-		}
-		if err := s.sessions.Append(history.Record{
-			SessionID:      managedAgent.SessionID,
-			Provider:       managedAgent.Provider,
-			AgentID:        managedAgent.ID,
-			Name:           managedAgent.Name,
-			Task:           managedAgent.Task,
-			Summary:        managedAgent.Summary,
-			Cwd:            managedAgent.Cwd,
-			Mode:           managedAgent.Mode,
-			TranscriptPath: managedAgent.TranscriptPath,
-			Workspace:      managedAgent.Workspace,
-			CreatedAt:      managedAgent.CreatedAt,
-			UpdatedAt:      time.Now().UTC(),
-		}); err != nil {
-			diagnostic.Logger().Warn("session history append failed",
-				"agent_id", id,
-				"error", err,
-			)
-		}
+	if managedAgent.SessionID == "" {
 		return
+	}
+	if err := s.sessions.Append(history.Record{
+		SessionID:      managedAgent.SessionID,
+		Provider:       managedAgent.Provider,
+		AgentID:        managedAgent.ID,
+		Name:           managedAgent.Name,
+		Task:           managedAgent.Task,
+		Summary:        managedAgent.Summary,
+		Cwd:            managedAgent.Cwd,
+		Mode:           managedAgent.Mode,
+		TranscriptPath: managedAgent.TranscriptPath,
+		Workspace:      managedAgent.Workspace,
+		CreatedAt:      managedAgent.CreatedAt,
+		UpdatedAt:      time.Now().UTC(),
+	}); err != nil {
+		diagnostic.Logger().Warn("session history append failed",
+			"agent_id", id,
+			"error", err,
+		)
 	}
 }
 
@@ -472,6 +504,20 @@ func (s *Service) SessionHistory(ctx context.Context) ([]history.Record, error) 
 // to one line per session. Meant for startup, off the event path.
 func (s *Service) CompactSessionHistory() error {
 	return s.sessions.Compact()
+}
+
+// find resolves an id — possibly shortened — against the live roster.
+func (s *Service) find(ctx context.Context, id string) (agent.Agent, error) {
+	agents, err := s.runtime.ListAgents(ctx)
+	if err != nil {
+		return agent.Agent{}, err
+	}
+	for _, managedAgent := range agents {
+		if managedAgent.ID == id || strings.HasPrefix(managedAgent.ID, id) {
+			return managedAgent, nil
+		}
+	}
+	return agent.Agent{}, fmt.Errorf("agent %q not found", id)
 }
 
 func (s *Service) Providers() []provider.Info {

--- a/internal/provider/provider.go
+++ b/internal/provider/provider.go
@@ -3,6 +3,7 @@ package provider
 import (
 	"fmt"
 	"os/exec"
+	"path/filepath"
 	"slices"
 	"strings"
 
@@ -19,24 +20,48 @@ type Info struct {
 	Path      string
 }
 
+// Adapter builds the launches for one provider. Resolve starts a fresh
+// conversation; Resume reopens a recorded one by its session id, with the
+// same lifecycle wiring a fresh dispatch gets and no prompt — reopening
+// hands the conversation back to the human at its composer, it does not
+// start a turn. A machine that reboots overnight has to wake up to agents
+// that are back, not to agents that are working unattended.
 type Adapter interface {
 	ID() agent.Provider
 	Label() string
 	Resolve(prompt string, mode agent.PermissionMode) (Launch, error)
-	// Resume builds the launch that reopens an existing provider session
-	// by its id, with the same lifecycle wiring a fresh dispatch gets.
+	// CanResume reports whether this adapter has a resume path at all.
+	// Capability is a value, not a type: one adapter implementation serves
+	// every command-line provider, and whether a given one can be reopened
+	// is a fact about that provider rather than about the code.
+	CanResume() bool
 	Resume(sessionID string, mode agent.PermissionMode) (Launch, error)
+	// SessionFromTranscript reads the provider's conversation id out of a
+	// transcript path. The recorded session id is the primary handle —
+	// both providers report it on every lifecycle event — but a record
+	// written before that capture existed holds only the transcript path,
+	// and the adapter is the party that knows how its own transcripts are
+	// named. An empty result means the path names nothing resumable.
+	SessionFromTranscript(transcriptPath string) string
 }
 
 type commandAdapter struct {
-	id      agent.Provider
-	label   string
-	binary  string
+	id     agent.Provider
+	label  string
+	binary string
+	// extra is the user's configured extra_args, applied by the adapter
+	// rather than folded into the builders — both dispatch and resume have
+	// to place them, and only the adapter knows both.
+	extra   []string
 	argsFor func(prompt string, mode agent.PermissionMode) ([]string, error)
-	// resumeArgsFor is nil for providers without a known resume verb —
-	// custom specs declare how to start a conversation, not how to reopen
-	// one — and nil is what makes Resume answer "cannot resume".
-	resumeArgsFor func(sessionID string, mode agent.PermissionMode) ([]string, error)
+	// resumeFor builds the arguments that reopen a conversation, or is nil
+	// for a provider that cannot — custom specs declare how to start a
+	// conversation, not how to reopen one. Like argsFor it keeps the
+	// variable argument last, so extra args slot in the same way for both.
+	resumeFor func(sessionID string, mode agent.PermissionMode) ([]string, error)
+	// sessionFor reads the provider's conversation id out of a transcript
+	// path; an empty result means this path names nothing resumable.
+	sessionFor func(transcriptPath string) string
 }
 
 func (a commandAdapter) ID() agent.Provider {
@@ -48,30 +73,57 @@ func (a commandAdapter) Label() string {
 }
 
 func (a commandAdapter) Resolve(prompt string, mode agent.PermissionMode) (Launch, error) {
-	path, err := exec.LookPath(a.binary)
-	if err != nil {
-		return Launch{}, fmt.Errorf("%s is not installed or not on PATH", a.binary)
-	}
-	args, err := a.argsFor(prompt, mode)
-	if err != nil {
-		return Launch{}, err
-	}
-	return Launch{Path: path, Args: args}, nil
+	return a.launch(a.argsFor, prompt, mode)
 }
 
-func (a commandAdapter) Resume(sessionID string, mode agent.PermissionMode) (Launch, error) {
-	if a.resumeArgsFor == nil {
-		return Launch{}, fmt.Errorf("%s sessions cannot be resumed", a.label)
+func (a commandAdapter) CanResume() bool {
+	return a.resumeFor != nil
+}
+
+func (a commandAdapter) Resume(
+	sessionID string,
+	mode agent.PermissionMode,
+) (Launch, error) {
+	if !a.CanResume() {
+		return Launch{}, fmt.Errorf("%s cannot resume a conversation", a.label)
 	}
+	return a.launch(a.resumeFor, sessionID, mode)
+}
+
+func (a commandAdapter) SessionFromTranscript(transcriptPath string) string {
+	if a.sessionFor == nil {
+		return ""
+	}
+	return a.sessionFor(transcriptPath)
+}
+
+func (a commandAdapter) launch(
+	build func(string, agent.PermissionMode) ([]string, error),
+	value string,
+	mode agent.PermissionMode,
+) (Launch, error) {
 	path, err := exec.LookPath(a.binary)
 	if err != nil {
 		return Launch{}, fmt.Errorf("%s is not installed or not on PATH", a.binary)
 	}
-	args, err := a.resumeArgsFor(sessionID, mode)
+	args, err := build(value, mode)
 	if err != nil {
 		return Launch{}, err
 	}
-	return Launch{Path: path, Args: args}, nil
+	return Launch{Path: path, Args: a.withExtra(args)}, nil
+}
+
+// withExtra slots the user's extra args in just before the final argument.
+// Both builders keep the variable part — the prompt, the `--resume=<id>`
+// that stands in for it, or the positional session id — last, so one rule
+// places extras for both.
+func (a commandAdapter) withExtra(args []string) []string {
+	if len(a.extra) == 0 || len(args) == 0 {
+		return args
+	}
+	combined := slices.Clone(args[:len(args)-1])
+	combined = append(combined, a.extra...)
+	return append(combined, args[len(args)-1])
 }
 
 // Spec customizes or declares a provider from user configuration. A Spec
@@ -103,18 +155,20 @@ func NewRegistry() *Registry {
 func NewRegistryWithSpecs(specs []Spec) *Registry {
 	adapters := []Adapter{
 		commandAdapter{
-			id:            agent.ProviderCodex,
-			label:         "Codex",
-			binary:        "codex",
-			argsFor:       codexArgs,
-			resumeArgsFor: codexResumeArgs,
+			id:         agent.ProviderCodex,
+			label:      "Codex",
+			binary:     "codex",
+			argsFor:    codexArgs,
+			resumeFor:  codexResumeArgs,
+			sessionFor: codexSessionID,
 		},
 		commandAdapter{
-			id:            agent.ProviderClaude,
-			label:         "Claude",
-			binary:        "claude",
-			argsFor:       claudeArgs,
-			resumeArgsFor: claudeResumeArgs,
+			id:         agent.ProviderClaude,
+			label:      "Claude",
+			binary:     "claude",
+			argsFor:    claudeArgs,
+			resumeFor:  claudeResumeArgs,
+			sessionFor: claudeSessionID,
 		},
 	}
 
@@ -144,32 +198,7 @@ func customizeBuiltin(builtin commandAdapter, spec Spec) commandAdapter {
 	if spec.Label != "" {
 		builtin.label = spec.Label
 	}
-	if len(spec.ExtraArgs) == 0 {
-		return builtin
-	}
-	base := builtin.argsFor
-	extra := slices.Clone(spec.ExtraArgs)
-	builtin.argsFor = func(prompt string, mode agent.PermissionMode) ([]string, error) {
-		args, err := base(prompt, mode)
-		if err != nil {
-			return nil, err
-		}
-		// Built-in arg builders keep the prompt as the final argument;
-		// extra args slot in just before it.
-		prefix := slices.Clone(args[:len(args)-1])
-		prefix = append(prefix, extra...)
-		return append(prefix, args[len(args)-1]), nil
-	}
-	baseResume := builtin.resumeArgsFor
-	builtin.resumeArgsFor = func(sessionID string, mode agent.PermissionMode) ([]string, error) {
-		args, err := baseResume(sessionID, mode)
-		if err != nil {
-			return nil, err
-		}
-		// A resume launch has no trailing prompt to protect, and both
-		// providers parse flags after the session id, so extra args append.
-		return append(args, extra...), nil
-	}
+	builtin.extra = slices.Clone(spec.ExtraArgs)
 	return builtin
 }
 
@@ -237,6 +266,12 @@ func (r *Registry) Resume(
 	if !ok {
 		return Launch{}, fmt.Errorf("unsupported provider %q", id)
 	}
+	if !adapter.CanResume() {
+		return Launch{}, fmt.Errorf(
+			"%s cannot resume a conversation",
+			adapter.Label(),
+		)
+	}
 	if strings.TrimSpace(sessionID) == "" {
 		return Launch{}, fmt.Errorf("session id cannot be empty")
 	}
@@ -244,6 +279,46 @@ func (r *Registry) Resume(
 		mode = agent.DefaultMode
 	}
 	return adapter.Resume(sessionID, mode)
+}
+
+// SessionID resolves the conversation id a record holds: the recorded id
+// when one was captured, else whatever the provider's transcript naming
+// gives back. Empty means the record names nothing resumable.
+func (r *Registry) SessionID(
+	id agent.Provider,
+	recordedID string,
+	transcriptPath string,
+) string {
+	if strings.TrimSpace(recordedID) != "" {
+		return strings.TrimSpace(recordedID)
+	}
+	adapter, ok := r.adapters[id]
+	if !ok {
+		return ""
+	}
+	return adapter.SessionFromTranscript(transcriptPath)
+}
+
+// CanResume reports whether a provider can reopen its own conversations at
+// all — the question a restore listing asks before it asks about any
+// particular agent.
+func (r *Registry) CanResume(id agent.Provider) bool {
+	adapter, ok := r.adapters[id]
+	if !ok {
+		return false
+	}
+	return adapter.CanResume()
+}
+
+// Label names a provider for a human, falling back to the bare id for one
+// that is configured out of existence — a snapshot outlives the config that
+// dispatched it, so restore has to be able to talk about a provider that is
+// no longer registered.
+func (r *Registry) Label(id agent.Provider) string {
+	if adapter, ok := r.adapters[id]; ok {
+		return adapter.Label()
+	}
+	return string(id)
 }
 
 func (r *Registry) Infos() []Info {
@@ -297,9 +372,10 @@ func codexArgs(prompt string, mode agent.PermissionMode) ([]string, error) {
 
 // codexResumeArgs reopens a recorded session in place of starting one:
 // `codex resume <session-id>` continues the conversation the rollout file
-// holds, and the resumed process carries the same lifecycle wiring a fresh
-// dispatch gets, so it reports into the dashboard like any other agent. No
-// prompt rides along — the reopened conversation is handed to the human.
+// holds, with the same lifecycle wiring a fresh dispatch gets. No prompt
+// rides along — the reopened conversation is handed to the human. The id
+// stays the final argument, positional after the flags, which is where
+// withExtra slots the user's extra args in front of.
 func codexResumeArgs(sessionID string, mode agent.PermissionMode) ([]string, error) {
 	lifecycle, err := codexLifecycleArgs(mode)
 	if err != nil {
@@ -307,6 +383,27 @@ func codexResumeArgs(sessionID string, mode agent.PermissionMode) ([]string, err
 	}
 	args := append([]string{"resume"}, lifecycle...)
 	return append(args, sessionID), nil
+}
+
+// codexSessionID reads the conversation id out of a Codex rollout path.
+// Codex names rollouts `rollout-<timestamp>-<uuid>.jsonl`, so the trailing
+// uuid of the stem is the id `codex resume` takes; anything shaped
+// differently names no conversation.
+func codexSessionID(transcriptPath string) string {
+	stem, found := strings.CutSuffix(
+		filepath.Base(strings.TrimSpace(transcriptPath)),
+		".jsonl",
+	)
+	if !found || !strings.HasPrefix(stem, "rollout-") || len(stem) < 36 {
+		return ""
+	}
+	id := stem[len(stem)-36:]
+	for _, index := range []int{8, 13, 18, 23} {
+		if id[index] != '-' {
+			return ""
+		}
+	}
+	return id
 }
 
 func codexLifecycleArgs(mode agent.PermissionMode) ([]string, error) {
@@ -359,24 +456,42 @@ func codexModeArgs(mode agent.PermissionMode) []string {
 	}
 }
 
+// claudeSessionID reads the conversation id out of a Claude transcript path.
+// Claude names the file for the session — `<projects>/<slug>/<uuid>.jsonl` —
+// so the basename is the id, and a path that is not a `.jsonl` names no
+// conversation Stormlight can hand back to `--resume`.
+func claudeSessionID(transcriptPath string) string {
+	base := filepath.Base(strings.TrimSpace(transcriptPath))
+	id, found := strings.CutSuffix(base, ".jsonl")
+	if !found || id == "" || id == "." {
+		return ""
+	}
+	return id
+}
+
+// claudeResumeArgs reopens a recorded session in place of starting one,
+// with the same hooks and permission mode a dispatch would give it and no
+// prompt: Claude loads the transcript and idles at its composer.
+//
+// `--resume=<id>` rather than `--resume <id>` because the value has to stay
+// one argument. It is the last one, which is where withExtra slots the
+// user's extra_args in front of — the same rule the prompt gets — and a
+// two-argument spelling would let an extra arg land between the flag and
+// its value.
+func claudeResumeArgs(sessionID string, mode agent.PermissionMode) ([]string, error) {
+	args, err := claudeLifecycleArgs(mode)
+	if err != nil {
+		return nil, err
+	}
+	return append(args, "--resume="+sessionID), nil
+}
+
 func claudeArgs(prompt string, mode agent.PermissionMode) ([]string, error) {
 	args, err := claudeLifecycleArgs(mode)
 	if err != nil {
 		return nil, err
 	}
 	return append(args, prompt), nil
-}
-
-// claudeResumeArgs reopens a recorded session in place of starting one:
-// `claude --resume <session-id>` continues the conversation from its
-// transcript, with the same lifecycle wiring a fresh dispatch gets. No
-// prompt rides along — the reopened conversation is handed to the human.
-func claudeResumeArgs(sessionID string, mode agent.PermissionMode) ([]string, error) {
-	args, err := claudeLifecycleArgs(mode)
-	if err != nil {
-		return nil, err
-	}
-	return append(args, "--resume", sessionID), nil
 }
 
 func claudeLifecycleArgs(mode agent.PermissionMode) ([]string, error) {

--- a/internal/provider/provider_test.go
+++ b/internal/provider/provider_test.go
@@ -236,8 +236,7 @@ func TestResumeArgsReopenSessionWithLifecycleWiring(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	count := len(claude)
-	if count < 2 || claude[count-2] != "--resume" || claude[count-1] != sessionID {
+	if claude[len(claude)-1] != "--resume="+sessionID {
 		t.Fatalf("claude resume args = %#v", claude)
 	}
 	if claude[0] != "--settings" ||
@@ -274,22 +273,22 @@ func TestRegistryResumeRejectsCustomProvidersAndEmptyIDs(t *testing.T) {
 	}
 }
 
-func TestBuiltinSpecExtraArgsRideResumeLaunches(t *testing.T) {
-	registry := NewRegistryWithSpecs([]Spec{{
-		ID:        agent.ProviderClaude,
-		Binary:    "echo",
-		ExtraArgs: []string{"--model", "opus"},
-	}})
-	launch, err := registry.Resume(agent.ProviderClaude, "some-id", agent.ModeAsk)
-	if err != nil {
-		t.Fatal(err)
+// Codex derives the session id from its rollout naming —
+// `rollout-<timestamp>-<uuid>.jsonl` — the fallback handle for records
+// written before hook payloads carried session_id.
+func TestCodexSessionIDReadsTheRolloutBasename(t *testing.T) {
+	cases := map[string]string{
+		"/Users/u/.codex/sessions/2026/08/09/rollout-2026-08-09T10-19-00-019fe71b-1a86-7400-b39d-74bf1c5f903d.jsonl": "019fe71b-1a86-7400-b39d-74bf1c5f903d",
+		"rollout-2026-08-09T10-19-00-019fe71b-1a86-7400-b39d-74bf1c5f903d.jsonl":                                     "019fe71b-1a86-7400-b39d-74bf1c5f903d",
+		"/Users/u/.codex/history.jsonl": "",
+		"rollout-short.jsonl":           "",
+		"019fe71b-1a86-7400-b39d-74bf1c5f903d.jsonl": "",
+		"": "",
 	}
-	count := len(launch.Args)
-	if launch.Args[count-1] != "opus" || launch.Args[count-2] != "--model" {
-		t.Fatalf("extra args lost on resume: %#v", launch.Args)
-	}
-	if !slices.Contains(launch.Args, "--resume") {
-		t.Fatalf("resume flag lost: %#v", launch.Args)
+	for path, want := range cases {
+		if got := codexSessionID(path); got != want {
+			t.Errorf("codexSessionID(%q) = %q, want %q", path, got, want)
+		}
 	}
 }
 
@@ -339,5 +338,84 @@ func TestClaudeArgsConfigureLifecycleHooks(t *testing.T) {
 	// no longer exists.
 	if groups := settings.Hooks["PermissionRequest"]; len(groups) != 0 {
 		t.Fatalf("PermissionRequest hook resurfaced: %#v", groups)
+	}
+}
+
+func TestClaudeResumeArgsCarryTheHooksAndNoPrompt(t *testing.T) {
+	args, err := claudeResumeArgs("5f2b8c14-0000-4000-8000-000000000001", agent.ModeAuto)
+	if err != nil {
+		t.Fatal(err)
+	}
+	// Reopening a conversation is not resuming its work: the launch ends at
+	// --resume, with nothing after it that Claude would read as a prompt.
+	last := args[len(args)-1]
+	if last != "--resume=5f2b8c14-0000-4000-8000-000000000001" {
+		t.Fatalf("resume args end with %q: %#v", last, args)
+	}
+	if !slices.Contains(args, "--settings") {
+		t.Fatalf("a restored agent lost its lifecycle hooks: %#v", args)
+	}
+	// The permission mode has to survive too, or an auto agent comes back
+	// asking about every edit it was cleared to make before the reboot.
+	if !slices.Contains(args, "bypassPermissions") {
+		t.Fatalf("permission mode lost on resume: %#v", args)
+	}
+}
+
+// The session id has to stay one argument, because that is what lets a
+// user's extra_args slot in ahead of it the way they do ahead of a prompt.
+func TestResumeKeepsExtraArgsOffTheSessionID(t *testing.T) {
+	registry := NewRegistryWithSpecs([]Spec{{
+		ID:        agent.ProviderClaude,
+		Binary:    "echo",
+		ExtraArgs: []string{"--model", "opus"},
+	}})
+	launch, err := registry.Resume(
+		agent.ProviderClaude,
+		"5f2b8c14-0000-4000-8000-000000000001",
+		agent.ModeAuto,
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+	count := len(launch.Args)
+	if launch.Args[count-1] != "--resume=5f2b8c14-0000-4000-8000-000000000001" ||
+		launch.Args[count-2] != "opus" || launch.Args[count-3] != "--model" {
+		t.Fatalf("extra args misplaced on resume: %#v", launch.Args)
+	}
+}
+
+func TestClaudeSessionIDReadsTheTranscriptBasename(t *testing.T) {
+	cases := map[string]string{
+		"/home/u/.claude/projects/slug/abc-123.jsonl": "abc-123",
+		"abc-123.jsonl": "abc-123",
+		"/home/u/.claude/projects/slug/abc-123.json": "",
+		"/home/u/.claude/projects/slug/":             "",
+		"":                                           "",
+	}
+	for path, want := range cases {
+		if got := claudeSessionID(path); got != want {
+			t.Errorf("claudeSessionID(%q) = %q, want %q", path, got, want)
+		}
+	}
+}
+
+// Both built-in providers can reopen their own conversations — verified
+// against `claude --resume` and `codex resume` (codex-cli 0.147.0) — and a
+// provider that cannot has to say so: a restore screen that silently
+// offered one would spawn a command nobody verified.
+func TestProvidersDeclareWhetherTheyCanResume(t *testing.T) {
+	registry := NewRegistry()
+	if !registry.CanResume(agent.ProviderClaude) {
+		t.Error("Claude should be resumable")
+	}
+	if !registry.CanResume(agent.ProviderCodex) {
+		t.Error("Codex should be resumable")
+	}
+	if registry.CanResume(agent.Provider("nope")) {
+		t.Error("an unknown provider claims a resume path")
+	}
+	if _, err := registry.Resume(agent.ProviderClaude, "  ", agent.ModeAuto); err == nil {
+		t.Error("resuming with no session id reported success")
 	}
 }

--- a/internal/provider/provider_test.go
+++ b/internal/provider/provider_test.go
@@ -280,8 +280,8 @@ func TestCodexSessionIDReadsTheRolloutBasename(t *testing.T) {
 	cases := map[string]string{
 		"/Users/u/.codex/sessions/2026/08/09/rollout-2026-08-09T10-19-00-019fe71b-1a86-7400-b39d-74bf1c5f903d.jsonl": "019fe71b-1a86-7400-b39d-74bf1c5f903d",
 		"rollout-2026-08-09T10-19-00-019fe71b-1a86-7400-b39d-74bf1c5f903d.jsonl":                                     "019fe71b-1a86-7400-b39d-74bf1c5f903d",
-		"/Users/u/.codex/history.jsonl": "",
-		"rollout-short.jsonl":           "",
+		"/Users/u/.codex/history.jsonl":              "",
+		"rollout-short.jsonl":                        "",
 		"019fe71b-1a86-7400-b39d-74bf1c5f903d.jsonl": "",
 		"": "",
 	}

--- a/internal/resurrect/candidate.go
+++ b/internal/resurrect/candidate.go
@@ -1,0 +1,33 @@
+package resurrect
+
+// Candidate is a snapshot entry weighed against the world as it is now: the
+// providers installed, the directories that still exist, the agents already
+// running. It is what both the dashboard and `stormlight restore` read.
+//
+// An entry that cannot come back keeps its place in the list with the reason
+// attached, rather than being filtered out. A roster that quietly loses rows
+// is how a human concludes an agent never existed.
+type Candidate struct {
+	Entry Entry
+	// Live is true when an agent with this id is already running — the
+	// snapshot and the runtime agree, and there is nothing to restore.
+	Live bool
+	// Reason is why this entry cannot be restored; empty means it can.
+	Reason string
+}
+
+// Restorable reports whether restoring this candidate would do anything.
+func (c Candidate) Restorable() bool {
+	return !c.Live && c.Reason == ""
+}
+
+// Restorable filters candidates down to the ones a restore would act on.
+func Restorable(candidates []Candidate) []Candidate {
+	var out []Candidate
+	for _, candidate := range candidates {
+		if candidate.Restorable() {
+			out = append(out, candidate)
+		}
+	}
+	return out
+}

--- a/internal/resurrect/snapshot.go
+++ b/internal/resurrect/snapshot.go
@@ -1,0 +1,326 @@
+// Package resurrect keeps a record of the agent roster on disk so it can
+// outlive the tmux server that hosts it.
+//
+// Everything Stormlight knows about an agent lives in tmux window options,
+// next to the process the options describe. That is the right home while the
+// server is up and the wrong one the instant it is not: a reboot, a
+// kill-server, or an OOM takes the whole roster with it — not just the
+// processes, which were always going to die, but the record of which
+// workspace each agent was in, what it was asked to do, and which of them was
+// waiting on an answer.
+//
+// The providers keep their side. A Claude conversation is still sitting in
+// its transcript file. So the loss is Stormlight's alone to fix, and this
+// package is the fix: a snapshot mirroring the roster, captured continuously
+// because a server death gives no warning.
+package resurrect
+
+import (
+	"encoding/json"
+	"errors"
+	"fmt"
+	"os"
+	"path/filepath"
+	"slices"
+	"strings"
+	"sync"
+	"time"
+
+	"github.com/trentkm/stormlight/internal/agent"
+	"github.com/trentkm/stormlight/internal/workspace"
+)
+
+const snapshotVersion = 1
+
+// Entry is one agent as the snapshot remembers it: everything the runtime
+// would have to be told to build the window back, plus the state that makes
+// the restored row read the way the lost one did.
+//
+// Live process state is deliberately absent. Activity, exit codes, and pane
+// ids describe a process that is by definition gone by the time anyone reads
+// this file; recording them would only invite a restore that claims to know
+// something it cannot.
+type Entry struct {
+	ID          string               `json:"id"`
+	Provider    agent.Provider       `json:"provider"`
+	Name        string               `json:"name"`
+	Task        string               `json:"task"`
+	Summary     string               `json:"summary,omitempty"`
+	Cwd         string               `json:"cwd"`
+	CreatedAt   time.Time            `json:"created_at,omitzero"`
+	Mode        agent.PermissionMode `json:"mode,omitempty"`
+	Attention   agent.Attention      `json:"attention,omitempty"`
+	AttentionAt time.Time            `json:"attention_at,omitzero"`
+	Mark        agent.Mark           `json:"mark,omitempty"`
+	// SessionID is the provider's own id for the conversation — the value
+	// its resume command takes — reported by its lifecycle hooks. It is
+	// the primary handle for bringing the conversation back.
+	SessionID string `json:"session_id,omitempty"`
+	// TranscriptPath is the provider's own conversation file. It is the
+	// fallback handle — an entry recorded before session ids were captured
+	// still names its conversation through the transcript's filename — and
+	// the existence check that says whether the provider still holds the
+	// conversation at all.
+	TranscriptPath string            `json:"transcript_path,omitempty"`
+	Workspace      workspace.Context `json:"workspace"`
+}
+
+// Snapshot is the whole roster at one moment, plus the session it belonged
+// to — restoring into a differently-named session is a different world, and
+// the file says which one it came from rather than assuming.
+type Snapshot struct {
+	Version int       `json:"version"`
+	Session string    `json:"session,omitempty"`
+	SavedAt time.Time `json:"saved_at"`
+	Agents  []Entry   `json:"agents"`
+}
+
+// Find returns the entry with the given id, or a prefix of it, matching how
+// every other Stormlight command accepts a shortened agent id.
+func (s Snapshot) Find(id string) (Entry, bool) {
+	for _, entry := range s.Agents {
+		if entry.ID == id {
+			return entry, true
+		}
+	}
+	var match Entry
+	found := false
+	for _, entry := range s.Agents {
+		if !strings.HasPrefix(entry.ID, id) {
+			continue
+		}
+		if found {
+			return Entry{}, false
+		}
+		match, found = entry, true
+	}
+	return match, found
+}
+
+// EntryOf reduces a live agent to what survives it.
+func EntryOf(live agent.Agent) Entry {
+	return Entry{
+		ID:             live.ID,
+		Provider:       live.Provider,
+		Name:           live.Name,
+		Task:           live.Task,
+		Summary:        live.Summary,
+		Cwd:            live.Cwd,
+		CreatedAt:      live.CreatedAt,
+		Mode:           live.Mode,
+		Attention:      live.Attention,
+		AttentionAt:    live.AttentionAt,
+		Mark:           live.Mark,
+		SessionID:      live.SessionID,
+		TranscriptPath: live.TranscriptPath,
+		Workspace:      live.Workspace,
+	}
+}
+
+// Store is the snapshot file. Writes are atomic — a temporary file renamed
+// over the target — because the thing most likely to interrupt one is
+// exactly the event the file exists for.
+type Store struct {
+	path string
+	mu   sync.Mutex
+
+	// fingerprint is the last roster written. A dashboard polls the runtime
+	// about once a second and the roster changes far less often than that, so
+	// the common case is recognising that there is nothing to write.
+	fingerprint string
+}
+
+func NewStore() *Store {
+	return &Store{path: SnapshotPath()}
+}
+
+func NewStoreAt(path string) *Store {
+	return &Store{path: path}
+}
+
+// Path is where this store writes, for commands that want to name the file.
+func (s *Store) Path() string {
+	return s.path
+}
+
+func (s *Store) Load() (Snapshot, error) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	return s.read()
+}
+
+// Save replaces the snapshot with the given roster.
+//
+// It is only ever called with an authoritative listing. "No agents" and "no
+// tmux server" arrive as the same empty slice, and writing the second as the
+// first would erase the snapshot at precisely the moment it is needed; the
+// caller settles that question before calling, because only the runtime can.
+func (s *Store) Save(sessionName string, agents []agent.Agent) error {
+	entries := make([]Entry, 0, len(agents))
+	for _, live := range agents {
+		entries = append(entries, EntryOf(live))
+	}
+	// A total order, because tmux stamps creation to the second: two agents
+	// dispatched together would otherwise swap places between saves and make
+	// every listing look like a change.
+	slices.SortFunc(entries, func(a, b Entry) int {
+		if order := a.CreatedAt.Compare(b.CreatedAt); order != 0 {
+			return order
+		}
+		return strings.Compare(a.ID, b.ID)
+	})
+
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	print := fingerprint(sessionName, entries)
+	if print == s.fingerprint {
+		return nil
+	}
+	if err := s.write(Snapshot{
+		Session: sessionName,
+		SavedAt: time.Now().UTC(),
+		Agents:  entries,
+	}); err != nil {
+		return err
+	}
+	s.fingerprint = print
+	return nil
+}
+
+// Forget drops one agent from the snapshot. Deleting an agent is the human
+// saying they are done with it, and a roster listing cannot distinguish that
+// from a window that vanished with its server — so the deletion says so
+// itself, here, rather than being inferred later.
+func (s *Store) Forget(ids ...string) error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	data, err := s.read()
+	if err != nil {
+		return err
+	}
+	before := len(data.Agents)
+	data.Agents = slices.DeleteFunc(data.Agents, func(entry Entry) bool {
+		return slices.Contains(ids, entry.ID)
+	})
+	if len(data.Agents) == before {
+		return nil
+	}
+	data.SavedAt = time.Now().UTC()
+	if err := s.write(data); err != nil {
+		return err
+	}
+	s.fingerprint = fingerprint(data.Session, data.Agents)
+	return nil
+}
+
+func (s *Store) read() (Snapshot, error) {
+	data := Snapshot{Version: snapshotVersion}
+	if strings.TrimSpace(s.path) == "" {
+		return data, nil
+	}
+	content, err := os.ReadFile(s.path)
+	if errors.Is(err, os.ErrNotExist) {
+		return data, nil
+	}
+	if err != nil {
+		return Snapshot{}, fmt.Errorf("read agent snapshot: %w", err)
+	}
+	if err := json.Unmarshal(content, &data); err != nil {
+		return Snapshot{}, fmt.Errorf("decode agent snapshot: %w", err)
+	}
+	if data.Version != snapshotVersion {
+		return Snapshot{}, fmt.Errorf(
+			"unsupported agent snapshot version %d",
+			data.Version,
+		)
+	}
+	return data, nil
+}
+
+func (s *Store) write(data Snapshot) error {
+	if strings.TrimSpace(s.path) == "" {
+		return nil
+	}
+	data.Version = snapshotVersion
+	if data.Agents == nil {
+		data.Agents = []Entry{}
+	}
+	directory := filepath.Dir(s.path)
+	if err := os.MkdirAll(directory, 0o700); err != nil {
+		return fmt.Errorf("create agent snapshot directory: %w", err)
+	}
+	file, err := os.CreateTemp(directory, ".session-*")
+	if err != nil {
+		return fmt.Errorf("create agent snapshot: %w", err)
+	}
+	temporaryPath := file.Name()
+	defer os.Remove(temporaryPath)
+
+	if err := file.Chmod(0o600); err != nil {
+		_ = file.Close()
+		return fmt.Errorf("set agent snapshot permissions: %w", err)
+	}
+	encoder := json.NewEncoder(file)
+	encoder.SetIndent("", "  ")
+	if err := encoder.Encode(data); err != nil {
+		_ = file.Close()
+		return fmt.Errorf("encode agent snapshot: %w", err)
+	}
+	if err := file.Sync(); err != nil {
+		_ = file.Close()
+		return fmt.Errorf("sync agent snapshot: %w", err)
+	}
+	if err := file.Close(); err != nil {
+		return fmt.Errorf("close agent snapshot: %w", err)
+	}
+	if err := os.Rename(temporaryPath, s.path); err != nil {
+		return fmt.Errorf("replace agent snapshot: %w", err)
+	}
+	return nil
+}
+
+// fingerprint covers the fields a restore reads back. Anything outside it
+// changing is not a reason to rewrite the file — and the timestamp the write
+// stamps is deliberately outside it, or every save would look like a change.
+func fingerprint(sessionName string, entries []Entry) string {
+	var builder strings.Builder
+	builder.WriteString(sessionName)
+	for _, entry := range entries {
+		builder.WriteString("\x1f")
+		builder.WriteString(strings.Join([]string{
+			entry.ID,
+			string(entry.Provider),
+			entry.Name,
+			entry.Task,
+			entry.Summary,
+			entry.Cwd,
+			string(entry.Mode),
+			string(entry.Attention),
+			string(entry.Mark),
+			entry.SessionID,
+			entry.TranscriptPath,
+			entry.Workspace.ID,
+			entry.Workspace.ExecutionRoot,
+		}, "\x1e"))
+	}
+	return builder.String()
+}
+
+// SnapshotPath sits beside the workspace catalog in XDG state, and answers
+// to an override of its own for tests and for running more than one
+// Stormlight against one machine.
+func SnapshotPath() string {
+	if configured := os.Getenv("STORMLIGHT_SNAPSHOT_FILE"); configured != "" {
+		return configured
+	}
+	if stateHome := os.Getenv("XDG_STATE_HOME"); stateHome != "" {
+		return filepath.Join(stateHome, "stormlight", "session.json")
+	}
+	home, err := os.UserHomeDir()
+	if err != nil {
+		return ""
+	}
+	return filepath.Join(home, ".local", "state", "stormlight", "session.json")
+}

--- a/internal/resurrect/snapshot_test.go
+++ b/internal/resurrect/snapshot_test.go
@@ -1,0 +1,222 @@
+package resurrect
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/trentkm/stormlight/internal/agent"
+	"github.com/trentkm/stormlight/internal/workspace"
+)
+
+func storeFixture(t *testing.T) *Store {
+	t.Helper()
+	return NewStoreAt(filepath.Join(t.TempDir(), "state", "session.json"))
+}
+
+func agentFixture(id string) agent.Agent {
+	return agent.Agent{
+		ID:             id,
+		Provider:       agent.ProviderClaude,
+		Name:           "cl-" + id,
+		Task:           "do the thing",
+		Summary:        "did the thing",
+		Cwd:            "/tmp/work",
+		CreatedAt:      time.Unix(1700000000, 0).UTC(),
+		Activity:       agent.ActivityWorking,
+		Attention:      agent.AttentionQuestion,
+		AttentionAt:    time.Unix(1700000100, 0).UTC(),
+		Mode:           agent.ModeAuto,
+		TranscriptPath: "/tmp/transcripts/" + id + ".jsonl",
+		PaneID:         "%9",
+		ProcessLive:    true,
+		Workspace:      workspace.DirectoryContext("/tmp/work"),
+	}
+}
+
+func TestSaveAndLoadRoundTripsTheFieldsRestoreNeeds(t *testing.T) {
+	store := storeFixture(t)
+	if err := store.Save("agents", []agent.Agent{agentFixture("a1")}); err != nil {
+		t.Fatal(err)
+	}
+	snapshot, err := store.Load()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if snapshot.Session != "agents" || len(snapshot.Agents) != 1 {
+		t.Fatalf("snapshot did not record the roster: %#v", snapshot)
+	}
+	entry := snapshot.Agents[0]
+	want := agentFixture("a1")
+	switch {
+	case entry.ID != want.ID:
+		t.Errorf("id = %q, want %q", entry.ID, want.ID)
+	case entry.TranscriptPath != want.TranscriptPath:
+		t.Errorf("transcript = %q, want %q",
+			entry.TranscriptPath, want.TranscriptPath)
+	case entry.Attention != want.Attention:
+		t.Errorf("attention = %q, want %q", entry.Attention, want.Attention)
+	case !entry.AttentionAt.Equal(want.AttentionAt):
+		t.Errorf("attention_at = %v, want %v", entry.AttentionAt, want.AttentionAt)
+	case entry.Mode != want.Mode:
+		t.Errorf("mode = %q, want %q", entry.Mode, want.Mode)
+	case entry.Workspace.Root != want.Workspace.Root:
+		t.Errorf("workspace root = %q, want %q",
+			entry.Workspace.Root, want.Workspace.Root)
+	}
+}
+
+// A restore must never claim to know what a dead process was doing, so
+// activity and pane identity deliberately do not survive the write.
+func TestSnapshotOmitsLiveProcessState(t *testing.T) {
+	store := storeFixture(t)
+	if err := store.Save("agents", []agent.Agent{agentFixture("a1")}); err != nil {
+		t.Fatal(err)
+	}
+	content, err := os.ReadFile(store.Path())
+	if err != nil {
+		t.Fatal(err)
+	}
+	var raw struct {
+		Agents []map[string]any `json:"agents"`
+	}
+	if err := json.Unmarshal(content, &raw); err != nil {
+		t.Fatal(err)
+	}
+	for _, forbidden := range []string{"activity", "pane_id", "process_live"} {
+		if _, present := raw.Agents[0][forbidden]; present {
+			t.Errorf("snapshot recorded %q, which describes a dead process", forbidden)
+		}
+	}
+}
+
+func TestSaveSkipsAnUnchangedRoster(t *testing.T) {
+	store := storeFixture(t)
+	agents := []agent.Agent{agentFixture("a1")}
+	if err := store.Save("agents", agents); err != nil {
+		t.Fatal(err)
+	}
+	// Tamper with the file, then save the same roster. Surviving bytes are
+	// proof no write happened — where a timestamp comparison would only
+	// prove the two writes landed inside one clock tick. A dashboard polls
+	// this path about once a second and the roster changes far less often.
+	marker := []byte(`{"version":1,"session":"tampered","agents":[]}`)
+	if err := os.WriteFile(store.Path(), marker, 0o600); err != nil {
+		t.Fatal(err)
+	}
+	if err := store.Save("agents", agents); err != nil {
+		t.Fatal(err)
+	}
+	content, err := os.ReadFile(store.Path())
+	if err != nil {
+		t.Fatal(err)
+	}
+	if string(content) != string(marker) {
+		t.Fatal("an unchanged roster was written again")
+	}
+
+	changed := []agent.Agent{agentFixture("a1")}
+	changed[0].Summary = "something new"
+	if err := store.Save("agents", changed); err != nil {
+		t.Fatal(err)
+	}
+	snapshot, err := store.Load()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if snapshot.Agents[0].Summary != "something new" {
+		t.Fatalf("a changed roster was not written: %#v", snapshot.Agents[0])
+	}
+}
+
+func TestForgetDropsOnlyTheNamedAgents(t *testing.T) {
+	store := storeFixture(t)
+	if err := store.Save("agents", []agent.Agent{
+		agentFixture("a1"),
+		agentFixture("a2"),
+	}); err != nil {
+		t.Fatal(err)
+	}
+	if err := store.Forget("a1"); err != nil {
+		t.Fatal(err)
+	}
+	snapshot, err := store.Load()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(snapshot.Agents) != 1 || snapshot.Agents[0].ID != "a2" {
+		t.Fatalf("forget did not leave a2 alone: %#v", snapshot.Agents)
+	}
+}
+
+// Forget has to invalidate the fingerprint too, or the next identical
+// listing would decide there was nothing to write and leave the agent
+// deleted in tmux but remembered on disk.
+func TestForgetLetsTheNextIdenticalSaveRewrite(t *testing.T) {
+	store := storeFixture(t)
+	agents := []agent.Agent{agentFixture("a1"), agentFixture("a2")}
+	if err := store.Save("agents", agents); err != nil {
+		t.Fatal(err)
+	}
+	if err := store.Forget("a1"); err != nil {
+		t.Fatal(err)
+	}
+	if err := store.Save("agents", agents); err != nil {
+		t.Fatal(err)
+	}
+	snapshot, err := store.Load()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(snapshot.Agents) != 2 {
+		t.Fatalf("the roster was not written back after a forget: %#v",
+			snapshot.Agents)
+	}
+}
+
+func TestLoadRejectsAnUnknownVersion(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "session.json")
+	if err := os.WriteFile(path, []byte(`{"version":99,"agents":[]}`), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := NewStoreAt(path).Load(); err == nil {
+		t.Fatal("a future snapshot version loaded without complaint")
+	}
+}
+
+func TestLoadOfAMissingFileIsEmptyRatherThanAnError(t *testing.T) {
+	snapshot, err := storeFixture(t).Load()
+	if err != nil {
+		t.Fatalf("a first run should not fail: %v", err)
+	}
+	if len(snapshot.Agents) != 0 {
+		t.Fatalf("empty store returned agents: %#v", snapshot.Agents)
+	}
+}
+
+func TestFindAcceptsAShortenedID(t *testing.T) {
+	snapshot := Snapshot{Agents: []Entry{{ID: "abcdef01"}, {ID: "abcff002"}}}
+	if entry, ok := snapshot.Find("abcd"); !ok || entry.ID != "abcdef01" {
+		t.Fatalf("prefix lookup returned %#v (ok=%v)", entry, ok)
+	}
+	if _, ok := snapshot.Find("abc"); ok {
+		t.Fatal("an ambiguous prefix resolved to a single agent")
+	}
+	if _, ok := snapshot.Find("zz"); ok {
+		t.Fatal("an unknown id resolved")
+	}
+}
+
+func TestRestorableKeepsOnlyWhatCanComeBack(t *testing.T) {
+	candidates := []Candidate{
+		{Entry: Entry{ID: "ready"}},
+		{Entry: Entry{ID: "running"}, Live: true},
+		{Entry: Entry{ID: "blocked"}, Reason: "no transcript"},
+	}
+	restorable := Restorable(candidates)
+	if len(restorable) != 1 || restorable[0].Entry.ID != "ready" {
+		t.Fatalf("restorable = %#v", restorable)
+	}
+}

--- a/internal/session/runtime.go
+++ b/internal/session/runtime.go
@@ -24,6 +24,36 @@ type Runtime interface {
 	SyncWindowSizes(context.Context, int, int) error
 }
 
+// Restorer is an optional runtime capability: a runtime whose agent records
+// live and die with the runtime itself, and which can therefore be handed a
+// record from before it started and asked to build the agent back.
+//
+// It is separate from Runtime because it is about the runtime's own
+// mortality rather than about agents: a runtime that persists its roster by
+// construction has nothing to restore, and callers treat its absence as
+// "this roster cannot be lost".
+type Restorer interface {
+	// SessionName identifies the world a roster belongs to, so a record
+	// written by one can say which one it came from.
+	SessionName() string
+	// RosterLive reports whether the runtime's agent listing is
+	// authoritative right now. An empty listing is ambiguous — it reads the
+	// same whether the last agent was deleted or the whole session is gone —
+	// and the difference decides whether a snapshot may be overwritten with
+	// nothing. False means the roster is not there to be believed.
+	RosterLive(context.Context) (bool, error)
+	// Restore builds an agent back from a record, preserving its identity so
+	// continuity holds across the gap.
+	Restore(context.Context, RestoreRequest) (agent.Agent, error)
+}
+
+// RestoreRequest is a dispatch whose identity and history already exist. The
+// runtime is being told what the agent was, not asked to invent one.
+type RestoreRequest struct {
+	Agent  agent.Agent
+	Launch Launch
+}
+
 // StatusPublisher is an optional runtime capability: a runtime whose
 // terminal has chrome of its own can carry Stormlight's tally on it, so the
 // count of what is working and what is waiting stays readable from inside an

--- a/internal/tmux/runtime.go
+++ b/internal/tmux/runtime.go
@@ -143,7 +143,10 @@ type Runtime struct {
 	publishedStatus string
 }
 
-var _ session.Runtime = (*Runtime)(nil)
+var (
+	_ session.Runtime  = (*Runtime)(nil)
+	_ session.Restorer = (*Runtime)(nil)
+)
 
 func NewRuntime(runner Runner, sessionName string) (*Runtime, error) {
 	if sessionName == "" {
@@ -302,28 +305,91 @@ func (r *Runtime) Dispatch(ctx context.Context, req session.DispatchRequest) (ag
 		return agent.Agent{}, err
 	}
 
-	createdAt := time.Now().UTC()
-	options := map[string]string{
-		"@stormlight_id":           id,
-		"@stormlight_provider":     string(req.Provider),
-		"@stormlight_task":         metadataValue(req.Task),
-		"@stormlight_summary":      metadataValue(req.Task),
-		"@stormlight_cwd":          cwd,
-		"@stormlight_created_at":   strconv.FormatInt(createdAt.Unix(), 10),
-		"@stormlight_activity":     string(agent.ActivityStarting),
-		"@stormlight_attention":    "",
-		"@stormlight_attention_at": "",
-		"@stormlight_mark":         "",
-		"@stormlight_pane":         target.paneID,
-		"@stormlight_mode":         string(req.Mode),
+	return r.start(ctx, target, executable, agent.Agent{
+		ID:        id,
+		Provider:  req.Provider,
+		Name:      name,
+		Task:      req.Task,
+		Summary:   req.Task,
+		Cwd:       cwd,
+		CreatedAt: time.Now().UTC(),
+		Activity:  agent.ActivityStarting,
+		Mode:      req.Mode,
+		Workspace: req.Workspace,
+	}, req.Launch)
+}
+
+// Restore builds an agent back from a record that outlived the server it ran
+// on. It is a dispatch that invents nothing: the id, the creation time, the
+// place in the amber inbox, and the transcript all come from the record, so
+// the restored row is the same agent rather than a new one wearing its name.
+//
+// The launch is the caller's business, and by contract carries no prompt —
+// the provider reopens its conversation and idles at the composer. Restoring
+// an agent is not resuming its work.
+func (r *Runtime) Restore(
+	ctx context.Context,
+	req session.RestoreRequest,
+) (agent.Agent, error) {
+	restored := req.Agent
+	if strings.TrimSpace(restored.ID) == "" {
+		return agent.Agent{}, fmt.Errorf("restored agent has no id")
 	}
-	workspaceOptions, err := encodeWorkspaceOptions(req.Workspace)
+	if req.Launch.Path == "" {
+		return agent.Agent{}, fmt.Errorf("provider launch command is empty")
+	}
+	cwd, err := normalizeCwd(restored.Cwd)
+	if err != nil {
+		return agent.Agent{}, err
+	}
+	restored.Cwd = cwd
+	if restored.Name = metadataValue(restored.Name); restored.Name == "" {
+		restored.Name = windowName(restored.Provider, restored.Task)
+	}
+	if restored.CreatedAt.IsZero() {
+		restored.CreatedAt = time.Now().UTC()
+	}
+	// A restored agent is starting, whatever it was doing when the server
+	// died. What it was *waiting on* is a different question, and that the
+	// record keeps: a question left unanswered overnight is still unanswered.
+	restored.Activity = agent.ActivityStarting
+
+	// Resolved before the window exists, exactly as a dispatch does: a
+	// restored agent whose pane dies on a bad launcher path is worse than one
+	// that never came back, because the dashboard lists it as though it had.
+	executable, err := r.launchPath()
+	if err != nil {
+		return agent.Agent{}, err
+	}
+	target, err := r.createWindow(ctx, restored.Name, cwd)
+	if err != nil {
+		return agent.Agent{}, err
+	}
+	return r.start(ctx, target, executable, restored, req.Launch)
+}
+
+// start writes an agent's metadata onto a freshly created window and respawns
+// its pane on the provider. It is the half of dispatch that restore shares:
+// everything from "there is a window" to "there is an agent in it".
+// The executable is passed in rather than resolved here because both callers
+// resolve it before creating a window: a launcher path that names nothing
+// must fail where the caller can report it, not as shell noise in a pane.
+func (r *Runtime) start(
+	ctx context.Context,
+	target windowTarget,
+	executable string,
+	managedAgent agent.Agent,
+	launch session.Launch,
+) (agent.Agent, error) {
+	managedAgent.TmuxSession = r.sessionName
+	managedAgent.WindowID = target.windowID
+	managedAgent.PaneID = target.paneID
+	managedAgent.ProcessLive = true
+
+	options, err := encodeAgentOptions(managedAgent)
 	if err != nil {
 		r.cleanupWindow(target.windowID)
 		return agent.Agent{}, err
-	}
-	for key, value := range workspaceOptions {
-		options[key] = value
 	}
 	for key, value := range options {
 		if _, err := r.runner.Run(ctx, nil, "set-option", "-w", "-t", target.windowID, key, value); err != nil {
@@ -335,7 +401,7 @@ func (r *Runtime) Dispatch(ctx context.Context, req session.DispatchRequest) (ag
 		r.cleanupWindow(target.windowID)
 		return agent.Agent{}, fmt.Errorf("enable pane persistence: %w", err)
 	}
-	payload, err := encodeLaunch(req.Launch)
+	payload, err := encodeLaunch(launch)
 	if err != nil {
 		r.cleanupWindow(target.windowID)
 		return agent.Agent{}, err
@@ -349,32 +415,31 @@ func (r *Runtime) Dispatch(ctx context.Context, req session.DispatchRequest) (ag
 	commandArgs = append(commandArgs,
 		"--session", r.sessionName,
 		"_run",
-		"--id", id,
+		"--id", managedAgent.ID,
 		"--window", target.windowID,
-		"--cwd", cwd,
+		"--cwd", managedAgent.Cwd,
 		"--launch", payload,
 	)
 	command := shellJoin(commandArgs)
-	if _, err := r.runner.Run(ctx, nil, "respawn-pane", "-k", "-t", target.paneID, "-c", cwd, command); err != nil {
+	if _, err := r.runner.Run(ctx, nil, "respawn-pane", "-k", "-t", target.paneID, "-c", managedAgent.Cwd, command); err != nil {
 		r.cleanupWindow(target.windowID)
 		return agent.Agent{}, fmt.Errorf("start provider: %w", err)
 	}
+	return managedAgent, nil
+}
 
-	return agent.Agent{
-		ID:          id,
-		Provider:    req.Provider,
-		Name:        name,
-		Task:        req.Task,
-		Summary:     req.Task,
-		Cwd:         cwd,
-		CreatedAt:   createdAt,
-		Activity:    agent.ActivityStarting,
-		TmuxSession: r.sessionName,
-		WindowID:    target.windowID,
-		PaneID:      target.paneID,
-		ProcessLive: true,
-		Workspace:   req.Workspace,
-	}, nil
+// RosterLive reports whether the managed session exists, which is the only
+// honest way to read an empty agent listing. With no session there is nothing
+// to enumerate, and "no agents" means the roster was lost rather than emptied
+// — the difference between a snapshot worth keeping and one worth erasing.
+func (r *Runtime) RosterLive(ctx context.Context) (bool, error) {
+	if _, err := r.runner.Run(ctx, nil, "has-session", "-t", r.sessionName); err != nil {
+		if isNoServerError(err) || isNoSessionError(err) {
+			return false, nil
+		}
+		return false, fmt.Errorf("inspect managed tmux session: %w", err)
+	}
+	return true, nil
 }
 
 func (r *Runtime) Capture(ctx context.Context, id string, lines int) (string, error) {
@@ -1297,6 +1362,15 @@ func isNoServerError(err error) bool {
 		strings.Contains(text, "failed to connect to server") ||
 		strings.Contains(text, "error connecting to") ||
 		strings.Contains(text, "no sessions")
+}
+
+// isNoSessionError recognises a live server that has never heard of the
+// session — the case where the appliance is up (the dashboard's own host
+// session keeps it up) but every agent went down with the one that held them.
+func isNoSessionError(err error) bool {
+	text := strings.ToLower(err.Error())
+	return strings.Contains(text, "can't find session") ||
+		strings.Contains(text, "session not found")
 }
 
 // tableBinding finds the bind-key line for a key in `list-keys -T <table>`

--- a/internal/tmux/runtime_test.go
+++ b/internal/tmux/runtime_test.go
@@ -3,11 +3,13 @@ package tmux
 import (
 	"context"
 	"errors"
+	"fmt"
 	"path/filepath"
 	"slices"
 	"strconv"
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/trentkm/stormlight/internal/agent"
 	"github.com/trentkm/stormlight/internal/session"
@@ -1235,5 +1237,134 @@ func TestClearAttentionTakesDownTheAttentionMarkOnly(t *testing.T) {
 	}
 	if got := markWrites(runner.calls); len(got) != 0 {
 		t.Fatalf("mark writes = %v, want the in-progress mark kept", got)
+	}
+}
+
+// restoreRunner records the tmux commands a restore issues, and can be told
+// whether the managed session exists.
+type restoreRunner struct {
+	sessionExists bool
+	options       map[string]string
+	respawned     string
+	calls         [][]string
+}
+
+func (r *restoreRunner) Run(_ context.Context, _ []byte, args ...string) (string, error) {
+	r.calls = append(r.calls, slices.Clone(args))
+	if len(args) == 0 {
+		return "", nil
+	}
+	switch args[0] {
+	case "has-session":
+		if r.sessionExists {
+			return "", nil
+		}
+		return "", fmt.Errorf("can't find session: stormlight-agents")
+	case "new-window", "new-session":
+		return "@7" + fieldSeparator + "%7", nil
+	case "show-options":
+		return "1", nil
+	case "set-option":
+		if len(args) >= 6 && args[1] == "-w" {
+			if r.options == nil {
+				r.options = map[string]string{}
+			}
+			r.options[args[4]] = args[5]
+		}
+	case "respawn-pane":
+		r.respawned = args[len(args)-1]
+	}
+	return "", nil
+}
+
+func TestRosterLiveDistinguishesALostSessionFromAnEmptyOne(t *testing.T) {
+	runner := &restoreRunner{}
+	runtime, err := NewRuntime(runner, "stormlight-agents")
+	if err != nil {
+		t.Fatal(err)
+	}
+	// A session tmux has never heard of is not an empty roster — it is a
+	// roster that was lost, and nothing may overwrite the record from it.
+	live, err := runtime.RosterLive(context.Background())
+	if err != nil {
+		t.Fatal(err)
+	}
+	if live {
+		t.Fatal("a missing session reported a live roster")
+	}
+	runner.sessionExists = true
+	live, err = runtime.RosterLive(context.Background())
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !live {
+		t.Fatal("an existing session reported a dead roster")
+	}
+}
+
+func TestRestoreWritesTheRememberedMetadataOntoTheNewWindow(t *testing.T) {
+	runner := &restoreRunner{sessionExists: true}
+	runtime, err := NewRuntime(runner, "stormlight-agents")
+	if err != nil {
+		t.Fatal(err)
+	}
+	createdAt := time.Unix(1700000000, 0).UTC()
+	attentionAt := time.Unix(1700000100, 0).UTC()
+	restored, err := runtime.Restore(context.Background(), session.RestoreRequest{
+		Agent: agent.Agent{
+			ID:             "a1b2c3d4",
+			Provider:       agent.ProviderClaude,
+			Name:           "cl-old-name",
+			Task:           "the original task",
+			Summary:        "where it left off",
+			Cwd:            t.TempDir(),
+			CreatedAt:      createdAt,
+			Attention:      agent.AttentionQuestion,
+			AttentionAt:    attentionAt,
+			Mode:           agent.ModeAuto,
+			TranscriptPath: "/transcripts/a1.jsonl",
+		},
+		Launch: session.Launch{Path: "/usr/bin/claude", Args: []string{"--resume=a1"}},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if restored.ID != "a1b2c3d4" {
+		t.Fatalf("restore invented an id: %q", restored.ID)
+	}
+	// Continuity is the whole promise: the same agent, not a new one wearing
+	// its name. Everything the dashboard keys off has to come from the record.
+	want := map[string]string{
+		"@stormlight_id":              "a1b2c3d4",
+		"@stormlight_created_at":      "1700000000",
+		"@stormlight_attention":       "question",
+		"@stormlight_attention_at":    "1700000100",
+		"@stormlight_summary":         "where it left off",
+		"@stormlight_transcript_path": "/transcripts/a1.jsonl",
+		"@stormlight_mode":            "auto",
+		// A restored agent is starting, whatever it was doing when the
+		// server died.
+		"@stormlight_activity": string(agent.ActivityStarting),
+	}
+	for key, value := range want {
+		if runner.options[key] != value {
+			t.Errorf("%s = %q, want %q", key, runner.options[key], value)
+		}
+	}
+	if !strings.Contains(runner.respawned, "'--id' 'a1b2c3d4'") {
+		t.Fatalf("the supervisor was not told the restored id: %q", runner.respawned)
+	}
+}
+
+func TestRestoreRefusesARecordWithNoIdentity(t *testing.T) {
+	runtime, err := NewRuntime(&restoreRunner{sessionExists: true}, "stormlight-agents")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := runtime.Restore(context.Background(), session.RestoreRequest{
+		Agent:  agent.Agent{Cwd: t.TempDir()},
+		Launch: session.Launch{Path: "/usr/bin/claude"},
+	}); err == nil {
+		t.Fatal("an idless record restored")
 	}
 }

--- a/internal/ui/flows_test.go
+++ b/internal/ui/flows_test.go
@@ -2,13 +2,16 @@ package ui
 
 import (
 	"context"
+	"slices"
 	"strings"
 	"testing"
 
 	tea "charm.land/bubbletea/v2"
 	"github.com/charmbracelet/x/ansi"
 	"github.com/trentkm/stormlight/internal/agent"
+	"github.com/trentkm/stormlight/internal/app"
 	"github.com/trentkm/stormlight/internal/history"
+	"github.com/trentkm/stormlight/internal/resurrect"
 	"github.com/trentkm/stormlight/internal/workspace"
 )
 
@@ -273,7 +276,7 @@ func TestComposerYieldsWhenPromptArrivesMidCompose(t *testing.T) {
 
 func TestHelpModalOpensRendersAndDismisses(t *testing.T) {
 	model := flowModelFixture(t, &flowBackend{})
-	resized, _ := model.Update(tea.WindowSizeMsg{Width: 100, Height: 45})
+	resized, _ := model.Update(tea.WindowSizeMsg{Width: 100, Height: 50})
 	model = resized.(Model)
 	updated, _ := model.updateNormal(runeKey("?"))
 	model = updated.(Model)
@@ -791,7 +794,7 @@ func TestHistoryFlowBrowsesAndResumes(t *testing.T) {
 	if model.mode != modeNormal || resumeCmd == nil {
 		t.Fatalf("enter did not leave the modal resuming: mode=%d", model.mode)
 	}
-	drainCmd(t, resumeCmd)
+	drainCmd(resumeCmd)
 	if backend.resumedID != "session-old" {
 		t.Fatalf("resumed %q, want the cursor's session", backend.resumedID)
 	}
@@ -806,15 +809,157 @@ func TestHistoryFlowBrowsesAndResumes(t *testing.T) {
 	}
 }
 
-// drainCmd executes a command tree far enough to run its side effects.
-func drainCmd(t *testing.T, cmd tea.Cmd) {
-	t.Helper()
+// restoreBackend answers the restore screen with a fixed snapshot and
+// records what it is asked to bring back.
+type restoreBackend struct {
+	stubBackend
+	candidates   []resurrect.Candidate
+	restoredIDs  []string
+	forgottenIDs []string
+}
+
+func (b *restoreBackend) RestoreCandidates(
+	context.Context,
+) ([]resurrect.Candidate, error) {
+	return b.candidates, nil
+}
+
+func (b *restoreBackend) Restore(
+	_ context.Context,
+	ids ...string,
+) ([]app.RestoreResult, error) {
+	b.restoredIDs = append(b.restoredIDs, ids...)
+	return nil, nil
+}
+
+func (b *restoreBackend) Forget(_ context.Context, ids ...string) error {
+	b.forgottenIDs = append(b.forgottenIDs, ids...)
+	return nil
+}
+
+// drainCmd executes a command tree far enough to run its side effects,
+// following tea.Batch all the way down so a test sees what the batched
+// commands actually did.
+func drainCmd(cmd tea.Cmd) {
 	if cmd == nil {
 		return
 	}
 	if batch, ok := cmd().(tea.BatchMsg); ok {
 		for _, item := range batch {
-			drainCmd(t, item)
+			drainCmd(item)
 		}
+	}
+}
+
+func restoreCandidatesFixture() []resurrect.Candidate {
+	return []resurrect.Candidate{
+		{Entry: resurrect.Entry{ID: "ready-1", Name: "cl-one"}},
+		{Entry: resurrect.Entry{ID: "ready-2", Name: "cl-two"}},
+		{Entry: resurrect.Entry{ID: "blocked", Name: "cx-three"},
+			Reason: "Codex cannot reopen a conversation"},
+		{Entry: resurrect.Entry{ID: "running", Name: "cl-four"}, Live: true},
+	}
+}
+
+func restoreModelFixture(t *testing.T, backend Backend) Model {
+	t.Helper()
+	model := flowModelFixture(t, backend)
+	updated, _ := model.beginRestore()
+	model = updated.(Model)
+	model.applyRestoreCandidates(restoreCandidatesMsg{
+		candidates: restoreCandidatesFixture(),
+	})
+	return model
+}
+
+func TestRestorePickerChoosesEverythingThatCanComeBack(t *testing.T) {
+	backend := &restoreBackend{candidates: restoreCandidatesFixture()}
+	model := restoreModelFixture(t, backend)
+	if model.mode != modeRestore {
+		t.Fatalf("mode = %v, want modeRestore", model.mode)
+	}
+	updated, cmd := model.Update(tea.KeyPressMsg{Code: tea.KeyEnter})
+	model = updated.(Model)
+	if model.mode != modeNormal {
+		t.Fatalf("restoring left the picker open: %v", model.mode)
+	}
+	if cmd != nil {
+		cmd()
+	}
+	// Everything restorable, and only that: a row that cannot come back is
+	// never quietly included, and one already running is not restored twice.
+	if !slices.Equal(backend.restoredIDs, []string{"ready-1", "ready-2"}) {
+		t.Fatalf("restored %#v", backend.restoredIDs)
+	}
+}
+
+func TestRestorePickerWillNotChooseAnUnrestorableRow(t *testing.T) {
+	backend := &restoreBackend{candidates: restoreCandidatesFixture()}
+	model := restoreModelFixture(t, backend)
+	// Move onto the blocked row and try to toggle it on.
+	for range 2 {
+		updated, _ := model.Update(tea.KeyPressMsg{Code: 'j'})
+		model = updated.(Model)
+	}
+	updated, _ := model.Update(tea.KeyPressMsg{Code: tea.KeySpace})
+	model = updated.(Model)
+	if model.restoreChosen["blocked"] {
+		t.Fatal("a row that cannot be restored was selected")
+	}
+}
+
+func TestRestorePickerTogglesAndForgets(t *testing.T) {
+	backend := &restoreBackend{candidates: restoreCandidatesFixture()}
+	model := restoreModelFixture(t, backend)
+
+	// Space clears the row under the cursor; the rest stay chosen.
+	updated, _ := model.Update(tea.KeyPressMsg{Code: tea.KeySpace})
+	model = updated.(Model)
+	if model.restoreChosen["ready-1"] || !model.restoreChosen["ready-2"] {
+		t.Fatalf("space toggled the wrong row: %#v", model.restoreChosen)
+	}
+	// `a` reads as select-all until everything is chosen, then as clear.
+	updated, _ = model.Update(tea.KeyPressMsg{Code: 'a'})
+	model = updated.(Model)
+	if !model.restoreChosen["ready-1"] || !model.restoreChosen["ready-2"] {
+		t.Fatalf("a did not select all: %#v", model.restoreChosen)
+	}
+	updated, _ = model.Update(tea.KeyPressMsg{Code: 'a'})
+	model = updated.(Model)
+	if model.restoreChosen["ready-1"] || model.restoreChosen["ready-2"] {
+		t.Fatalf("a did not clear a full selection: %#v", model.restoreChosen)
+	}
+
+	updated, cmd := model.Update(tea.KeyPressMsg{Code: 'x'})
+	model = updated.(Model)
+	drainCmd(cmd)
+	if !slices.Contains(backend.forgottenIDs, "ready-1") {
+		t.Fatalf("forgot %#v", backend.forgottenIDs)
+	}
+}
+
+// The offer is for the dashboard you open after a reboot. An empty roster
+// with nothing recoverable behind it must not put a modal in the way.
+func TestAnEmptyRosterWithNothingToRestoreDoesNotOfferOne(t *testing.T) {
+	model := flowModelFixture(t, &restoreBackend{})
+	model.applyRestoreCandidates(restoreCandidatesMsg{offer: true})
+	if model.mode != modeNormal {
+		t.Fatalf("mode = %v, want the dashboard left alone", model.mode)
+	}
+	model.applyRestoreCandidates(restoreCandidatesMsg{
+		candidates: []resurrect.Candidate{
+			{Entry: resurrect.Entry{ID: "running"}, Live: true},
+		},
+		offer: true,
+	})
+	if model.mode != modeNormal {
+		t.Fatal("an offer opened for agents that are already running")
+	}
+	model.applyRestoreCandidates(restoreCandidatesMsg{
+		candidates: restoreCandidatesFixture(),
+		offer:      true,
+	})
+	if model.mode != modeRestore {
+		t.Fatal("a recoverable roster did not offer to come back")
 	}
 }

--- a/internal/ui/input_test.go
+++ b/internal/ui/input_test.go
@@ -20,6 +20,7 @@ import (
 	"github.com/trentkm/stormlight/internal/app"
 	"github.com/trentkm/stormlight/internal/history"
 	"github.com/trentkm/stormlight/internal/provider"
+	"github.com/trentkm/stormlight/internal/resurrect"
 	"github.com/trentkm/stormlight/internal/surface"
 	"github.com/trentkm/stormlight/internal/workspace"
 )
@@ -2412,6 +2413,23 @@ func (stubBackend) SessionHistory(context.Context) ([]history.Record, error) {
 
 func (stubBackend) Resume(context.Context, history.Record) (agent.Agent, error) {
 	return agent.Agent{}, nil
+}
+
+func (stubBackend) RestoreCandidates(
+	context.Context,
+) ([]resurrect.Candidate, error) {
+	return nil, nil
+}
+
+func (stubBackend) Restore(
+	context.Context,
+	...string,
+) ([]app.RestoreResult, error) {
+	return nil, nil
+}
+
+func (stubBackend) Forget(context.Context, ...string) error {
+	return nil
 }
 
 type recordingBackend struct {

--- a/internal/ui/layout.go
+++ b/internal/ui/layout.go
@@ -97,6 +97,13 @@ func (m Model) renderBody() string {
 			width,
 			contentHeight,
 		)
+	case modeRestore:
+		return overlayCentered(
+			dashboard,
+			m.renderRestoreModal(width, contentHeight),
+			width,
+			contentHeight,
+		)
 	case modeInfo:
 		return overlayCentered(
 			dashboard,

--- a/internal/ui/modals.go
+++ b/internal/ui/modals.go
@@ -167,6 +167,7 @@ func (m Model) renderHelpModal(width, height int) string {
 			{"M", "mark agent or workspace seen"},
 			{"K", "workspace info"},
 			{"H", "session history; Enter resumes one"},
+			{"Ctrl-r", "restore agents lost with the tmux server"},
 		}},
 		{"View", [][2]string{
 			{", then a/n/c", "sort: attention, name, newest"},

--- a/internal/ui/model.go
+++ b/internal/ui/model.go
@@ -16,6 +16,7 @@ import (
 	"github.com/trentkm/stormlight/internal/diagnostic"
 	"github.com/trentkm/stormlight/internal/history"
 	"github.com/trentkm/stormlight/internal/provider"
+	"github.com/trentkm/stormlight/internal/resurrect"
 	"github.com/trentkm/stormlight/internal/surface"
 	"github.com/trentkm/stormlight/internal/theme"
 	"github.com/trentkm/stormlight/internal/workspace"
@@ -40,6 +41,11 @@ type Backend interface {
 	Providers() []provider.Info
 	SessionHistory(context.Context) ([]history.Record, error)
 	Resume(context.Context, history.Record) (agent.Agent, error)
+	// RestoreCandidates reads the agents remembered from before the runtime
+	// that is hosting this dashboard existed, and Restore brings them back.
+	RestoreCandidates(context.Context) ([]resurrect.Candidate, error)
+	Restore(context.Context, ...string) ([]app.RestoreResult, error)
+	Forget(context.Context, ...string) error
 }
 
 type mode int
@@ -56,6 +62,7 @@ const (
 	modeInfo
 	modeHelp
 	modeHistory
+	modeRestore
 )
 
 // sortMode orders workspaces and agents. Sorting is always an explicit
@@ -176,6 +183,11 @@ type Model struct {
 	shimmerPhase        int
 	shimmerRunning      bool
 
+	restoreCandidates []resurrect.Candidate
+	restoreChosen     map[string]bool
+	restoreCursor     int
+	restoreOffered    bool
+
 	normalPrefix   string
 	sortMode       sortMode
 	dispatchPrefix string
@@ -223,6 +235,14 @@ type workspaceAddedMsg struct {
 type historyMsg struct {
 	records []history.Record
 	err     error
+}
+
+type restoreCandidatesMsg struct {
+	candidates []resurrect.Candidate
+	// offer marks the unprompted reading taken at startup, which opens the
+	// picker on its own if there is something worth opening it for.
+	offer bool
+	err   error
 }
 
 type tickMsg time.Time
@@ -322,6 +342,10 @@ func (m Model) Init() tea.Cmd {
 		m.refreshCmd(),
 		tickCmd(),
 		shimmerTickCmd(),
+		// Read the snapshot once at startup. Whether it opens the picker
+		// depends on what the first listing finds; asking now means the
+		// answer is already in hand when that lands.
+		restoreCandidatesCmd(m.backend, false),
 		// Ask the terminal what it is painted on. Lip Gloss v1 answered this
 		// itself by querying behind the program's back on first use; v2 does
 		// not, so the palette runs on its dark default until this comes back.
@@ -416,6 +440,16 @@ func (m Model) Update(message tea.Msg) (tea.Model, tea.Cmd) {
 			m.interactionLoadedAt = time.Now()
 			cmds = append(cmds, m.loadInteractionCmd())
 		}
+		if !m.restoreOffered && msg.err == nil {
+			// An empty roster on the first listing is the shape a lost tmux
+			// server leaves behind. Ask the snapshot whether it agrees, once:
+			// the offer is for the dashboard you open after the reboot, not
+			// for every moment you happen to have no agents running.
+			m.restoreOffered = true
+			if len(m.agents) == 0 && m.mode == modeNormal {
+				cmds = append(cmds, restoreCandidatesCmd(m.backend, true))
+			}
+		}
 		return m, tea.Batch(cmds...)
 
 	case historyMsg:
@@ -426,6 +460,10 @@ func (m Model) Update(message tea.Msg) (tea.Model, tea.Cmd) {
 		}
 		m.historyRecords = msg.records
 		m.historyCursor = clamp(m.historyCursor, 0, max(0, len(msg.records)-1))
+		return m, nil
+
+	case restoreCandidatesMsg:
+		m.applyRestoreCandidates(msg)
 		return m, nil
 
 	case interactionMsg:
@@ -581,6 +619,8 @@ func (m Model) Update(message tea.Msg) (tea.Model, tea.Cmd) {
 			return m.updateMark(msg)
 		case modeHistory:
 			return m.updateHistory(msg)
+		case modeRestore:
+			return m.updateRestore(msg)
 		case modeInfo, modeHelp:
 			// Any key dismisses an informational overlay.
 			m.mode = modeNormal
@@ -825,6 +865,8 @@ func (m Model) updateNormal(msg tea.KeyPressMsg) (tea.Model, tea.Cmd) {
 		return m, tea.Batch(m.refreshCmd(), m.loadInteractionCmd())
 	case "R":
 		return m.beginRename()
+	case "ctrl+r":
+		return m.beginRestore()
 	case "m":
 		return m.beginMark()
 	case "M":

--- a/internal/ui/restore.go
+++ b/internal/ui/restore.go
@@ -1,0 +1,284 @@
+package ui
+
+// The restore picker: agents remembered from before the tmux server died,
+// and the choice of which to bring back. See issue #91.
+
+import (
+	"context"
+	"fmt"
+	"strings"
+	"time"
+
+	tea "charm.land/bubbletea/v2"
+	"charm.land/lipgloss/v2"
+	"github.com/trentkm/stormlight/internal/diagnostic"
+	"github.com/trentkm/stormlight/internal/resurrect"
+)
+
+// restoreCandidatesCmd reads what the snapshot remembers. It runs on its own
+// rather than riding the dashboard poll: the answer changes only when agents
+// start or stop, and the file is on disk rather than in tmux.
+func restoreCandidatesCmd(backend Backend, offer bool) tea.Cmd {
+	return func() tea.Msg {
+		ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+		defer cancel()
+		candidates, err := backend.RestoreCandidates(ctx)
+		if err != nil {
+			diagnostic.Logger().Warn("restore candidates unavailable", "error", err)
+		}
+		return restoreCandidatesMsg{candidates: candidates, offer: offer, err: err}
+	}
+}
+
+func restoreCmd(backend Backend, ids []string) tea.Cmd {
+	return func() tea.Msg {
+		// Restoring spawns a window and a provider process per agent, so the
+		// budget is per-agent rather than the flat ten seconds an action gets.
+		timeout := time.Duration(len(ids)) * 15 * time.Second
+		ctx, cancel := context.WithTimeout(context.Background(), timeout)
+		defer cancel()
+		results, err := backend.Restore(ctx, ids...)
+		if err != nil {
+			return actionMsg{status: "Restore failed", err: err}
+		}
+		restored, failed := 0, 0
+		for _, result := range results {
+			if result.Err != nil {
+				failed++
+				diagnostic.Logger().Error("restore failed",
+					"agent_id", result.Entry.ID,
+					"error", result.Err,
+				)
+				continue
+			}
+			restored++
+		}
+		if failed > 0 {
+			return actionMsg{
+				status: fmt.Sprintf("Restored %d, failed %d", restored, failed),
+				err:    fmt.Errorf("%d agent(s) could not be restored", failed),
+			}
+		}
+		return actionMsg{status: fmt.Sprintf("Restored %d agent(s)", restored)}
+	}
+}
+
+func forgetCmd(backend Backend, ids []string) tea.Cmd {
+	return actionCmd("Forgotten", func(ctx context.Context) error {
+		return backend.Forget(ctx, ids...)
+	})
+}
+
+// beginRestore opens the picker. Everything that can come back starts
+// chosen: the human who reaches for this screen has just lost their whole
+// working set, and the common answer is "all of it".
+func (m Model) beginRestore() (tea.Model, tea.Cmd) {
+	m.mode = modeRestore
+	m.restoreCursor = 0
+	m.restoreChosen = map[string]bool{}
+	m.err = nil
+	m.status = "Restore agents"
+	return m, restoreCandidatesCmd(m.backend, false)
+}
+
+// applyRestoreCandidates lands a fresh reading of the snapshot. `offer` marks
+// the unprompted case — the dashboard starting to an empty roster — which
+// opens the picker only if there is in fact something to bring back.
+func (m *Model) applyRestoreCandidates(msg restoreCandidatesMsg) {
+	if msg.err != nil && m.mode == modeRestore {
+		// An empty picker and an unreadable record look identical on screen,
+		// and only one of them is the user's fault.
+		m.err = msg.err
+	}
+	m.restoreCandidates = msg.candidates
+	m.restoreCursor = clamp(m.restoreCursor, 0, max(0, len(msg.candidates)-1))
+	if m.restoreChosen == nil {
+		m.restoreChosen = map[string]bool{}
+	}
+	for _, candidate := range msg.candidates {
+		if _, decided := m.restoreChosen[candidate.Entry.ID]; !decided {
+			m.restoreChosen[candidate.Entry.ID] = candidate.Restorable()
+		}
+	}
+	if !msg.offer {
+		return
+	}
+	if len(resurrect.Restorable(msg.candidates)) == 0 {
+		return
+	}
+	m.mode = modeRestore
+	m.restoreCursor = 0
+	m.status = "Agents remembered from a previous session"
+}
+
+func (m Model) updateRestore(msg tea.KeyPressMsg) (tea.Model, tea.Cmd) {
+	switch msg.String() {
+	case "esc", "ctrl+c", "ctrl+[", "q":
+		m.mode = modeNormal
+		m.status = "Ready"
+		return m, nil
+	case "j", "down":
+		m.restoreCursor = clamp(
+			m.restoreCursor+1, 0, max(0, len(m.restoreCandidates)-1))
+		return m, nil
+	case "k", "up":
+		m.restoreCursor = clamp(
+			m.restoreCursor-1, 0, max(0, len(m.restoreCandidates)-1))
+		return m, nil
+	case "space":
+		candidate, ok := m.restoreCandidateAt(m.restoreCursor)
+		if !ok || !candidate.Restorable() {
+			return m, nil
+		}
+		m.restoreChosen[candidate.Entry.ID] = !m.restoreChosen[candidate.Entry.ID]
+		return m, nil
+	case "a":
+		// Toggle the whole list on the state of the first thing that could
+		// go either way, so the key reads as "select all" until everything
+		// is selected and "clear" after.
+		target := !m.allRestorableChosen()
+		for _, candidate := range m.restoreCandidates {
+			if candidate.Restorable() {
+				m.restoreChosen[candidate.Entry.ID] = target
+			}
+		}
+		return m, nil
+	case "x", "ctrl+x":
+		candidate, ok := m.restoreCandidateAt(m.restoreCursor)
+		if !ok || candidate.Live {
+			return m, nil
+		}
+		id := candidate.Entry.ID
+		m.status = "Forgetting " + candidate.Entry.Name
+		return m, tea.Batch(
+			forgetCmd(m.backend, []string{id}),
+			restoreCandidatesCmd(m.backend, false),
+		)
+	case "enter":
+		ids := m.chosenRestoreIDs()
+		if len(ids) == 0 {
+			m.mode = modeNormal
+			m.status = "Ready"
+			return m, nil
+		}
+		m.mode = modeNormal
+		m.status = fmt.Sprintf("Restoring %d agent(s)", len(ids))
+		return m, restoreCmd(m.backend, ids)
+	}
+	return m, nil
+}
+
+func (m Model) restoreCandidateAt(index int) (resurrect.Candidate, bool) {
+	if index < 0 || index >= len(m.restoreCandidates) {
+		return resurrect.Candidate{}, false
+	}
+	return m.restoreCandidates[index], true
+}
+
+func (m Model) chosenRestoreIDs() []string {
+	var ids []string
+	for _, candidate := range m.restoreCandidates {
+		if candidate.Restorable() && m.restoreChosen[candidate.Entry.ID] {
+			ids = append(ids, candidate.Entry.ID)
+		}
+	}
+	return ids
+}
+
+func (m Model) allRestorableChosen() bool {
+	any := false
+	for _, candidate := range m.restoreCandidates {
+		if !candidate.Restorable() {
+			continue
+		}
+		any = true
+		if !m.restoreChosen[candidate.Entry.ID] {
+			return false
+		}
+	}
+	return any
+}
+
+func (m Model) renderRestoreModal(width, height int) string {
+	// Title, blank, the rows, blank, hints — plus the border.
+	modalWidth, modalHeight := modalDimensions(
+		width,
+		height,
+		78,
+		len(m.restoreCandidates)+7,
+	)
+	innerWidth := max(1, modalWidth-2)
+	contentWidth := max(1, innerWidth-4)
+
+	lines := []string{
+		"  " + titleStyle().Render("Restore agents"),
+		"  " + mutedStyle().Render(
+			truncate("Reopens each conversation at its composer; "+
+				"it does not resume the agent's work.", contentWidth)),
+		"",
+	}
+	if len(m.restoreCandidates) == 0 {
+		lines = append(lines,
+			"  "+mutedStyle().Render("Nothing remembered."),
+			"",
+			"  "+mutedStyle().Render("Esc close"),
+		)
+		return renderModal(strings.Join(lines, "\n"), modalWidth, modalHeight)
+	}
+
+	nameWidth := max(8, min(24, contentWidth/3))
+	for index, candidate := range m.restoreCandidates {
+		box := "[ ]"
+		switch {
+		case !candidate.Restorable():
+			box = "   "
+		case m.restoreChosen[candidate.Entry.ID]:
+			box = "[x]"
+		}
+		name := lipgloss.NewStyle().
+			Width(nameWidth).
+			Render(truncate(candidate.Entry.Name, nameWidth))
+		detailWidth := max(1, contentWidth-nameWidth-len(box)-4)
+		detail := truncate(m.restoreDetail(candidate), detailWidth)
+		row := box + " " + name + "  " + detail
+		if index == m.restoreCursor {
+			lines = append(lines,
+				"  "+renderSelectableRow(row, contentWidth, true))
+			continue
+		}
+		styled := mutedStyle()
+		if candidate.Restorable() {
+			styled = titleStyle()
+		}
+		lines = append(lines, "  "+lipgloss.NewStyle().
+			Width(contentWidth).
+			MaxWidth(contentWidth).
+			Render(" "+accentStyle().Render(box)+" "+
+				styled.Render(name)+"  "+
+				mutedStyle().Render(detail)))
+	}
+	lines = append(lines,
+		"",
+		"  "+mutedStyle().Render(
+			"Space choose  a all  Enter restore  x forget  Esc close"),
+	)
+	return renderModal(strings.Join(lines, "\n"), modalWidth, modalHeight)
+}
+
+// restoreDetail says what will happen to a row, or why nothing will.
+func (m Model) restoreDetail(candidate resurrect.Candidate) string {
+	switch {
+	case candidate.Live:
+		return "already running"
+	case candidate.Reason != "":
+		return candidate.Reason
+	}
+	summary := strings.TrimSpace(candidate.Entry.Summary)
+	if summary == "" {
+		summary = strings.TrimSpace(candidate.Entry.Task)
+	}
+	if workspaceName := candidate.Entry.Workspace.Name; workspaceName != "" {
+		return workspaceName + " · " + summary
+	}
+	return summary
+}

--- a/main.go
+++ b/main.go
@@ -20,6 +20,7 @@ import (
 	"github.com/trentkm/stormlight/internal/config"
 	"github.com/trentkm/stormlight/internal/diagnostic"
 	"github.com/trentkm/stormlight/internal/provider"
+	"github.com/trentkm/stormlight/internal/resurrect"
 	"github.com/trentkm/stormlight/internal/selfpath"
 	"github.com/trentkm/stormlight/internal/session"
 	"github.com/trentkm/stormlight/internal/surface"
@@ -136,6 +137,7 @@ func newRootCommand() *cobra.Command {
 		newProviderEventCommand(&socket, &sessionName, cfg),
 		newLogsCommand(&logFile),
 		newRunCommand(&socket, &sessionName, cfg),
+		newRestoreCommand(&socket, &sessionName, cfg),
 		newConfigCommand(&socket, &sessionName, cfg),
 	)
 	return root
@@ -488,7 +490,11 @@ func newService(socket, sessionName string, cfg config.Config) (*app.Service, er
 		runtime.SetPreviousKeys(cfg.Tmux.PreviousKeys)
 	}
 	registry := provider.NewRegistryWithSpecs(providerSpecs(cfg))
-	return app.NewService(runtime, registry, workspace.NewRegistry()), nil
+	// Every command that reaches the runtime keeps the roster on disk. It
+	// has to be every one: a server dies without warning, and the snapshot
+	// is only worth reading if it was current when that happened.
+	return app.NewService(runtime, registry, workspace.NewRegistry()).
+		Remembering(resurrect.NewStore()), nil
 }
 
 // stormlightServerConfig resolves the config for Stormlight-owned tmux
@@ -578,6 +584,111 @@ func dispatchDirectory(cwd string) (string, error) {
 		return os.Getwd()
 	}
 	return filepath.Abs(cwd)
+}
+
+// newRestoreCommand brings agents back from the snapshot after the tmux
+// server that held them is gone. Listing is the default because restoring is
+// not: it opens conversations and costs real windows, so it happens when
+// asked for.
+func newRestoreCommand(socket, sessionName *string, cfg config.Config) *cobra.Command {
+	var restoreAll bool
+	var forget bool
+	command := &cobra.Command{
+		Use:   "restore [id...]",
+		Short: "Bring remembered agents back after the tmux server is gone",
+		Long: "Restore reopens each agent's conversation where it left off " +
+			"and idles at the composer; it never resumes the agent's work.\n\n" +
+			"With no arguments it lists what is remembered. Name ids to " +
+			"restore them, or pass --all for everything that can come back.",
+		RunE: func(cmd *cobra.Command, args []string) error {
+			service, err := newService(*socket, *sessionName, cfg)
+			if err != nil {
+				return err
+			}
+			ctx, cancel := context.WithTimeout(cmd.Context(), 30*time.Second)
+			defer cancel()
+
+			if forget {
+				if len(args) == 0 {
+					return fmt.Errorf("name the agents to forget")
+				}
+				if err := service.Forget(ctx, args...); err != nil {
+					return err
+				}
+				fmt.Fprintf(cmd.OutOrStdout(), "Forgot %d agent(s).\n", len(args))
+				return nil
+			}
+
+			candidates, err := service.RestoreCandidates(ctx)
+			if err != nil {
+				return err
+			}
+			if len(candidates) == 0 {
+				fmt.Fprintf(cmd.OutOrStdout(),
+					"Nothing remembered in %s.\n", service.SnapshotPath())
+				return nil
+			}
+			if len(args) == 0 && !restoreAll {
+				printRestoreCandidates(cmd.OutOrStdout(), candidates)
+				return nil
+			}
+			results, err := service.Restore(ctx, args...)
+			if err != nil {
+				return err
+			}
+			return printRestoreResults(cmd.OutOrStdout(), results)
+		},
+	}
+	command.Flags().BoolVar(&restoreAll, "all", false,
+		"restore every agent that can come back")
+	command.Flags().BoolVar(&forget, "forget", false,
+		"drop the named agents from the record instead of restoring them")
+	return command
+}
+
+func printRestoreCandidates(out io.Writer, candidates []resurrect.Candidate) {
+	fmt.Fprintf(out, "%-10s %-8s %-24s %s\n", "ID", "PROVIDER", "NAME", "STATE")
+	for _, candidate := range candidates {
+		state := "restorable"
+		switch {
+		case candidate.Live:
+			state = "running"
+		case candidate.Reason != "":
+			state = candidate.Reason
+		}
+		fmt.Fprintf(out, "%-10s %-8s %-24s %s\n",
+			shortID(candidate.Entry.ID),
+			candidate.Entry.Provider,
+			truncatePlain(candidate.Entry.Name, 24),
+			state,
+		)
+	}
+	if len(resurrect.Restorable(candidates)) > 0 {
+		fmt.Fprintln(out, "\nRestore them with: stormlight restore --all")
+	}
+}
+
+func printRestoreResults(out io.Writer, results []app.RestoreResult) error {
+	if len(results) == 0 {
+		fmt.Fprintln(out, "Nothing to restore.")
+		return nil
+	}
+	failures := 0
+	for _, result := range results {
+		if result.Err != nil {
+			failures++
+			fmt.Fprintf(out, "%-10s %s: %v\n",
+				shortID(result.Entry.ID), result.Entry.Name, result.Err)
+			continue
+		}
+		fmt.Fprintf(out, "%-10s %s restored\n",
+			shortID(result.Agent.ID), result.Agent.Name)
+	}
+	if failures > 0 {
+		return fmt.Errorf("%d of %d agents could not be restored",
+			failures, len(results))
+	}
+	return nil
 }
 
 func newListCommand(socket, sessionName *string, cfg config.Config) *cobra.Command {


### PR DESCRIPTION
Closes #91.

Everything Stormlight knew about an agent lived in tmux window options and
nowhere else, so a reboot, a `kill-server`, or an OOM took the whole roster
with it — not just the processes, which were always going to die, but the
record of which workspace each agent was in, what it was asked to do, and
which of them was waiting on an answer. The providers kept their side; the
loss was Stormlight's alone.

## The record

`internal/resurrect` mirrors the roster into `session.json` beside the
workspace catalog, written on every reconciling listing and gated on a
fingerprint so a polling dashboard is not rewriting a file every second.

The subtle part is when it may be written. An empty listing reads identically
whether the last agent was deleted or the whole session died, and writing the
second as the first would erase the record at the one moment it matters — so
the runtime is asked whether its listing is authoritative first
(`session.Restorer.RosterLive`, which resolves to "does the managed session
exist"). Deletion therefore records itself at the point of deletion rather
than being inferred later from an absence that could mean either thing.

## Restore brings the agent back, not the turn

`provider.Resumer` maps a transcript path — the only durable handle Stormlight
holds — to a launch that reopens the conversation, and that launch carries no
prompt. A restored agent comes back with its own id, workspace, task, and
place in the amber inbox, and idles at its composer. A machine that reboots
overnight must not wake up to a dozen agents spending tokens unattended.

Claude is the only provider that declares the capability. Codex needs a
working install to verify against (#92), and an agent that never reported a
turn has no transcript to reopen at all — both say so in the listing rather
than being dropped from it, along with an agent whose worktree was torn down
underneath it.

## Surfaces

```
stormlight restore              # what is remembered, and what can come back
stormlight restore --all
stormlight restore <id>...
stormlight restore --forget <id>...
```

The dashboard offers the same on `Ctrl-r`, and unprompted when it starts to an
empty roster and a record that is not.

## Verification

Unit tests cover the record's write rules, the resume launch shape, restore's
preservation of identity, and the picker. End to end, on this branch's build
against an isolated socket and XDG state: dispatched a Claude agent, killed
the tmux server, confirmed the empty listing left the record alone, and
restored — same id and `created_at`, attention preserved, the conversation
loaded and idle, launched with `--resume=<session>` and no prompt. A turn
taken after the restore reported the same session id, so successive reboots
keep working. Re-ran the whole sequence after rebasing onto #93, which moved
where the launcher path is resolved.

🤖 Generated with [Claude Code](https://claude.com/claude-code)