### PR TITLE
Store provider session ids; browse and resume past sessions

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,6 +63,14 @@ bar returns to the dashboard.
 Closing the dashboard removes only its temporary session; agents keep
 running on the Stormlight server.
 
+Conversations outlive their windows. Both providers name every session with
+an id their own `resume` command accepts, and Stormlight records it — with
+the task, workspace, and transcript path — in an append-only log at
+`$XDG_STATE_HOME/stormlight/sessions.jsonl`. Deleting an agent's window
+hands its session to that log rather than erasing it: `H` opens the history
+browser, and Enter reopens the selected conversation as a new managed agent
+in the workspace it left, with everything it had already said and done.
+
 ## Requirements
 
 - tmux 3.3 or newer. tmux 3.7+ is strongly recommended: Yazi and Neovim

--- a/internal/agent/agent.go
+++ b/internal/agent/agent.go
@@ -177,6 +177,10 @@ type Agent struct {
 	ProcessLive bool           `json:"process_live"`
 	ExitCode    *int           `json:"exit_code,omitempty"`
 	Mode        PermissionMode `json:"mode,omitempty"`
+	// SessionID is the provider's own id for this conversation — the value
+	// `claude --resume` and `codex resume` take — reported by its hooks and
+	// notify surface. It is what lets a conversation outlive its window.
+	SessionID string `json:"session_id,omitempty"`
 	// TranscriptPath is the provider's own transcript file for this
 	// conversation (Claude Code session JSONL), reported by its hooks.
 	TranscriptPath string            `json:"transcript_path,omitempty"`

--- a/internal/app/service.go
+++ b/internal/app/service.go
@@ -182,6 +182,42 @@ func (s *Service) Dispatch(ctx context.Context, req DispatchRequest) (agent.Agen
 	return managedAgent, nil
 }
 
+// Resume reopens a recorded provider session as a new managed agent: same
+// conversation, fresh window. The record supplies everything a dispatch
+// asks for — task, cwd, mode — so the resumed agent lands in the workspace
+// it left, and its hooks re-report whatever session id the provider
+// assigns the continuation.
+func (s *Service) Resume(
+	ctx context.Context,
+	record history.Record,
+) (agent.Agent, error) {
+	mode := record.Mode
+	if mode == "" {
+		mode = agent.DefaultMode
+	}
+	launch, err := s.providers.Resume(record.Provider, record.SessionID, mode)
+	if err != nil {
+		return agent.Agent{}, err
+	}
+	task := strings.TrimSpace(record.Task)
+	if task == "" {
+		task = "Resume session " + record.SessionID
+	}
+	workspaceContext, err := s.workspaces.Resolve(ctx, record.Cwd)
+	if err != nil {
+		return agent.Agent{}, fmt.Errorf("resolve workspace: %w", err)
+	}
+	return s.runtime.Dispatch(ctx, session.DispatchRequest{
+		Provider:  record.Provider,
+		Name:      record.Name,
+		Task:      task,
+		Cwd:       record.Cwd,
+		Mode:      mode,
+		Launch:    launch,
+		Workspace: workspaceContext,
+	})
+}
+
 func (s *Service) ListWorkspaces(ctx context.Context) ([]workspace.Context, error) {
 	paths, err := s.catalog.Paths()
 	if err != nil {

--- a/internal/app/service.go
+++ b/internal/app/service.go
@@ -11,6 +11,7 @@ import (
 
 	"github.com/trentkm/stormlight/internal/agent"
 	"github.com/trentkm/stormlight/internal/diagnostic"
+	"github.com/trentkm/stormlight/internal/history"
 	"github.com/trentkm/stormlight/internal/provider"
 	"github.com/trentkm/stormlight/internal/session"
 	"github.com/trentkm/stormlight/internal/workspace"
@@ -31,6 +32,7 @@ type Service struct {
 	providers  *provider.Registry
 	workspaces *workspace.Registry
 	catalog    *workspace.Catalog
+	sessions   *history.Log
 
 	// resolved caches catalog-path resolution (one git spawn per path per
 	// call otherwise); the dashboard polls fast, directories change slowly.
@@ -59,6 +61,7 @@ func NewService(
 		providers,
 		workspaces,
 		workspace.NewCatalog(),
+		history.NewLog(),
 	)
 }
 
@@ -67,6 +70,7 @@ func NewServiceWithCatalog(
 	providers *provider.Registry,
 	workspaces *workspace.Registry,
 	catalog *workspace.Catalog,
+	sessions *history.Log,
 ) *Service {
 	if workspaces == nil {
 		workspaces = workspace.NewRegistry()
@@ -74,11 +78,15 @@ func NewServiceWithCatalog(
 	if catalog == nil {
 		catalog = workspace.NewCatalog()
 	}
+	if sessions == nil {
+		sessions = history.NewLog()
+	}
 	return &Service{
 		runtime:    runtime,
 		providers:  providers,
 		workspaces: workspaces,
 		catalog:    catalog,
+		sessions:   sessions,
 	}
 }
 
@@ -345,7 +353,89 @@ func (s *Service) Delete(ctx context.Context, id string) error {
 }
 
 func (s *Service) Update(ctx context.Context, id string, update session.Update) error {
-	return s.runtime.Update(ctx, id, update)
+	if err := s.runtime.Update(ctx, id, update); err != nil {
+		return err
+	}
+	s.recordHistory(ctx, id)
+	return nil
+}
+
+// recordHistory mirrors the agent's current state into the session history
+// log. It rides on Update because provider events are the only moments the
+// record changes — and because the events are also what carry the session
+// id, the one field that makes a record worth keeping. Best-effort by
+// design: history is a byproduct of the update, never a reason to fail it.
+func (s *Service) recordHistory(ctx context.Context, id string) {
+	agents, err := s.runtime.ListAgents(ctx)
+	if err != nil {
+		diagnostic.Logger().Warn("session history listing failed",
+			"agent_id", id,
+			"error", err,
+		)
+		return
+	}
+	for _, managedAgent := range agents {
+		if managedAgent.ID != id && !strings.HasPrefix(managedAgent.ID, id) {
+			continue
+		}
+		if managedAgent.SessionID == "" {
+			return
+		}
+		if err := s.sessions.Append(history.Record{
+			SessionID:      managedAgent.SessionID,
+			Provider:       managedAgent.Provider,
+			AgentID:        managedAgent.ID,
+			Name:           managedAgent.Name,
+			Task:           managedAgent.Task,
+			Summary:        managedAgent.Summary,
+			Cwd:            managedAgent.Cwd,
+			Mode:           managedAgent.Mode,
+			TranscriptPath: managedAgent.TranscriptPath,
+			Workspace:      managedAgent.Workspace,
+			CreatedAt:      managedAgent.CreatedAt,
+			UpdatedAt:      time.Now().UTC(),
+		}); err != nil {
+			diagnostic.Logger().Warn("session history append failed",
+				"agent_id", id,
+				"error", err,
+			)
+		}
+		return
+	}
+}
+
+// SessionHistory returns past conversations: every session the log knows
+// that no current window claims. A dead pane still on the board is not
+// history yet — its window is the live record, and deleting it is what
+// hands the session over to the log.
+func (s *Service) SessionHistory(ctx context.Context) ([]history.Record, error) {
+	records, err := s.sessions.Records()
+	if err != nil {
+		return nil, err
+	}
+	agents, err := s.runtime.ListAgents(ctx)
+	if err != nil {
+		return nil, err
+	}
+	live := make(map[string]bool, len(agents))
+	for _, managedAgent := range agents {
+		if managedAgent.SessionID != "" {
+			live[managedAgent.SessionID] = true
+		}
+	}
+	past := records[:0]
+	for _, record := range records {
+		if !live[record.SessionID] {
+			past = append(past, record)
+		}
+	}
+	return past, nil
+}
+
+// CompactSessionHistory folds the log's accumulated per-event records down
+// to one line per session. Meant for startup, off the event path.
+func (s *Service) CompactSessionHistory() error {
+	return s.sessions.Compact()
 }
 
 func (s *Service) Providers() []provider.Info {

--- a/internal/app/service_test.go
+++ b/internal/app/service_test.go
@@ -2,9 +2,11 @@ package app
 
 import (
 	"context"
+	"path/filepath"
 	"testing"
 
 	"github.com/trentkm/stormlight/internal/agent"
+	"github.com/trentkm/stormlight/internal/history"
 	"github.com/trentkm/stormlight/internal/provider"
 	"github.com/trentkm/stormlight/internal/session"
 	"github.com/trentkm/stormlight/internal/workspace"
@@ -14,6 +16,14 @@ type recordingRuntime struct {
 	session.Runtime
 	agents      []agent.Agent
 	workspaceID string
+}
+
+func (r *recordingRuntime) Update(
+	context.Context,
+	string,
+	session.Update,
+) error {
+	return nil
 }
 
 func (r *recordingRuntime) ListAgents(
@@ -57,5 +67,64 @@ func TestWorkspaceBackfillUsesRuntimeNeutralAgentID(t *testing.T) {
 			"workspace persisted with runtime handle %q, want agent ID",
 			current.workspaceID,
 		)
+	}
+}
+
+func TestUpdateRecordsSessionHistory(t *testing.T) {
+	current := &recordingRuntime{
+		agents: []agent.Agent{{
+			ID:        "agent-one",
+			Provider:  agent.ProviderClaude,
+			Name:      "cl-tests",
+			Task:      "Run the tests",
+			Cwd:       t.TempDir(),
+			SessionID: "3308ff3d-2cbc-47ab-81b1-a8fa28940a14",
+			Workspace: workspace.DirectoryContext("/workspace/project"),
+		}},
+	}
+	log := history.NewLogAt(filepath.Join(t.TempDir(), "sessions.jsonl"))
+	service := NewServiceWithCatalog(
+		current,
+		provider.NewRegistry(),
+		workspace.NewRegistry(),
+		workspace.NewCatalogAt(filepath.Join(t.TempDir(), "workspaces.json")),
+		log,
+	)
+
+	if err := service.Update(
+		context.Background(),
+		"agent-one",
+		session.Update{Activity: agent.ActivityWorking},
+	); err != nil {
+		t.Fatal(err)
+	}
+
+	records, err := log.Records()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(records) != 1 ||
+		records[0].SessionID != "3308ff3d-2cbc-47ab-81b1-a8fa28940a14" ||
+		records[0].Task != "Run the tests" {
+		t.Fatalf("records = %#v", records)
+	}
+
+	// While the window is alive its session is not history yet.
+	past, err := service.SessionHistory(context.Background())
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(past) != 0 {
+		t.Fatalf("live session listed as history: %#v", past)
+	}
+
+	// The window going away is what hands the session to the log.
+	current.agents = nil
+	past, err = service.SessionHistory(context.Background())
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(past) != 1 || past[0].SessionID != records[0].SessionID {
+		t.Fatalf("past = %#v", past)
 	}
 }

--- a/internal/history/history.go
+++ b/internal/history/history.go
@@ -1,0 +1,255 @@
+// Package history keeps the on-disk record of every provider conversation
+// Stormlight has run. Live agent metadata lives as tmux window options and
+// dies with the window; the provider's conversation outlives both — its
+// transcript stays on disk and its session id still resumes — so the record
+// that ties id, task, and workspace together has to live somewhere a window
+// close cannot reach.
+//
+// The log is append-only JSONL, one full record per write, coalesced by
+// session id on read with the last record winning. Appends come from hook
+// processes that run concurrently — one per provider event, across every
+// live agent — which is why this is not a read-modify-write catalog like
+// workspaces.json: an O_APPEND write of one line needs no coordination with
+// its peers, where racing rewrites of a shared object would eat each
+// other's records. The redundancy of re-writing the whole record every
+// event is the price of that, and Compact reclaims it.
+package history
+
+import (
+	"encoding/json"
+	"fmt"
+	"os"
+	"path/filepath"
+	"slices"
+	"strings"
+	"syscall"
+	"time"
+
+	"github.com/trentkm/stormlight/internal/agent"
+	"github.com/trentkm/stormlight/internal/workspace"
+)
+
+// Record is one provider conversation as last seen. Every append carries
+// the full record rather than a delta, so a reader needs only the newest
+// line per session id and a torn or lost line costs one update, not the
+// integrity of the log.
+type Record struct {
+	// SessionID is the provider's own id for the conversation — the value
+	// `claude --resume` and `codex resume` take — and the log's key.
+	SessionID string               `json:"session_id"`
+	Provider  agent.Provider       `json:"provider"`
+	AgentID   string               `json:"agent_id,omitempty"`
+	Name      string               `json:"name,omitempty"`
+	Task      string               `json:"task,omitempty"`
+	Summary   string               `json:"summary,omitempty"`
+	Cwd       string               `json:"cwd,omitempty"`
+	Mode      agent.PermissionMode `json:"mode,omitempty"`
+	// TranscriptPath points at the provider's own transcript file. The log
+	// stores the pointer, never a copy, so providers that prune old
+	// sessions leave records whose transcript is gone; HasTranscript is
+	// the liveness check.
+	TranscriptPath string            `json:"transcript_path,omitempty"`
+	Workspace      workspace.Context `json:"workspace,omitempty"`
+	CreatedAt      time.Time         `json:"created_at"`
+	UpdatedAt      time.Time         `json:"updated_at"`
+}
+
+// HasTranscript reports whether the provider's transcript file still
+// exists. A record whose transcript the provider pruned is still history —
+// it names what ran and when — but there is nothing left to render.
+func (r Record) HasTranscript() bool {
+	if r.TranscriptPath == "" {
+		return false
+	}
+	_, err := os.Stat(r.TranscriptPath)
+	return err == nil
+}
+
+func (r Record) DisplaySummary() string {
+	if strings.TrimSpace(r.Summary) != "" {
+		return strings.TrimSpace(r.Summary)
+	}
+	return strings.TrimSpace(r.Task)
+}
+
+// Log is a handle on the session history file. The zero value is unusable;
+// NewLog resolves the real path and NewLogAt serves tests.
+type Log struct {
+	path string
+}
+
+func NewLog() *Log {
+	return &Log{path: logPath()}
+}
+
+func NewLogAt(path string) *Log {
+	return &Log{path: path}
+}
+
+func (l *Log) Path() string {
+	return l.path
+}
+
+// Append records the current state of one conversation. Concurrent appends
+// are expected — hook processes across agents fire independently — and are
+// safe: the line lands with a single O_APPEND write under the log's lock.
+func (l *Log) Append(record Record) error {
+	if l.path == "" {
+		return fmt.Errorf("session history path is not resolvable")
+	}
+	if record.SessionID == "" {
+		return fmt.Errorf("session history record has no session id")
+	}
+	encoded, err := json.Marshal(record)
+	if err != nil {
+		return fmt.Errorf("encode session history record: %w", err)
+	}
+	if err := os.MkdirAll(filepath.Dir(l.path), 0o755); err != nil {
+		return fmt.Errorf("create session history directory: %w", err)
+	}
+	unlock, err := l.lock()
+	if err != nil {
+		return err
+	}
+	defer unlock()
+	file, err := os.OpenFile(l.path, os.O_CREATE|os.O_WRONLY|os.O_APPEND, 0o644)
+	if err != nil {
+		return fmt.Errorf("open session history: %w", err)
+	}
+	defer file.Close()
+	if _, err := file.Write(append(encoded, '\n')); err != nil {
+		return fmt.Errorf("append session history: %w", err)
+	}
+	return nil
+}
+
+// Records returns one record per session, newest first. Lines that fail to
+// decode are skipped rather than failing the read: a torn write from a
+// killed hook process costs that one update, and the session's next event
+// re-writes the whole record anyway.
+func (l *Log) Records() ([]Record, error) {
+	records, _, err := l.load()
+	return records, err
+}
+
+func (l *Log) load() ([]Record, int, error) {
+	if l.path == "" {
+		return nil, 0, fmt.Errorf("session history path is not resolvable")
+	}
+	data, err := os.ReadFile(l.path)
+	if os.IsNotExist(err) {
+		return nil, 0, nil
+	}
+	if err != nil {
+		return nil, 0, fmt.Errorf("read session history: %w", err)
+	}
+	lines := 0
+	byID := map[string]int{}
+	var records []Record
+	for _, line := range strings.Split(string(data), "\n") {
+		if strings.TrimSpace(line) == "" {
+			continue
+		}
+		lines++
+		var record Record
+		if err := json.Unmarshal([]byte(line), &record); err != nil {
+			continue
+		}
+		if record.SessionID == "" {
+			continue
+		}
+		if index, seen := byID[record.SessionID]; seen {
+			records[index] = record
+			continue
+		}
+		byID[record.SessionID] = len(records)
+		records = append(records, record)
+	}
+	slices.SortStableFunc(records, func(a, b Record) int {
+		return b.UpdatedAt.Compare(a.UpdatedAt)
+	})
+	return records, lines, nil
+}
+
+// compactionSlack is how many redundant lines the log tolerates before
+// Compact rewrites it. Every event re-appends its session's whole record,
+// so the file grows past its information content by design; below this
+// floor a rewrite saves less than it costs.
+const compactionSlack = 256
+
+// Compact rewrites the log as one line per session when enough redundant
+// lines have accumulated. It is meant for a startup path — the dashboard
+// runs it once — not for the event path, whose whole point is to never
+// contend on a rewrite.
+func (l *Log) Compact() error {
+	unlock, err := l.lock()
+	if err != nil {
+		return err
+	}
+	defer unlock()
+	records, lines, err := l.load()
+	if err != nil {
+		return err
+	}
+	if lines <= len(records)+compactionSlack {
+		return nil
+	}
+	var encoded []byte
+	// Oldest first, so a future append-then-read still sees newest last.
+	for index := len(records) - 1; index >= 0; index-- {
+		line, err := json.Marshal(records[index])
+		if err != nil {
+			return fmt.Errorf("encode session history record: %w", err)
+		}
+		encoded = append(encoded, line...)
+		encoded = append(encoded, '\n')
+	}
+	temporary := l.path + ".compact"
+	if err := os.WriteFile(temporary, encoded, 0o644); err != nil {
+		return fmt.Errorf("write compacted session history: %w", err)
+	}
+	if err := os.Rename(temporary, l.path); err != nil {
+		return fmt.Errorf("replace session history: %w", err)
+	}
+	return nil
+}
+
+// lock serializes writers on a sibling lock file. The lock file, not the
+// log itself, carries the flock: Compact replaces the log by rename, and a
+// writer that locked the old inode would append into the orphaned file. The
+// lock file's path never changes, so its inode is the one thing every
+// writer agrees on.
+func (l *Log) lock() (func(), error) {
+	file, err := os.OpenFile(l.path+".lock", os.O_CREATE|os.O_RDWR, 0o644)
+	if err != nil {
+		return nil, fmt.Errorf("open session history lock: %w", err)
+	}
+	if err := syscall.Flock(int(file.Fd()), syscall.LOCK_EX); err != nil {
+		file.Close()
+		return nil, fmt.Errorf("lock session history: %w", err)
+	}
+	return func() {
+		syscall.Flock(int(file.Fd()), syscall.LOCK_UN)
+		file.Close()
+	}, nil
+}
+
+func logPath() string {
+	if configured := os.Getenv("STORMLIGHT_SESSIONS_FILE"); configured != "" {
+		return configured
+	}
+	if stateHome := os.Getenv("XDG_STATE_HOME"); stateHome != "" {
+		return filepath.Join(stateHome, "stormlight", "sessions.jsonl")
+	}
+	home, err := os.UserHomeDir()
+	if err != nil {
+		return ""
+	}
+	return filepath.Join(
+		home,
+		".local",
+		"state",
+		"stormlight",
+		"sessions.jsonl",
+	)
+}

--- a/internal/history/history_test.go
+++ b/internal/history/history_test.go
@@ -1,0 +1,187 @@
+package history
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/trentkm/stormlight/internal/agent"
+)
+
+func testLog(t *testing.T) *Log {
+	t.Helper()
+	return NewLogAt(filepath.Join(t.TempDir(), "sessions.jsonl"))
+}
+
+func record(id string, updatedAt time.Time) Record {
+	return Record{
+		SessionID: id,
+		Provider:  agent.ProviderClaude,
+		Task:      "task for " + id,
+		CreatedAt: updatedAt.Add(-time.Minute),
+		UpdatedAt: updatedAt,
+	}
+}
+
+func TestRecordsCoalesceBySessionNewestFirst(t *testing.T) {
+	log := testLog(t)
+	base := time.Date(2026, 8, 9, 12, 0, 0, 0, time.UTC)
+
+	first := record("session-a", base)
+	if err := log.Append(first); err != nil {
+		t.Fatal(err)
+	}
+	if err := log.Append(record("session-b", base.Add(time.Minute))); err != nil {
+		t.Fatal(err)
+	}
+	updated := record("session-a", base.Add(2*time.Minute))
+	updated.Summary = "second turn"
+	if err := log.Append(updated); err != nil {
+		t.Fatal(err)
+	}
+
+	records, err := log.Records()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(records) != 2 {
+		t.Fatalf("records = %#v", records)
+	}
+	if records[0].SessionID != "session-a" || records[0].Summary != "second turn" {
+		t.Fatalf("newest record = %#v", records[0])
+	}
+	if records[1].SessionID != "session-b" {
+		t.Fatalf("second record = %#v", records[1])
+	}
+}
+
+func TestRecordsSkipTornLines(t *testing.T) {
+	log := testLog(t)
+	if err := log.Append(record("session-a", time.Now().UTC())); err != nil {
+		t.Fatal(err)
+	}
+	// A hook process killed mid-write leaves a truncated line; the log
+	// must keep serving every intact record around it.
+	file, err := os.OpenFile(log.Path(), os.O_WRONLY|os.O_APPEND, 0o644)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := file.WriteString(`{"session_id":"session-b","upd`); err != nil {
+		t.Fatal(err)
+	}
+	file.Close()
+
+	records, err := log.Records()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(records) != 1 || records[0].SessionID != "session-a" {
+		t.Fatalf("records = %#v", records)
+	}
+}
+
+func TestMissingLogReadsAsEmpty(t *testing.T) {
+	records, err := testLog(t).Records()
+	if err != nil || len(records) != 0 {
+		t.Fatalf("records = %#v, err = %v", records, err)
+	}
+}
+
+func TestAppendRejectsRecordWithoutSessionID(t *testing.T) {
+	if err := testLog(t).Append(Record{Task: "orphan"}); err == nil {
+		t.Fatal("expected error for record without session id")
+	}
+}
+
+func TestConcurrentAppendsAllLand(t *testing.T) {
+	log := testLog(t)
+	base := time.Now().UTC()
+	var group sync.WaitGroup
+	for worker := range 8 {
+		group.Add(1)
+		go func() {
+			defer group.Done()
+			for turn := range 16 {
+				id := string(rune('a' + worker))
+				if err := log.Append(
+					record("session-"+id, base.Add(time.Duration(turn)*time.Second)),
+				); err != nil {
+					t.Error(err)
+				}
+			}
+		}()
+	}
+	group.Wait()
+
+	records, err := log.Records()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(records) != 8 {
+		t.Fatalf("expected 8 sessions, got %d", len(records))
+	}
+	data, err := os.ReadFile(log.Path())
+	if err != nil {
+		t.Fatal(err)
+	}
+	lines := strings.Split(strings.TrimSpace(string(data)), "\n")
+	if len(lines) != 8*16 {
+		t.Fatalf("expected %d intact lines, got %d", 8*16, len(lines))
+	}
+}
+
+func TestCompactRewritesOnlyWhenBloated(t *testing.T) {
+	log := testLog(t)
+	base := time.Date(2026, 8, 9, 12, 0, 0, 0, time.UTC)
+	for turn := range compactionSlack + 10 {
+		if err := log.Append(
+			record("session-a", base.Add(time.Duration(turn)*time.Second)),
+		); err != nil {
+			t.Fatal(err)
+		}
+	}
+	if err := log.Append(record("session-b", base)); err != nil {
+		t.Fatal(err)
+	}
+
+	if err := log.Compact(); err != nil {
+		t.Fatal(err)
+	}
+	data, err := os.ReadFile(log.Path())
+	if err != nil {
+		t.Fatal(err)
+	}
+	lines := strings.Split(strings.TrimSpace(string(data)), "\n")
+	if len(lines) != 2 {
+		t.Fatalf("expected 2 compacted lines, got %d", len(lines))
+	}
+
+	records, err := log.Records()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(records) != 2 || records[0].SessionID != "session-a" {
+		t.Fatalf("records after compact = %#v", records)
+	}
+
+	// Below the slack threshold a rewrite saves less than it costs, so the
+	// file must be left alone.
+	stat, err := os.Stat(log.Path())
+	if err != nil {
+		t.Fatal(err)
+	}
+	before := stat.ModTime()
+	if err := log.Compact(); err != nil {
+		t.Fatal(err)
+	}
+	stat, err = os.Stat(log.Path())
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !stat.ModTime().Equal(before) {
+		t.Fatal("compact rewrote a file below the slack threshold")
+	}
+}

--- a/internal/provider/event.go
+++ b/internal/provider/event.go
@@ -14,6 +14,10 @@ type Event struct {
 	Activity  agent.Activity
 	Attention agent.Attention
 	Summary   string
+	// SessionID is the provider's own id for the conversation — what
+	// `claude --resume` and `codex resume` take. Hook payloads carry it as
+	// session_id on both providers; Codex's notify carries it as thread-id.
+	SessionID string
 	// TranscriptPath is the provider's transcript file for the session,
 	// when the event carries one (Claude hook payloads always do).
 	TranscriptPath string
@@ -50,7 +54,11 @@ func parseCodexEvent(payload []byte) (Event, bool, error) {
 
 func parseCodexNotification(payload []byte) (Event, bool, error) {
 	var notification struct {
-		Type                 string `json:"type"`
+		Type string `json:"type"`
+		// ThreadID is what Codex calls the session id on this surface; it
+		// is the same UUID the hooks report as session_id and the rollout
+		// file is named after.
+		ThreadID             string `json:"thread-id"`
 		LastAssistantMessage string `json:"last-assistant-message"`
 	}
 	if err := json.Unmarshal(payload, &notification); err != nil {
@@ -63,6 +71,7 @@ func parseCodexNotification(payload []byte) (Event, bool, error) {
 		Activity:  agent.ActivityIdle,
 		Attention: turnEndAttention(notification.LastAssistantMessage),
 		Summary:   eventSummary(notification.LastAssistantMessage),
+		SessionID: notification.ThreadID,
 		TurnEnded: true,
 	}, true, nil
 }
@@ -83,6 +92,7 @@ type hookPayload struct {
 	// Stop.
 	LastAssistantMessage string `json:"last_assistant_message"`
 
+	SessionID      string `json:"session_id"`
 	TranscriptPath string `json:"transcript_path"`
 }
 
@@ -97,6 +107,7 @@ func parseHookEvent(providerID agent.Provider, payload []byte) (Event, bool, err
 		return Event{
 			Activity:       agent.ActivityWorking,
 			Summary:        eventSummary(hook.Prompt),
+			SessionID:      hook.SessionID,
 			TranscriptPath: hook.TranscriptPath,
 		}, true, nil
 	case "Notification":
@@ -114,6 +125,7 @@ func parseHookEvent(providerID agent.Provider, payload []byte) (Event, bool, err
 			Activity:       agent.ActivityIdle,
 			Attention:      agent.AttentionApproval,
 			Summary:        summary,
+			SessionID:      hook.SessionID,
 			TranscriptPath: hook.TranscriptPath,
 		}, true, nil
 	case "Stop":
@@ -121,6 +133,7 @@ func parseHookEvent(providerID agent.Provider, payload []byte) (Event, bool, err
 			Activity:       agent.ActivityIdle,
 			Attention:      turnEndAttention(hook.LastAssistantMessage),
 			Summary:        eventSummary(hook.LastAssistantMessage),
+			SessionID:      hook.SessionID,
 			TranscriptPath: hook.TranscriptPath,
 			TurnEnded:      true,
 		}, true, nil

--- a/internal/provider/event_test.go
+++ b/internal/provider/event_test.go
@@ -111,6 +111,52 @@ func TestCodexTurnEndIsIdenticalOnBothSurfaces(t *testing.T) {
 	}
 }
 
+// Both providers name the conversation in every payload — hooks as
+// session_id (captured from claude 2.1.226 and codex-cli 0.147.0), Codex's
+// notify as thread-id (codex-rs legacy_notify.rs) — and the id is what
+// `claude --resume` / `codex resume` take, so every surface must deliver it.
+func TestEventsCarrySessionID(t *testing.T) {
+	tests := []struct {
+		name     string
+		provider agent.Provider
+		payload  string
+	}{
+		{
+			name:     "claude hook",
+			provider: agent.ProviderClaude,
+			payload: `{"hook_event_name":"Stop",` +
+				`"session_id":"3308ff3d-2cbc-47ab-81b1-a8fa28940a14",` +
+				`"last_assistant_message":"ok"}`,
+		},
+		{
+			name:     "codex hook",
+			provider: agent.ProviderCodex,
+			payload: `{"hook_event_name":"UserPromptSubmit",` +
+				`"session_id":"3308ff3d-2cbc-47ab-81b1-a8fa28940a14",` +
+				`"prompt":"Run the tests"}`,
+		},
+		{
+			name:     "codex notify",
+			provider: agent.ProviderCodex,
+			payload: `{"type":"agent-turn-complete",` +
+				`"thread-id":"3308ff3d-2cbc-47ab-81b1-a8fa28940a14",` +
+				`"last-assistant-message":"ok"}`,
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			event, handled, err := ParseEvent(test.provider, []byte(test.payload))
+			if err != nil {
+				t.Fatal(err)
+			}
+			if !handled || event.SessionID != "3308ff3d-2cbc-47ab-81b1-a8fa28940a14" {
+				t.Fatalf("event = %#v, handled = %v", event, handled)
+			}
+		})
+	}
+}
+
 func TestEventSummaryIsBounded(t *testing.T) {
 	event, handled, err := ParseEvent(agent.ProviderCodex, []byte(
 		`{"hook_event_name":"Stop","last_assistant_message":"`+

--- a/internal/provider/provider.go
+++ b/internal/provider/provider.go
@@ -23,6 +23,9 @@ type Adapter interface {
 	ID() agent.Provider
 	Label() string
 	Resolve(prompt string, mode agent.PermissionMode) (Launch, error)
+	// Resume builds the launch that reopens an existing provider session
+	// by its id, with the same lifecycle wiring a fresh dispatch gets.
+	Resume(sessionID string, mode agent.PermissionMode) (Launch, error)
 }
 
 type commandAdapter struct {
@@ -30,6 +33,10 @@ type commandAdapter struct {
 	label   string
 	binary  string
 	argsFor func(prompt string, mode agent.PermissionMode) ([]string, error)
+	// resumeArgsFor is nil for providers without a known resume verb —
+	// custom specs declare how to start a conversation, not how to reopen
+	// one — and nil is what makes Resume answer "cannot resume".
+	resumeArgsFor func(sessionID string, mode agent.PermissionMode) ([]string, error)
 }
 
 func (a commandAdapter) ID() agent.Provider {
@@ -46,6 +53,21 @@ func (a commandAdapter) Resolve(prompt string, mode agent.PermissionMode) (Launc
 		return Launch{}, fmt.Errorf("%s is not installed or not on PATH", a.binary)
 	}
 	args, err := a.argsFor(prompt, mode)
+	if err != nil {
+		return Launch{}, err
+	}
+	return Launch{Path: path, Args: args}, nil
+}
+
+func (a commandAdapter) Resume(sessionID string, mode agent.PermissionMode) (Launch, error) {
+	if a.resumeArgsFor == nil {
+		return Launch{}, fmt.Errorf("%s sessions cannot be resumed", a.label)
+	}
+	path, err := exec.LookPath(a.binary)
+	if err != nil {
+		return Launch{}, fmt.Errorf("%s is not installed or not on PATH", a.binary)
+	}
+	args, err := a.resumeArgsFor(sessionID, mode)
 	if err != nil {
 		return Launch{}, err
 	}
@@ -81,16 +103,18 @@ func NewRegistry() *Registry {
 func NewRegistryWithSpecs(specs []Spec) *Registry {
 	adapters := []Adapter{
 		commandAdapter{
-			id:      agent.ProviderCodex,
-			label:   "Codex",
-			binary:  "codex",
-			argsFor: codexArgs,
+			id:            agent.ProviderCodex,
+			label:         "Codex",
+			binary:        "codex",
+			argsFor:       codexArgs,
+			resumeArgsFor: codexResumeArgs,
 		},
 		commandAdapter{
-			id:      agent.ProviderClaude,
-			label:   "Claude",
-			binary:  "claude",
-			argsFor: claudeArgs,
+			id:            agent.ProviderClaude,
+			label:         "Claude",
+			binary:        "claude",
+			argsFor:       claudeArgs,
+			resumeArgsFor: claudeResumeArgs,
 		},
 	}
 
@@ -135,6 +159,16 @@ func customizeBuiltin(builtin commandAdapter, spec Spec) commandAdapter {
 		prefix := slices.Clone(args[:len(args)-1])
 		prefix = append(prefix, extra...)
 		return append(prefix, args[len(args)-1]), nil
+	}
+	baseResume := builtin.resumeArgsFor
+	builtin.resumeArgsFor = func(sessionID string, mode agent.PermissionMode) ([]string, error) {
+		args, err := baseResume(sessionID, mode)
+		if err != nil {
+			return nil, err
+		}
+		// A resume launch has no trailing prompt to protect, and both
+		// providers parse flags after the session id, so extra args append.
+		return append(args, extra...), nil
 	}
 	return builtin
 }
@@ -193,6 +227,25 @@ func (r *Registry) Resolve(
 	return adapter.Resolve(prompt, mode)
 }
 
+// Resume builds the launch that reopens a provider's recorded session.
+func (r *Registry) Resume(
+	id agent.Provider,
+	sessionID string,
+	mode agent.PermissionMode,
+) (Launch, error) {
+	adapter, ok := r.adapters[id]
+	if !ok {
+		return Launch{}, fmt.Errorf("unsupported provider %q", id)
+	}
+	if strings.TrimSpace(sessionID) == "" {
+		return Launch{}, fmt.Errorf("session id cannot be empty")
+	}
+	if mode == "" {
+		mode = agent.DefaultMode
+	}
+	return adapter.Resume(sessionID, mode)
+}
+
 func (r *Registry) Infos() []Info {
 	infos := make([]Info, 0, len(r.order))
 	for _, id := range r.order {
@@ -235,6 +288,28 @@ func (r *Registry) IDs() []agent.Provider {
 // tool call proceeds — and Stormlight answers prompts in the agent's own
 // terminal, exactly as it declines to intercept Claude's.
 func codexArgs(prompt string, mode agent.PermissionMode) ([]string, error) {
+	args, err := codexLifecycleArgs(mode)
+	if err != nil {
+		return nil, err
+	}
+	return append(args, prompt), nil
+}
+
+// codexResumeArgs reopens a recorded session in place of starting one:
+// `codex resume <session-id>` continues the conversation the rollout file
+// holds, and the resumed process carries the same lifecycle wiring a fresh
+// dispatch gets, so it reports into the dashboard like any other agent. No
+// prompt rides along — the reopened conversation is handed to the human.
+func codexResumeArgs(sessionID string, mode agent.PermissionMode) ([]string, error) {
+	lifecycle, err := codexLifecycleArgs(mode)
+	if err != nil {
+		return nil, err
+	}
+	args := append([]string{"resume"}, lifecycle...)
+	return append(args, sessionID), nil
+}
+
+func codexLifecycleArgs(mode agent.PermissionMode) ([]string, error) {
 	notify, err := tomlOverride(struct {
 		Notify []string `toml:"notify"`
 	}{
@@ -259,8 +334,7 @@ func codexArgs(prompt string, mode agent.PermissionMode) ([]string, error) {
 		return nil, err
 	}
 	args := []string{"-c", notify, "-c", hooks}
-	args = append(args, codexModeArgs(mode)...)
-	return append(args, prompt), nil
+	return append(args, codexModeArgs(mode)...), nil
 }
 
 // codexModeArgs maps Stormlight permission modes onto Codex's approval and
@@ -286,6 +360,26 @@ func codexModeArgs(mode agent.PermissionMode) []string {
 }
 
 func claudeArgs(prompt string, mode agent.PermissionMode) ([]string, error) {
+	args, err := claudeLifecycleArgs(mode)
+	if err != nil {
+		return nil, err
+	}
+	return append(args, prompt), nil
+}
+
+// claudeResumeArgs reopens a recorded session in place of starting one:
+// `claude --resume <session-id>` continues the conversation from its
+// transcript, with the same lifecycle wiring a fresh dispatch gets. No
+// prompt rides along — the reopened conversation is handed to the human.
+func claudeResumeArgs(sessionID string, mode agent.PermissionMode) ([]string, error) {
+	args, err := claudeLifecycleArgs(mode)
+	if err != nil {
+		return nil, err
+	}
+	return append(args, "--resume", sessionID), nil
+}
+
+func claudeLifecycleArgs(mode agent.PermissionMode) ([]string, error) {
 	// Prompts are answered in the agent's own terminal, not re-implemented
 	// in the dashboard: the Notification hook raises attention so the
 	// dashboard can point at the pane, and nothing intercepts the request
@@ -313,5 +407,5 @@ func claudeArgs(prompt string, mode agent.PermissionMode) ([]string, error) {
 	case agent.ModeAuto:
 		args = append(args, "--permission-mode", "bypassPermissions")
 	}
-	return append(args, prompt), nil
+	return args, nil
 }

--- a/internal/provider/provider_test.go
+++ b/internal/provider/provider_test.go
@@ -226,6 +226,73 @@ func TestBuiltinSpecOverridesBinaryAndAppendsExtraArgs(t *testing.T) {
 	}
 }
 
+// Resume launches must carry the same lifecycle wiring a fresh dispatch
+// gets — a resumed agent that reports nothing would sit on the dashboard
+// exactly like the broken-hooks failure mode the wiring exists to prevent.
+func TestResumeArgsReopenSessionWithLifecycleWiring(t *testing.T) {
+	const sessionID = "019b9a7e-9846-7da2-9041-d4cec65d4d1d"
+
+	claude, err := claudeResumeArgs(sessionID, agent.ModeAuto)
+	if err != nil {
+		t.Fatal(err)
+	}
+	count := len(claude)
+	if count < 2 || claude[count-2] != "--resume" || claude[count-1] != sessionID {
+		t.Fatalf("claude resume args = %#v", claude)
+	}
+	if claude[0] != "--settings" ||
+		!slices.Contains(claude, "bypassPermissions") {
+		t.Fatalf("claude lifecycle wiring lost: %#v", claude)
+	}
+	if slices.Contains(claude, "") {
+		t.Fatalf("claude resume carries an empty prompt: %#v", claude)
+	}
+
+	codex, err := codexResumeArgs(sessionID, agent.ModeAuto)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if codex[0] != "resume" || codex[len(codex)-1] != sessionID {
+		t.Fatalf("codex resume args = %#v", codex)
+	}
+	if codex[1] != "-c" || codex[3] != "-c" ||
+		!slices.Contains(codex, "--ask-for-approval") {
+		t.Fatalf("codex lifecycle wiring lost: %#v", codex)
+	}
+}
+
+func TestRegistryResumeRejectsCustomProvidersAndEmptyIDs(t *testing.T) {
+	registry := NewRegistryWithSpecs([]Spec{{
+		ID:     agent.Provider("echoer"),
+		Binary: "echo",
+	}})
+	if _, err := registry.Resume(agent.Provider("echoer"), "some-id", agent.ModeAsk); err == nil {
+		t.Fatal("custom provider resumed without a resume verb")
+	}
+	if _, err := registry.Resume(agent.ProviderClaude, "  ", agent.ModeAsk); err == nil {
+		t.Fatal("blank session id accepted")
+	}
+}
+
+func TestBuiltinSpecExtraArgsRideResumeLaunches(t *testing.T) {
+	registry := NewRegistryWithSpecs([]Spec{{
+		ID:        agent.ProviderClaude,
+		Binary:    "echo",
+		ExtraArgs: []string{"--model", "opus"},
+	}})
+	launch, err := registry.Resume(agent.ProviderClaude, "some-id", agent.ModeAsk)
+	if err != nil {
+		t.Fatal(err)
+	}
+	count := len(launch.Args)
+	if launch.Args[count-1] != "opus" || launch.Args[count-2] != "--model" {
+		t.Fatalf("extra args lost on resume: %#v", launch.Args)
+	}
+	if !slices.Contains(launch.Args, "--resume") {
+		t.Fatalf("resume flag lost: %#v", launch.Args)
+	}
+}
+
 func TestClaudeArgsConfigureLifecycleHooks(t *testing.T) {
 	args, err := claudeArgs("do work", agent.ModeAsk)
 	if err != nil {

--- a/internal/session/runtime.go
+++ b/internal/session/runtime.go
@@ -55,6 +55,9 @@ type Update struct {
 	Activity  agent.Activity
 	Attention agent.Attention
 	Summary   string
+	// SessionID records the provider's own conversation id when an event
+	// carries it; empty means "leave as is".
+	SessionID string
 	// TranscriptPath records the provider's own transcript file when a
 	// hook reports it; empty means "leave as is".
 	TranscriptPath string

--- a/internal/tmux/runtime.go
+++ b/internal/tmux/runtime.go
@@ -94,7 +94,7 @@ const (
 		`#{T;=/#{status-right-length}:status-right}` +
 		`#[pop-default]#[norange default]`
 	basePaneFieldCount = 10
-	metadataFieldCount = 21
+	metadataFieldCount = 22
 )
 
 var agentMetadataFields = [metadataFieldCount]string{
@@ -119,6 +119,7 @@ var agentMetadataFields = [metadataFieldCount]string{
 	"transcript_path",
 	"mark",
 	"attention_at",
+	"session_id",
 }
 
 type Runtime struct {
@@ -732,6 +733,9 @@ func (r *Runtime) Update(ctx context.Context, id string, update session.Update) 
 	if update.Activity != "" {
 		values["@stormlight_activity"] = string(update.Activity)
 	}
+	if update.SessionID != "" {
+		values["@stormlight_session_id"] = update.SessionID
+	}
 	if update.TranscriptPath != "" {
 		values["@stormlight_transcript_path"] = update.TranscriptPath
 	}
@@ -1079,6 +1083,7 @@ func parseAgent(line string) (agent.Agent, bool) {
 		Mode:           agent.PermissionMode(core[17]),
 		TranscriptPath: core[18],
 		Mark:           agent.Mark(core[19]),
+		SessionID:      core[21],
 		Workspace: workspace.Context{
 			ID:            core[9],
 			Kind:          core[10],
@@ -1107,6 +1112,7 @@ func encodeAgentOptions(managedAgent agent.Agent) (map[string]string, error) {
 		"@stormlight_mode":            string(managedAgent.Mode),
 		"@stormlight_transcript_path": managedAgent.TranscriptPath,
 		"@stormlight_mark":            string(managedAgent.Mark),
+		"@stormlight_session_id":      managedAgent.SessionID,
 	}
 	workspaceOptions, err := encodeWorkspaceOptions(managedAgent.Workspace)
 	if err != nil {

--- a/internal/tmux/runtime_test.go
+++ b/internal/tmux/runtime_test.go
@@ -47,6 +47,7 @@ func TestParseAgent(t *testing.T) {
 		"/tmp/claude/session.jsonl",
 		"attention",
 		"1700000600",
+		"019b9a7e-9846-7da2-9041-d4cec65d4d1d",
 	}
 	line := strings.Join(parts, fieldSeparator)
 
@@ -65,6 +66,9 @@ func TestParseAgent(t *testing.T) {
 	}
 	if managedAgent.Attention != agent.AttentionApproval {
 		t.Fatalf("attention = %q", managedAgent.Attention)
+	}
+	if managedAgent.SessionID != "019b9a7e-9846-7da2-9041-d4cec65d4d1d" {
+		t.Fatalf("session id = %q", managedAgent.SessionID)
 	}
 	if managedAgent.Workspace.ID != "git:/tmp/project/.git" ||
 		managedAgent.Workspace.Metadata["branch"] != "main" {

--- a/internal/ui/flows_test.go
+++ b/internal/ui/flows_test.go
@@ -8,6 +8,7 @@ import (
 	tea "charm.land/bubbletea/v2"
 	"github.com/charmbracelet/x/ansi"
 	"github.com/trentkm/stormlight/internal/agent"
+	"github.com/trentkm/stormlight/internal/history"
 	"github.com/trentkm/stormlight/internal/workspace"
 )
 
@@ -732,5 +733,88 @@ func TestSpanreedHeadingHonorsMarksOverDerivedState(t *testing.T) {
 				t.Fatalf("heading still claims %q:\n%s", testCase.absent, rendered)
 			}
 		})
+	}
+}
+
+type historyBackend struct {
+	stubBackend
+	records   []history.Record
+	resumedID string
+}
+
+func (b *historyBackend) SessionHistory(
+	context.Context,
+) ([]history.Record, error) {
+	return b.records, nil
+}
+
+func (b *historyBackend) Resume(
+	_ context.Context,
+	record history.Record,
+) (agent.Agent, error) {
+	b.resumedID = record.SessionID
+	return agent.Agent{Name: record.Name, Task: record.Task}, nil
+}
+
+func TestHistoryFlowBrowsesAndResumes(t *testing.T) {
+	backend := &historyBackend{records: []history.Record{
+		{SessionID: "session-new", Provider: agent.ProviderClaude,
+			Name: "cl-newer", Task: "newer work"},
+		{SessionID: "session-old", Provider: agent.ProviderCodex,
+			Name: "cx-older", Task: "older work"},
+	}}
+	model := flowModelFixture(t, backend)
+
+	updated, cmd := model.updateNormal(tea.KeyPressMsg{Code: 'H', Text: "H"})
+	model = updated.(Model)
+	if model.mode != modeHistory || cmd == nil {
+		t.Fatalf("H did not open history: mode=%d", model.mode)
+	}
+	// The load command's message carries the records into the model.
+	next, _ := model.Update(cmd())
+	model = next.(Model)
+	if len(model.historyRecords) != 2 || model.historyLoading {
+		t.Fatalf("history not loaded: %#v", model.historyRecords)
+	}
+
+	rendered := ansi.Strip(model.renderHistoryModal(100, 28))
+	for _, want := range []string{"cl-newer", "cx-older", "codex"} {
+		if !strings.Contains(rendered, want) {
+			t.Fatalf("history modal hides %q:\n%s", want, rendered)
+		}
+	}
+
+	next, _ = model.updateHistory(tea.KeyPressMsg{Code: 'j', Text: "j"})
+	model = next.(Model)
+	next, resumeCmd := model.updateHistory(tea.KeyPressMsg{Code: tea.KeyEnter})
+	model = next.(Model)
+	if model.mode != modeNormal || resumeCmd == nil {
+		t.Fatalf("enter did not leave the modal resuming: mode=%d", model.mode)
+	}
+	drainCmd(t, resumeCmd)
+	if backend.resumedID != "session-old" {
+		t.Fatalf("resumed %q, want the cursor's session", backend.resumedID)
+	}
+
+	// Esc closes without resuming.
+	updated, _ = model.updateNormal(tea.KeyPressMsg{Code: 'H', Text: "H"})
+	model = updated.(Model)
+	next, _ = model.updateHistory(tea.KeyPressMsg{Code: tea.KeyEscape})
+	model = next.(Model)
+	if model.mode != modeNormal {
+		t.Fatalf("esc left mode=%d", model.mode)
+	}
+}
+
+// drainCmd executes a command tree far enough to run its side effects.
+func drainCmd(t *testing.T, cmd tea.Cmd) {
+	t.Helper()
+	if cmd == nil {
+		return
+	}
+	if batch, ok := cmd().(tea.BatchMsg); ok {
+		for _, item := range batch {
+			drainCmd(t, item)
+		}
 	}
 }

--- a/internal/ui/input_test.go
+++ b/internal/ui/input_test.go
@@ -18,6 +18,7 @@ import (
 	"github.com/charmbracelet/x/ansi"
 	"github.com/trentkm/stormlight/internal/agent"
 	"github.com/trentkm/stormlight/internal/app"
+	"github.com/trentkm/stormlight/internal/history"
 	"github.com/trentkm/stormlight/internal/provider"
 	"github.com/trentkm/stormlight/internal/surface"
 	"github.com/trentkm/stormlight/internal/workspace"
@@ -2403,6 +2404,14 @@ func (stubBackend) SyncAgentWindows(context.Context, int, int) error {
 
 func (stubBackend) Providers() []provider.Info {
 	return nil
+}
+
+func (stubBackend) SessionHistory(context.Context) ([]history.Record, error) {
+	return nil, nil
+}
+
+func (stubBackend) Resume(context.Context, history.Record) (agent.Agent, error) {
+	return agent.Agent{}, nil
 }
 
 type recordingBackend struct {

--- a/internal/ui/layout.go
+++ b/internal/ui/layout.go
@@ -111,6 +111,13 @@ func (m Model) renderBody() string {
 			width,
 			contentHeight,
 		)
+	case modeHistory:
+		return overlayCentered(
+			dashboard,
+			m.renderHistoryModal(width, contentHeight),
+			width,
+			contentHeight,
+		)
 	}
 	return dashboard
 }

--- a/internal/ui/modals.go
+++ b/internal/ui/modals.go
@@ -166,6 +166,7 @@ func (m Model) renderHelpModal(width, height int) string {
 			{"m", "mark agent in progress / needs attention"},
 			{"M", "mark agent or workspace seen"},
 			{"K", "workspace info"},
+			{"H", "session history; Enter resumes one"},
 		}},
 		{"View", [][2]string{
 			{", then a/n/c", "sort: attention, name, newest"},

--- a/internal/ui/model.go
+++ b/internal/ui/model.go
@@ -14,6 +14,7 @@ import (
 	"github.com/trentkm/stormlight/internal/agent"
 	"github.com/trentkm/stormlight/internal/app"
 	"github.com/trentkm/stormlight/internal/diagnostic"
+	"github.com/trentkm/stormlight/internal/history"
 	"github.com/trentkm/stormlight/internal/provider"
 	"github.com/trentkm/stormlight/internal/surface"
 	"github.com/trentkm/stormlight/internal/theme"
@@ -37,6 +38,8 @@ type Backend interface {
 	RenameWorkspace(context.Context, workspace.Context, string) error
 	SyncAgentWindows(context.Context, int, int) error
 	Providers() []provider.Info
+	SessionHistory(context.Context) ([]history.Record, error)
+	Resume(context.Context, history.Record) (agent.Agent, error)
 }
 
 type mode int
@@ -52,6 +55,7 @@ const (
 	modeMark
 	modeInfo
 	modeHelp
+	modeHistory
 )
 
 // sortMode orders workspaces and agents. Sorting is always an explicit
@@ -158,6 +162,9 @@ type Model struct {
 	renameWorkspace         workspace.Context
 	markAgentID             string
 	markIndex               int
+	historyRecords          []history.Record
+	historyCursor           int
+	historyLoading          bool
 	pathNav                 pathNav
 	pickerStart             string
 	chooseDispatchDirectory bool
@@ -211,6 +218,11 @@ type taskEditedMsg struct {
 type workspaceAddedMsg struct {
 	value workspace.Context
 	err   error
+}
+
+type historyMsg struct {
+	records []history.Record
+	err     error
 }
 
 type tickMsg time.Time
@@ -406,6 +418,16 @@ func (m Model) Update(message tea.Msg) (tea.Model, tea.Cmd) {
 		}
 		return m, tea.Batch(cmds...)
 
+	case historyMsg:
+		m.historyLoading = false
+		if msg.err != nil {
+			m.err = msg.err
+			return m, nil
+		}
+		m.historyRecords = msg.records
+		m.historyCursor = clamp(m.historyCursor, 0, max(0, len(msg.records)-1))
+		return m, nil
+
 	case interactionMsg:
 		if msg.id == m.selectedAgentID() {
 			if m.interactionID != msg.id {
@@ -557,6 +579,8 @@ func (m Model) Update(message tea.Msg) (tea.Model, tea.Cmd) {
 			return m.updateRename(msg)
 		case modeMark:
 			return m.updateMark(msg)
+		case modeHistory:
+			return m.updateHistory(msg)
 		case modeInfo, modeHelp:
 			// Any key dismisses an informational overlay.
 			m.mode = modeNormal
@@ -813,6 +837,8 @@ func (m Model) updateNormal(msg tea.KeyPressMsg) (tea.Model, tea.Cmd) {
 			}
 			return m, nil
 		}
+	case "H":
+		return m.beginHistory()
 	case "?":
 		m.mode = modeHelp
 		m.status = "Keys"

--- a/internal/ui/sessions.go
+++ b/internal/ui/sessions.go
@@ -1,0 +1,198 @@
+package ui
+
+// The session history browser: past provider conversations from the
+// on-disk log, each one a session the provider can reopen. See #94.
+//
+// History is a modal picker rather than rows in the Agents pane because a
+// past session answers to almost none of an agent row's verbs — there is
+// nothing to interrupt, mark, or write to, only something to read about
+// and resume — and rows that refuse most of the pane's keys would be
+// special cases in every handler. The picker's two verbs are the two that
+// exist: Enter resumes, Esc closes.
+
+import (
+	"context"
+	"fmt"
+	"strings"
+	"time"
+
+	tea "charm.land/bubbletea/v2"
+	"charm.land/lipgloss/v2"
+	"github.com/trentkm/stormlight/internal/history"
+)
+
+func (m Model) beginHistory() (tea.Model, tea.Cmd) {
+	m.mode = modeHistory
+	m.err = nil
+	m.status = "Session history"
+	m.historyCursor = 0
+	m.historyRecords = nil
+	m.historyLoading = true
+	return m, historyCmd(m.backend)
+}
+
+func (m Model) updateHistory(msg tea.KeyPressMsg) (tea.Model, tea.Cmd) {
+	last := max(0, len(m.historyRecords)-1)
+	switch msg.String() {
+	case "esc", "ctrl+c", "ctrl+[", "q", "H":
+		m.mode = modeNormal
+		m.status = "Ready"
+		return m, nil
+	case "j", "down":
+		m.historyCursor = clamp(m.historyCursor+1, 0, last)
+		return m, nil
+	case "k", "up":
+		m.historyCursor = clamp(m.historyCursor-1, 0, last)
+		return m, nil
+	case "g", "home":
+		m.historyCursor = 0
+		return m, nil
+	case "G", "end":
+		m.historyCursor = last
+		return m, nil
+	case "ctrl+d", "pgdown":
+		m.historyCursor = clamp(m.historyCursor+historyPageSize, 0, last)
+		return m, nil
+	case "ctrl+u", "pgup":
+		m.historyCursor = clamp(m.historyCursor-historyPageSize, 0, last)
+		return m, nil
+	case "enter":
+		if len(m.historyRecords) == 0 {
+			return m, nil
+		}
+		record := m.historyRecords[m.historyCursor]
+		m.mode = modeNormal
+		m.status = "Resuming " + historyTitle(record)
+		backend := m.backend
+		return m, tea.Batch(
+			func() tea.Msg {
+				ctx, cancel := context.WithTimeout(
+					context.Background(), resumeTimeout)
+				defer cancel()
+				managedAgent, err := backend.Resume(ctx, record)
+				if err != nil {
+					return actionMsg{err: err}
+				}
+				return actionMsg{
+					status: "Resumed " + agentDisplayTitle(managedAgent),
+				}
+			},
+			m.refreshCmd(),
+		)
+	}
+	return m, nil
+}
+
+// historyPageSize is the ctrl+d/u jump; the modal shows about this many
+// rows, so a page reads as one screenful.
+const historyPageSize = 10
+
+const resumeTimeout = 15 * time.Second
+
+func historyCmd(backend Backend) tea.Cmd {
+	return func() tea.Msg {
+		ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+		defer cancel()
+		records, err := backend.SessionHistory(ctx)
+		return historyMsg{records: records, err: err}
+	}
+}
+
+func historyTitle(record history.Record) string {
+	if strings.TrimSpace(record.Name) != "" {
+		return strings.TrimSpace(record.Name)
+	}
+	summary := record.DisplaySummary()
+	if summary != "" {
+		return summary
+	}
+	return record.SessionID
+}
+
+func (m Model) renderHistoryModal(width, height int) string {
+	// Title, blank, a page of rows plus the overflow line, blank, hints —
+	// plus the border.
+	modalWidth, modalHeight := modalDimensions(
+		width,
+		height,
+		96,
+		historyPageSize+7,
+	)
+	innerWidth := max(1, modalWidth-2)
+	contentWidth := max(1, innerWidth-4)
+
+	lines := []string{
+		"  " + titleStyle().Render("Sessions · past"),
+		"",
+	}
+	switch {
+	case m.historyLoading:
+		lines = append(lines, "  "+mutedStyle().Render("Loading…"))
+	case len(m.historyRecords) == 0:
+		lines = append(lines,
+			"  "+mutedStyle().Render("No past sessions recorded yet."),
+			"  "+mutedStyle().Render(
+				"Finished conversations land here once their window is deleted."),
+		)
+	default:
+		lines = append(lines, m.renderHistoryRows(contentWidth)...)
+	}
+	lines = append(lines, "",
+		"  "+mutedStyle().Render("enter resume · j/k move · esc close"))
+	return renderModal(strings.Join(lines, "\n"), modalWidth, modalHeight)
+}
+
+func (m Model) renderHistoryRows(width int) []string {
+	first := clamp(
+		m.historyCursor-historyPageSize/2,
+		0,
+		max(0, len(m.historyRecords)-historyPageSize),
+	)
+	last := min(len(m.historyRecords), first+historyPageSize)
+	rows := make([]string, 0, historyPageSize+1)
+	for index := first; index < last; index++ {
+		rows = append(rows, m.renderHistoryRow(index, width))
+	}
+	if remaining := len(m.historyRecords) - last; remaining > 0 {
+		rows = append(rows,
+			"   "+mutedStyle().Render(fmt.Sprintf("… %d more", remaining)))
+	}
+	return rows
+}
+
+func (m Model) renderHistoryRow(index int, width int) string {
+	record := m.historyRecords[index]
+	title := historyTitle(record)
+	detail := record.DisplaySummary()
+	if detail == title {
+		detail = ""
+	}
+	// The trailing tags answer the questions a resume decision needs: what
+	// would reopen, where it would land, how stale it is, and whether the
+	// provider still has a transcript to continue from.
+	tags := []string{string(record.Provider), timeAgo(record.UpdatedAt)}
+	if name := record.Workspace.Name; name != "" {
+		tags = append(tags, name)
+	}
+	if !record.HasTranscript() {
+		tags = append(tags, "transcript gone")
+	}
+	suffix := " · " + strings.Join(tags, " · ")
+
+	body := truncate(title, max(8, width/3))
+	if detail != "" {
+		body += "  " + truncate(
+			detail,
+			max(1, width-lipgloss.Width(body)-lipgloss.Width(suffix)-4),
+		)
+	}
+	if index == m.historyCursor {
+		return "  " + renderSelectableRow(body+suffix, width, true)
+	}
+	// One leading space matches the selectable row's marker column, so
+	// moving the cursor never shifts the text sideways.
+	return "  " + lipgloss.NewStyle().
+		Width(width).
+		MaxWidth(width).
+		Render(" "+body+mutedStyle().Render(suffix))
+}

--- a/main.go
+++ b/main.go
@@ -885,6 +885,7 @@ func newProviderEventCommand(socket, sessionName *string, cfg config.Config) *co
 				Activity:       event.Activity,
 				Attention:      event.Attention,
 				Summary:        event.Summary,
+				SessionID:      event.SessionID,
 				TranscriptPath: event.TranscriptPath,
 				TurnEnded:      event.TurnEnded,
 			}); err != nil {

--- a/main.go
+++ b/main.go
@@ -245,6 +245,15 @@ func runDashboard(socket, sessionName string, cfg config.Config, openPath string
 			diagnostic.Logger().Warn("apply server options failed", "error", err)
 		}
 	}
+	// The session history log accretes one line per provider event, and
+	// dashboard launch is the natural moment to fold it down: off every
+	// event path, once per run. Best-effort — a log that cannot compact
+	// still appends and reads.
+	go func() {
+		if err := service.CompactSessionHistory(); err != nil {
+			diagnostic.Logger().Warn("session history compaction failed", "error", err)
+		}
+	}()
 	options := ui.Options{
 		YaziPath:        cfg.Tools.Yazi,
 		NvimPath:        cfg.Tools.Nvim,


### PR DESCRIPTION
Closes #94.

An agent's identity used to die with its tmux window. Now the conversation outlives it:

- **Capture** — hook payloads carry `session_id` on both providers (verified against claude 2.1.226 and codex-cli 0.147.0 with captured payloads), and Codex's untrusted-hooks `notify` floor carries it as `thread-id` (confirmed in codex-rs source). All three surfaces now decode it, and it persists as the `@stormlight_session_id` window option.
- **Persist** — `internal/history`: append-only JSONL at `$XDG_STATE_HOME/stormlight/sessions.jsonl`, one full record per provider event, coalesced by session id on read. O_APPEND single-line writes let concurrent hook processes land without coordination; a sibling lock file serializes them against compaction's rename; the dashboard folds the log down once at launch.
- **Resume** — `claude --resume <id>` / `codex resume <id>` launches composed with the same lifecycle wiring a fresh dispatch gets. Custom provider specs answer that resume is unsupported.
- **Browse** — `H` opens the session history modal: every session no current window claims, tagged with provider, age, workspace, and transcript liveness. Enter reopens it as a new managed agent in the workspace it left.

Verified end-to-end in an isolated harness (fresh XDG state, scratch sockets): dispatched a real Claude agent, watched both hook events land in the log under one session id, deleted the window, opened `H`, resumed — and the reopened agent's Spanreed showed the prior conversation. The continuation reported the same session id, so the log coalesced both runs into one record.

Transcript lifetime is pointer-only by design: providers prune old sessions, so a record can outlive its transcript — the browser tags those "transcript gone". Snapshotting is a possible follow-up.
