### PR TITLE
Make selection copying work across terminal environments

### DIFF
--- a/internal/ui/selection.go
+++ b/internal/ui/selection.go
@@ -7,6 +7,7 @@ import (
 	"fmt"
 	"os"
 	"os/exec"
+	"runtime"
 	"strings"
 
 	tea "charm.land/bubbletea/v2"
@@ -235,16 +236,7 @@ func (m Model) copyTerminalSelectionCmd() tea.Cmd {
 	}
 	text := strings.Join(selected, "\n")
 	count := len(selected)
-	return func() tea.Msg {
-		if err := copyToClipboard(text); err != nil {
-			return actionMsg{status: "Action failed", err: err}
-		}
-		label := "line"
-		if count != 1 {
-			label = "lines"
-		}
-		return actionMsg{status: fmt.Sprintf("Copied %d %s", count, label)}
-	}
+	return copyToClipboardCmd(text, count)
 }
 
 // paintTerminalSelection reverses the video of the selected span over the
@@ -362,8 +354,7 @@ func (m Model) selectionRange() (int, int) {
 }
 
 // copySelectionCmd extracts the highlighted lines and hands them to the
-// clipboard: the tmux buffer plus the system clipboard through tmux's
-// OSC 52 (-w) when inside tmux, pbcopy/xclip otherwise.
+// system clipboard through the transport appropriate to this session.
 func (m Model) copySelectionCmd() tea.Cmd {
 	start, end := m.selectionRange()
 	lines := strings.Split(ansi.Strip(m.interactionContent), "\n")
@@ -377,39 +368,83 @@ func (m Model) copySelectionCmd() tea.Cmd {
 	}
 	text := strings.Join(selected, "\n")
 	count := end - start + 1
+	return copyToClipboardCmd(text, count)
+}
+
+func copyToClipboardCmd(text string, count int) tea.Cmd {
+	label := "line"
+	if count != 1 {
+		label = "lines"
+	}
+	success := actionMsg{status: fmt.Sprintf("Copied %d %s", count, label)}
 	return func() tea.Msg {
-		if err := copyToClipboard(text); err != nil {
-			return actionMsg{status: "Action failed", err: err}
+		if os.Getenv("TMUX") != "" {
+			if err := runClipboardCommand(
+				"tmux", []string{"load-buffer", "-w", "-"}, text,
+			); err != nil {
+				return actionMsg{err: fmt.Errorf("copy with tmux: %w", err)}
+			}
+			return success
 		}
-		label := "line"
-		if count != 1 {
-			label = "lines"
+		if remoteTerminalSession() {
+			return osc52ClipboardCmd(text, success)()
 		}
-		return actionMsg{status: fmt.Sprintf("Copied %d %s", count, label)}
+		for _, candidate := range nativeClipboardCommands() {
+			path, err := findClipboardCommand(candidate[0])
+			if err != nil {
+				continue
+			}
+			if err := runClipboardCommand(path, candidate[1:], text); err == nil {
+				return success
+			}
+		}
+		return osc52ClipboardCmd(text, success)()
 	}
 }
 
-// copyToClipboard prefers tmux: load-buffer -w fills the tmux paste buffer
-// and forwards to the system clipboard via OSC 52 in one step.
-func copyToClipboard(text string) error {
-	if os.Getenv("TMUX") != "" {
-		command := exec.Command("tmux", "load-buffer", "-w", "-")
-		command.Stdin = strings.NewReader(text)
-		if err := command.Run(); err == nil {
-			return nil
-		}
-	}
-	for _, candidate := range [][]string{
-		{"pbcopy"}, {"wl-copy"}, {"xclip", "-selection", "clipboard"},
+var findClipboardCommand = exec.LookPath
+
+var runClipboardCommand = func(path string, args []string, text string) error {
+	command := exec.Command(path, args...)
+	command.Stdin = strings.NewReader(text)
+	return command.Run()
+}
+
+func remoteTerminalSession() bool {
+	for _, name := range []string{
+		"SSH_CONNECTION", "SSH_CLIENT", "SSH_TTY",
+		"MOSH_CONNECTION", "MOSH_IP",
 	} {
-		if _, err := exec.LookPath(candidate[0]); err != nil {
-			continue
+		if os.Getenv(name) != "" {
+			return true
 		}
-		command := exec.Command(candidate[0], candidate[1:]...)
-		command.Stdin = strings.NewReader(text)
-		return command.Run()
 	}
-	return fmt.Errorf("no clipboard tool found (tmux, pbcopy, wl-copy, xclip)")
+	return false
+}
+
+func nativeClipboardCommands() [][]string {
+	switch runtime.GOOS {
+	case "darwin":
+		return [][]string{{"pbcopy"}}
+	case "linux":
+		return [][]string{
+			{"wl-copy"},
+			{"xclip", "-selection", "clipboard"},
+		}
+	case "windows":
+		return [][]string{{"clip.exe"}}
+	default:
+		return nil
+	}
+}
+
+func osc52ClipboardCmd(text string, success actionMsg) tea.Cmd {
+	return tea.Sequence(
+		tea.SetClipboard(text),
+		func() tea.Msg {
+			return success
+		},
+	)
 }
 
 // paneAt maps a screen column to the dashboard pane rendered there.

--- a/internal/ui/selection_test.go
+++ b/internal/ui/selection_test.go
@@ -1,0 +1,229 @@
+package ui
+
+import (
+	"bytes"
+	"errors"
+	"fmt"
+	"reflect"
+	"testing"
+
+	tea "charm.land/bubbletea/v2"
+)
+
+const (
+	clipboardTestText = "first\ncaf\u00e9"
+	clipboardOSC52    = "\x1b]52;c;Zmlyc3QKY2Fmw6k=\x07"
+)
+
+type clipboardCopyModel struct {
+	status string
+	err    error
+}
+
+func (m clipboardCopyModel) Init() tea.Cmd {
+	return copyToClipboardCmd(clipboardTestText, 2)
+}
+
+func (m clipboardCopyModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
+	if action, ok := msg.(actionMsg); ok {
+		m.status = action.status
+		m.err = action.err
+		return m, tea.Quit
+	}
+	return m, nil
+}
+
+func (m clipboardCopyModel) View() tea.View {
+	return tea.NewView("")
+}
+
+type clipboardInvocation struct {
+	path string
+	args []string
+	text string
+}
+
+func resetClipboardEnvironment(t *testing.T) {
+	t.Helper()
+	for _, name := range []string{
+		"TMUX",
+		"SSH_CONNECTION", "SSH_CLIENT", "SSH_TTY",
+		"MOSH_CONNECTION", "MOSH_IP",
+	} {
+		t.Setenv(name, "")
+	}
+}
+
+func stubClipboardCommands(
+	t *testing.T,
+	results map[string]error,
+) *[]clipboardInvocation {
+	t.Helper()
+	previousFind := findClipboardCommand
+	previousRun := runClipboardCommand
+	var invocations []clipboardInvocation
+	findClipboardCommand = func(name string) (string, error) {
+		if _, ok := results[name]; ok {
+			return name, nil
+		}
+		return "", fmt.Errorf("%s not found", name)
+	}
+	runClipboardCommand = func(path string, args []string, text string) error {
+		invocations = append(invocations, clipboardInvocation{
+			path: path,
+			args: append([]string(nil), args...),
+			text: text,
+		})
+		err, ok := results[path]
+		if !ok {
+			return fmt.Errorf("unexpected clipboard command %s", path)
+		}
+		return err
+	}
+	t.Cleanup(func() {
+		findClipboardCommand = previousFind
+		runClipboardCommand = previousRun
+	})
+	return &invocations
+}
+
+func runClipboardCopy(t *testing.T) (string, clipboardCopyModel) {
+	t.Helper()
+	var output bytes.Buffer
+	result, err := tea.NewProgram(
+		clipboardCopyModel{},
+		tea.WithInput(nil),
+		tea.WithOutput(&output),
+		tea.WithoutRenderer(),
+	).Run()
+	if err != nil {
+		t.Fatalf("run clipboard command: %v", err)
+	}
+	return output.String(), result.(clipboardCopyModel)
+}
+
+func assertClipboardSuccess(t *testing.T, model clipboardCopyModel) {
+	t.Helper()
+	if model.err != nil {
+		t.Fatalf("copy failed: %v", model.err)
+	}
+	if model.status != "Copied 2 lines" {
+		t.Fatalf("status = %q, want %q", model.status, "Copied 2 lines")
+	}
+}
+
+func firstNativeClipboardCommand(t *testing.T) []string {
+	t.Helper()
+	candidates := nativeClipboardCommands()
+	if len(candidates) == 0 {
+		t.Skip("platform has no native clipboard command")
+	}
+	return candidates[0]
+}
+
+func TestCopyToClipboardUsesTmuxWhenNested(t *testing.T) {
+	resetClipboardEnvironment(t)
+	t.Setenv("TMUX", "/tmp/tmux/default,1,0")
+	t.Setenv("SSH_CONNECTION", "client 1 server 22")
+	invocations := stubClipboardCommands(t, map[string]error{"tmux": nil})
+
+	output, model := runClipboardCopy(t)
+
+	if output != "" {
+		t.Fatalf("terminal output = %q, want none", output)
+	}
+	assertClipboardSuccess(t, model)
+	want := []clipboardInvocation{{
+		path: "tmux",
+		args: []string{"load-buffer", "-w", "-"},
+		text: clipboardTestText,
+	}}
+	if !reflect.DeepEqual(*invocations, want) {
+		t.Fatalf("clipboard invocations = %#v, want %#v", *invocations, want)
+	}
+}
+
+func TestCopyToClipboardReportsTmuxFailure(t *testing.T) {
+	resetClipboardEnvironment(t)
+	t.Setenv("TMUX", "/tmp/tmux/default,1,0")
+	stubClipboardCommands(t, map[string]error{
+		"tmux": errors.New("server unavailable"),
+	})
+
+	output, model := runClipboardCopy(t)
+
+	if output != "" {
+		t.Fatalf("terminal output = %q, want none", output)
+	}
+	if model.err == nil ||
+		model.err.Error() != "copy with tmux: server unavailable" {
+		t.Fatalf("error = %v", model.err)
+	}
+}
+
+func TestCopyToClipboardUsesOSC52ForRemoteSession(t *testing.T) {
+	resetClipboardEnvironment(t)
+	t.Setenv("SSH_CONNECTION", "client 1 server 22")
+	candidate := firstNativeClipboardCommand(t)[0]
+	invocations := stubClipboardCommands(t, map[string]error{candidate: nil})
+
+	output, model := runClipboardCopy(t)
+
+	if output != clipboardOSC52 {
+		t.Fatalf("terminal output = %q, want %q", output, clipboardOSC52)
+	}
+	assertClipboardSuccess(t, model)
+	if len(*invocations) != 0 {
+		t.Fatalf("native clipboard command used remotely: %#v", *invocations)
+	}
+}
+
+func TestCopyToClipboardUsesNativeToolLocally(t *testing.T) {
+	resetClipboardEnvironment(t)
+	candidate := firstNativeClipboardCommand(t)
+	invocations := stubClipboardCommands(t, map[string]error{
+		candidate[0]: nil,
+	})
+
+	output, model := runClipboardCopy(t)
+
+	if output != "" {
+		t.Fatalf("terminal output = %q, want none", output)
+	}
+	assertClipboardSuccess(t, model)
+	want := []clipboardInvocation{{
+		path: candidate[0],
+		args: append([]string(nil), candidate[1:]...),
+		text: clipboardTestText,
+	}}
+	if !reflect.DeepEqual(*invocations, want) {
+		t.Fatalf("clipboard invocations = %#v, want %#v", *invocations, want)
+	}
+}
+
+func TestCopyToClipboardFallsBackToOSC52WhenNativeToolFails(t *testing.T) {
+	resetClipboardEnvironment(t)
+	candidate := firstNativeClipboardCommand(t)[0]
+	stubClipboardCommands(t, map[string]error{
+		candidate: errors.New("clipboard unavailable"),
+	})
+
+	output, model := runClipboardCopy(t)
+
+	if output != clipboardOSC52 {
+		t.Fatalf("terminal output = %q, want %q", output, clipboardOSC52)
+	}
+	assertClipboardSuccess(t, model)
+}
+
+func TestCopyToClipboardFallsBackToOSC52WithoutNativeTool(t *testing.T) {
+	resetClipboardEnvironment(t)
+	stubClipboardCommands(t, nil)
+
+	output, model := runClipboardCopy(t)
+
+	if output != clipboardOSC52 {
+		t.Fatalf("terminal output = %q, want %q", output, clipboardOSC52)
+	}
+	assertClipboardSuccess(t, model)
+}


### PR DESCRIPTION
## Summary
- route selection copies through `tmux load-buffer -w` when Stormlight runs inside tmux, preserving `set-clipboard external` behavior
- use OSC 52 directly for SSH and Mosh sessions so the client terminal receives the clipboard data
- prefer native clipboard tools in local sessions (`pbcopy`, `wl-copy`, `xclip`, or `clip.exe`) and fall back to OSC 52
- cover backend precedence, command failures, multiline UTF-8 payloads, and copy status

## Testing
- `go test ./...`
- `go vet ./...`
- `go build -o /tmp/stormlight-clipboard-final .`
- attached tmux client capture with `set-clipboard external` confirmed `load-buffer -w` emitted the OSC 52 payload

Fixes #108