### PR TITLE
Let the history browser filter with /

### DIFF
--- a/internal/ui/flows_test.go
+++ b/internal/ui/flows_test.go
@@ -809,6 +809,87 @@ func TestHistoryFlowBrowsesAndResumes(t *testing.T) {
 	}
 }
 
+func TestHistoryFilterNarrowsAndResumesTheMatch(t *testing.T) {
+	backend := &historyBackend{records: []history.Record{
+		{SessionID: "session-parser", Provider: agent.ProviderClaude,
+			Name: "cl-parser", Task: "fix the parser"},
+		{SessionID: "session-docs", Provider: agent.ProviderClaude,
+			Name: "cl-docs", Task: "write the docs"},
+		{SessionID: "session-tests", Provider: agent.ProviderCodex,
+			Name: "cx-tests", Task: "extend parser tests"},
+	}}
+	model := flowModelFixture(t, backend)
+
+	updated, cmd := model.updateNormal(tea.KeyPressMsg{Code: 'H', Text: "H"})
+	model = updated.(Model)
+	next, _ := model.Update(cmd())
+	model = next.(Model)
+
+	// / opens the filter; typed terms match anywhere in the record, and
+	// every term must match.
+	next, _ = model.updateHistory(tea.KeyPressMsg{Code: '/', Text: "/"})
+	model = next.(Model)
+	if !model.historyFiltering {
+		t.Fatal("/ did not start filtering")
+	}
+	for _, key := range []rune("parser") {
+		next, _ = model.updateHistory(tea.KeyPressMsg{Code: key, Text: string(key)})
+		model = next.(Model)
+	}
+	if visible := model.visibleHistory(); len(visible) != 2 {
+		t.Fatalf("filter kept %#v", visible)
+	}
+	rendered := ansi.Strip(model.renderHistoryModal(100, 28))
+	if !strings.Contains(rendered, "cl-parser") ||
+		strings.Contains(rendered, "cl-docs") {
+		t.Fatalf("filtered modal shows the wrong rows:\n%s", rendered)
+	}
+
+	// Arrows move within the narrowed list, and Enter resumes the match
+	// the cursor is on — the pathnav contract.
+	next, _ = model.updateHistory(tea.KeyPressMsg{Code: tea.KeyDown})
+	model = next.(Model)
+	next, resumeCmd := model.updateHistory(tea.KeyPressMsg{Code: tea.KeyEnter})
+	model = next.(Model)
+	if model.mode != modeNormal || resumeCmd == nil {
+		t.Fatalf("enter did not resume from the filter: mode=%d", model.mode)
+	}
+	drainCmd(resumeCmd)
+	if backend.resumedID != "session-tests" {
+		t.Fatalf("resumed %q, want the filtered cursor's session", backend.resumedID)
+	}
+}
+
+func TestHistoryFilterEscClearsBeforeClosing(t *testing.T) {
+	backend := &historyBackend{records: []history.Record{
+		{SessionID: "session-a", Provider: agent.ProviderClaude, Name: "cl-a"},
+	}}
+	model := flowModelFixture(t, backend)
+	updated, cmd := model.updateNormal(tea.KeyPressMsg{Code: 'H', Text: "H"})
+	model = updated.(Model)
+	next, _ := model.Update(cmd())
+	model = next.(Model)
+
+	next, _ = model.updateHistory(tea.KeyPressMsg{Code: '/', Text: "/"})
+	model = next.(Model)
+	next, _ = model.updateHistory(tea.KeyPressMsg{Code: 'z', Text: "z"})
+	model = next.(Model)
+
+	// First esc abandons the filter but keeps the modal open; the second
+	// closes it.
+	next, _ = model.updateHistory(tea.KeyPressMsg{Code: tea.KeyEscape})
+	model = next.(Model)
+	if model.mode != modeHistory || model.historyFilterActive() {
+		t.Fatalf("esc state: mode=%d filter=%q",
+			model.mode, model.historyFilter.Value())
+	}
+	next, _ = model.updateHistory(tea.KeyPressMsg{Code: tea.KeyEscape})
+	model = next.(Model)
+	if model.mode != modeNormal {
+		t.Fatalf("second esc left mode=%d", model.mode)
+	}
+}
+
 // restoreBackend answers the restore screen with a fixed snapshot and
 // records what it is asked to bring back.
 type restoreBackend struct {

--- a/internal/ui/model.go
+++ b/internal/ui/model.go
@@ -172,6 +172,8 @@ type Model struct {
 	historyRecords          []history.Record
 	historyCursor           int
 	historyLoading          bool
+	historyFilter           lineInput
+	historyFiltering        bool
 	pathNav                 pathNav
 	pickerStart             string
 	chooseDispatchDirectory bool

--- a/internal/ui/sessions.go
+++ b/internal/ui/sessions.go
@@ -7,8 +7,8 @@ package ui
 // past session answers to almost none of an agent row's verbs — there is
 // nothing to interrupt, mark, or write to, only something to read about
 // and resume — and rows that refuse most of the pane's keys would be
-// special cases in every handler. The picker's two verbs are the two that
-// exist: Enter resumes, Esc closes.
+// special cases in every handler. The picker's verbs are the ones that
+// exist: Enter resumes, / filters, Esc closes.
 
 import (
 	"context"
@@ -28,15 +28,32 @@ func (m Model) beginHistory() (tea.Model, tea.Cmd) {
 	m.historyCursor = 0
 	m.historyRecords = nil
 	m.historyLoading = true
+	m.historyFilter = newLineInput("type to filter")
+	m.historyFilter.Focus()
+	m.historyFiltering = false
 	return m, historyCmd(m.backend)
 }
 
 func (m Model) updateHistory(msg tea.KeyPressMsg) (tea.Model, tea.Cmd) {
-	last := max(0, len(m.historyRecords)-1)
+	if m.historyFiltering {
+		return m.updateHistoryFilter(msg)
+	}
+	visible := m.visibleHistory()
+	last := max(0, len(visible)-1)
 	switch msg.String() {
 	case "esc", "ctrl+c", "ctrl+[", "q", "H":
+		if m.historyFilterActive() {
+			// A set filter narrows what the list shows; leaving it behind
+			// on close would make the next H open onto a mystery subset.
+			m.historyFilter.SetValue("")
+			m.historyCursor = 0
+			return m, nil
+		}
 		m.mode = modeNormal
 		m.status = "Ready"
+		return m, nil
+	case "/":
+		m.historyFiltering = true
 		return m, nil
 	case "j", "down":
 		m.historyCursor = clamp(m.historyCursor+1, 0, last)
@@ -57,30 +74,103 @@ func (m Model) updateHistory(msg tea.KeyPressMsg) (tea.Model, tea.Cmd) {
 		m.historyCursor = clamp(m.historyCursor-historyPageSize, 0, last)
 		return m, nil
 	case "enter":
-		if len(m.historyRecords) == 0 {
-			return m, nil
-		}
-		record := m.historyRecords[m.historyCursor]
-		m.mode = modeNormal
-		m.status = "Resuming " + historyTitle(record)
-		backend := m.backend
-		return m, tea.Batch(
-			func() tea.Msg {
-				ctx, cancel := context.WithTimeout(
-					context.Background(), resumeTimeout)
-				defer cancel()
-				managedAgent, err := backend.Resume(ctx, record)
-				if err != nil {
-					return actionMsg{err: err}
-				}
-				return actionMsg{
-					status: "Resumed " + agentDisplayTitle(managedAgent),
-				}
-			},
-			m.refreshCmd(),
-		)
+		return m.resumeSelectedHistory()
 	}
 	return m, nil
+}
+
+// updateHistoryFilter owns the keys while the filter line is being typed:
+// characters narrow the list live, arrows move within the narrowed list,
+// Enter resumes the highlighted match the way pathnav's Enter picks one,
+// and Esc abandons the filter.
+func (m Model) updateHistoryFilter(msg tea.KeyPressMsg) (tea.Model, tea.Cmd) {
+	visible := m.visibleHistory()
+	last := max(0, len(visible)-1)
+	switch msg.String() {
+	case "esc", "ctrl+c", "ctrl+[":
+		m.historyFiltering = false
+		m.historyFilter.SetValue("")
+		m.historyCursor = 0
+		return m, nil
+	case "enter":
+		return m.resumeSelectedHistory()
+	case "down", "ctrl+n":
+		m.historyCursor = clamp(m.historyCursor+1, 0, last)
+		return m, nil
+	case "up", "ctrl+p":
+		m.historyCursor = clamp(m.historyCursor-1, 0, last)
+		return m, nil
+	}
+	before := m.historyFilter.Value()
+	m.historyFilter = m.historyFilter.Update(msg)
+	if m.historyFilter.Value() != before {
+		m.historyCursor = 0
+	}
+	return m, nil
+}
+
+func (m Model) resumeSelectedHistory() (tea.Model, tea.Cmd) {
+	visible := m.visibleHistory()
+	if len(visible) == 0 {
+		return m, nil
+	}
+	record := visible[min(m.historyCursor, len(visible)-1)]
+	m.mode = modeNormal
+	m.status = "Resuming " + historyTitle(record)
+	backend := m.backend
+	return m, tea.Batch(
+		func() tea.Msg {
+			ctx, cancel := context.WithTimeout(
+				context.Background(), resumeTimeout)
+			defer cancel()
+			managedAgent, err := backend.Resume(ctx, record)
+			if err != nil {
+				return actionMsg{err: err}
+			}
+			return actionMsg{
+				status: "Resumed " + agentDisplayTitle(managedAgent),
+			}
+		},
+		m.refreshCmd(),
+	)
+}
+
+func (m Model) historyFilterActive() bool {
+	return strings.TrimSpace(m.historyFilter.Value()) != ""
+}
+
+// visibleHistory is the record list the cursor and the rows agree on: all
+// of it, or the subset matching every filter term. Terms match anywhere a
+// human might remember a session by — name, task, summary, provider,
+// workspace, or the id itself.
+func (m Model) visibleHistory() []history.Record {
+	terms := strings.Fields(strings.ToLower(m.historyFilter.Value()))
+	if len(terms) == 0 {
+		return m.historyRecords
+	}
+	var matches []history.Record
+	for _, record := range m.historyRecords {
+		haystack := strings.ToLower(strings.Join([]string{
+			record.Name,
+			record.Task,
+			record.Summary,
+			string(record.Provider),
+			record.Workspace.Name,
+			record.Workspace.ComponentName,
+			record.SessionID,
+		}, "\x1f"))
+		matched := true
+		for _, term := range terms {
+			if !strings.Contains(haystack, term) {
+				matched = false
+				break
+			}
+		}
+		if matched {
+			matches = append(matches, record)
+		}
+	}
+	return matches
 }
 
 // historyPageSize is the ctrl+d/u jump; the modal shows about this many
@@ -110,13 +200,13 @@ func historyTitle(record history.Record) string {
 }
 
 func (m Model) renderHistoryModal(width, height int) string {
-	// Title, blank, a page of rows plus the overflow line, blank, hints —
-	// plus the border.
+	// Title, blank, the filter line, a page of rows plus the overflow
+	// line, blank, hints — plus the border.
 	modalWidth, modalHeight := modalDimensions(
 		width,
 		height,
 		96,
-		historyPageSize+7,
+		historyPageSize+8,
 	)
 	innerWidth := max(1, modalWidth-2)
 	contentWidth := max(1, innerWidth-4)
@@ -125,6 +215,11 @@ func (m Model) renderHistoryModal(width, height int) string {
 		"  " + titleStyle().Render("Sessions · past"),
 		"",
 	}
+	if m.historyFiltering || m.historyFilterActive() {
+		m.historyFilter.SetWidth(max(1, contentWidth-2))
+		lines = append(lines, "  > "+m.historyFilter.View())
+	}
+	visible := m.visibleHistory()
 	switch {
 	case m.historyLoading:
 		lines = append(lines, "  "+mutedStyle().Render("Loading…"))
@@ -134,34 +229,43 @@ func (m Model) renderHistoryModal(width, height int) string {
 			"  "+mutedStyle().Render(
 				"Finished conversations land here once their window is deleted."),
 		)
+	case len(visible) == 0:
+		lines = append(lines, "  "+mutedStyle().Render("No matching sessions."))
 	default:
-		lines = append(lines, m.renderHistoryRows(contentWidth)...)
+		lines = append(lines, m.renderHistoryRows(visible, contentWidth)...)
 	}
-	lines = append(lines, "",
-		"  "+mutedStyle().Render("enter resume · j/k move · esc close"))
+	hints := "enter resume · / filter · j/k move · esc close"
+	if m.historyFiltering {
+		hints = "enter resume · ↑/↓ move · esc clear filter"
+	}
+	lines = append(lines, "", "  "+mutedStyle().Render(hints))
 	return renderModal(strings.Join(lines, "\n"), modalWidth, modalHeight)
 }
 
-func (m Model) renderHistoryRows(width int) []string {
+func (m Model) renderHistoryRows(visible []history.Record, width int) []string {
+	cursor := min(m.historyCursor, len(visible)-1)
 	first := clamp(
-		m.historyCursor-historyPageSize/2,
+		cursor-historyPageSize/2,
 		0,
-		max(0, len(m.historyRecords)-historyPageSize),
+		max(0, len(visible)-historyPageSize),
 	)
-	last := min(len(m.historyRecords), first+historyPageSize)
+	last := min(len(visible), first+historyPageSize)
 	rows := make([]string, 0, historyPageSize+1)
 	for index := first; index < last; index++ {
-		rows = append(rows, m.renderHistoryRow(index, width))
+		rows = append(rows, m.renderHistoryRow(visible[index], index == cursor, width))
 	}
-	if remaining := len(m.historyRecords) - last; remaining > 0 {
+	if remaining := len(visible) - last; remaining > 0 {
 		rows = append(rows,
 			"   "+mutedStyle().Render(fmt.Sprintf("… %d more", remaining)))
 	}
 	return rows
 }
 
-func (m Model) renderHistoryRow(index int, width int) string {
-	record := m.historyRecords[index]
+func (m Model) renderHistoryRow(
+	record history.Record,
+	selected bool,
+	width int,
+) string {
 	title := historyTitle(record)
 	detail := record.DisplaySummary()
 	if detail == title {
@@ -186,7 +290,7 @@ func (m Model) renderHistoryRow(index int, width int) string {
 			max(1, width-lipgloss.Width(body)-lipgloss.Width(suffix)-4),
 		)
 	}
-	if index == m.historyCursor {
+	if selected {
 		return "  " + renderSelectableRow(body+suffix, width, true)
 	}
 	// One leading space matches the selectable row's marker column, so


### PR DESCRIPTION
`/` in the session history modal (`H`) opens a live filter: terms match against name, task, summary, provider, workspace, and session id, all terms required. Arrows navigate the narrowed list, Enter resumes the highlighted match (pathnav's contract), Esc clears the filter before it closes the modal.

Verified headless: filtered a real recorded session by term, confirmed the no-match state, and the hint line switching between modes.

Refs #94