### PR TITLE
Never forget an agent for merely being absent

### DIFF
--- a/README.md
+++ b/README.md
@@ -318,7 +318,11 @@ An empty agent list is never taken as "there are no agents" on its own. The
 managed tmux session is the arbiter: while it exists its windows are the
 truth and the record follows them, and while it does not the record is
 authoritative and nothing may overwrite it. That is what keeps a listing taken
-one second after the server died from erasing the very thing it is for.
+one second after the server died from erasing the very thing it is for. And
+absence alone never forgets: an agent leaves the record only when you delete
+it, forget it, or restore it — so dispatching new work or restoring only some
+of what was lost leaves the rest waiting under `Ctrl-r`, exactly where the
+crash left them.
 
 ## Workspaces
 

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -251,13 +251,17 @@ rather than reconciling against it.
 
 Two rules keep the mirror honest.
 
-The first is when it may be written. An empty listing is ambiguous — it reads
-identically whether the last agent was deleted or the whole session died — so
-the runtime is asked (`session.Restorer.RosterLive`) whether its listing is
-authoritative before any save. A missing managed session means the record
-stands and a listing may not touch it. Deletion is therefore recorded
-explicitly at the point of deletion, rather than inferred later from an
-absence that could mean either thing.
+The first is when it may forget. A listing is never trusted about absence,
+twice over. A listing from a runtime whose managed session is gone is not
+authoritative at all (`session.Restorer.RosterLive`) and may not write. And
+even an authoritative listing only refreshes the entries it contains: a
+save carries forward every stored entry the roster lacks, so dispatching
+new work or restoring a subset right after a server death cannot shrink the
+list restore is about to read. An entry leaves the record by deliberate act
+only — deleted (recorded as a Forget at the point of deletion), explicitly
+forgotten, or restored, at which point it is live and follows the roster
+again. The corollary is embraced: a window killed behind Stormlight's back
+stays remembered as a lost, restorable agent until a human says otherwise.
 
 The second is what restoring may do. A provider adapter's `Resume` maps a
 session id — the one the agent's hooks reported, or failing that the one the

--- a/internal/app/restore_test.go
+++ b/internal/app/restore_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"os"
 	"path/filepath"
+	"slices"
 	"testing"
 	"time"
 
@@ -56,6 +57,9 @@ func (r *restoringRuntime) Restore(
 	restored := req.Agent
 	restored.WindowID = "@restored"
 	restored.ProcessLive = true
+	// A restored agent is a live one: the listing sees it from here on,
+	// exactly as the real runtime's new window would appear in list-panes.
+	r.agents = append(r.agents, restored)
 	return restored, nil
 }
 
@@ -168,7 +172,11 @@ func TestAnEmptyListingFromALostSessionLeavesTheRecordAlone(t *testing.T) {
 // A session that is genuinely there and genuinely empty is the other half:
 // the record has to follow it down, or deleting your last agent would leave
 // it offering to restore forever.
-func TestAnEmptyListingFromALiveSessionEmptiesTheRecord(t *testing.T) {
+// An entry leaves the record by deliberate act only — deleted, forgotten,
+// or restored — never because a listing happened not to contain it. A
+// window that vanishes without a recorded deletion is a lost agent, and
+// lost agents are what the record is for (#98).
+func TestAListingWithoutAnAgentLeavesItsEntryAlone(t *testing.T) {
 	runtime := &restoringRuntime{
 		agents:     []agent.Agent{liveAgent(t, "a1")},
 		rosterLive: true,
@@ -185,8 +193,47 @@ func TestAnEmptyListingFromALiveSessionEmptiesTheRecord(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	if len(snapshot.Agents) != 0 {
-		t.Fatalf("a live empty session left agents behind: %#v", snapshot.Agents)
+	if len(snapshot.Agents) != 1 || snapshot.Agents[0].ID != "a1" {
+		t.Fatalf("an unexplained absence erased the record: %#v", snapshot.Agents)
+	}
+}
+
+// The post-crash trap the merge exists for: dispatching new work before
+// restoring must not shrink the list restore is about to read (#98).
+func TestNewAgentsJoinTheRecordWithoutEvictingTheLost(t *testing.T) {
+	runtime := &restoringRuntime{
+		agents:     []agent.Agent{liveAgent(t, "lost")},
+		rosterLive: true,
+	}
+	service, store := serviceFixture(t, runtime)
+	if _, err := service.ListAgents(context.Background()); err != nil {
+		t.Fatal(err)
+	}
+	// The server dies with the agent; a fresh one is dispatched after.
+	runtime.agents = []agent.Agent{liveAgent(t, "fresh")}
+	if _, err := service.ListAgents(context.Background()); err != nil {
+		t.Fatal(err)
+	}
+	snapshot, err := store.Load()
+	if err != nil {
+		t.Fatal(err)
+	}
+	ids := make([]string, 0, len(snapshot.Agents))
+	for _, entry := range snapshot.Agents {
+		ids = append(ids, entry.ID)
+	}
+	slices.Sort(ids)
+	if !slices.Equal(ids, []string{"fresh", "lost"}) {
+		t.Fatalf("record = %v, want the lost agent kept beside the fresh one", ids)
+	}
+
+	candidates, err := service.RestoreCandidates(context.Background())
+	if err != nil {
+		t.Fatal(err)
+	}
+	restorable := resurrect.Restorable(candidates)
+	if len(restorable) != 1 || restorable[0].Entry.ID != "lost" {
+		t.Fatalf("restorable = %#v, want exactly the lost agent", restorable)
 	}
 }
 
@@ -338,6 +385,40 @@ func TestRestoreOfEverythingSkipsWhatCannotComeBack(t *testing.T) {
 	}
 	if len(results) != 1 || results[0].Entry.ID != "a1" {
 		t.Fatalf("a bulk restore did not skip the unrestorable one: %#v", results)
+	}
+}
+
+// Restoring one agent must not evict the ones not chosen: the save that
+// follows a partial restore sees only what came back, and the remainder
+// has to survive it to be restorable on the next pass (#98).
+func TestPartialRestoreKeepsTheRemainderRestorable(t *testing.T) {
+	stubClaude(t)
+	runtime := &restoringRuntime{rosterLive: true}
+	service, store := serviceFixture(t, runtime)
+	if err := store.Save("agents", []agent.Agent{
+		liveAgent(t, "a1"), liveAgent(t, "a2"),
+	}); err != nil {
+		t.Fatal(err)
+	}
+
+	if _, err := service.Restore(context.Background(), "a1"); err != nil {
+		t.Fatal(err)
+	}
+
+	candidates, err := service.RestoreCandidates(context.Background())
+	if err != nil {
+		t.Fatal(err)
+	}
+	restorable := resurrect.Restorable(candidates)
+	if len(restorable) != 1 || restorable[0].Entry.ID != "a2" {
+		t.Fatalf("restorable after partial restore = %#v, want a2", restorable)
+	}
+	snapshot, err := store.Load()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(snapshot.Agents) != 2 {
+		t.Fatalf("partial restore shrank the record: %#v", snapshot.Agents)
 	}
 }
 

--- a/internal/resurrect/snapshot.go
+++ b/internal/resurrect/snapshot.go
@@ -155,10 +155,33 @@ func (s *Store) Load() (Snapshot, error) {
 // tmux server" arrive as the same empty slice, and writing the second as the
 // first would erase the snapshot at precisely the moment it is needed; the
 // caller settles that question before calling, because only the runtime can.
+// Save records the roster, carrying forward any stored entry the listing
+// does not contain. An entry leaves the record only by deliberate act —
+// deleted or forgotten (Forget), or restored, at which point it is live and
+// follows the roster again. A listing that merely lacks an entry proves
+// nothing: right after a server death it lacks every agent the record
+// exists to bring back, and a save taken then (a fresh dispatch, a partial
+// restore) must not shrink the very list restore is about to read. The
+// corollary is embraced: a window killed behind Stormlight's back stays
+// remembered as a lost agent until a human says otherwise.
 func (s *Store) Save(sessionName string, agents []agent.Agent) error {
-	entries := make([]Entry, 0, len(agents))
-	for _, live := range agents {
-		entries = append(entries, EntryOf(live))
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	stored, err := s.read()
+	if err != nil {
+		return err
+	}
+	live := make(map[string]bool, len(agents))
+	entries := make([]Entry, 0, len(agents)+len(stored.Agents))
+	for _, current := range agents {
+		entries = append(entries, EntryOf(current))
+		live[current.ID] = true
+	}
+	for _, entry := range stored.Agents {
+		if !live[entry.ID] {
+			entries = append(entries, entry)
+		}
 	}
 	// A total order, because tmux stamps creation to the second: two agents
 	// dispatched together would otherwise swap places between saves and make
@@ -169,9 +192,6 @@ func (s *Store) Save(sessionName string, agents []agent.Agent) error {
 		}
 		return strings.Compare(a.ID, b.ID)
 	})
-
-	s.mu.Lock()
-	defer s.mu.Unlock()
 
 	print := fingerprint(sessionName, entries)
 	if print == s.fingerprint {


### PR DESCRIPTION
Fixes #98.

`Store.Save` merges instead of overwriting: entries the listing contains are refreshed, entries it lacks are carried forward. An entry leaves the record only by deliberate act — deleted (`Forget` at the point of deletion), explicitly forgotten, or restored (at which point it is live and follows the roster again).

This closes both silent-shrink paths: dispatching new work before restoring, and restoring a subset. Embraced corollary: a window killed out-of-band stays remembered as a lost, restorable agent until forgotten — which is what the design's own deletion-records-itself rule implies.

Tests cover the dispatch-after-crash and partial-restore paths, and the old test codifying erase-on-live-empty-listing is rewritten to assert the new rule. Docs updated to state it.