### PR TITLE
Let managed agents create workspaces and peer agents

### DIFF
--- a/README.md
+++ b/README.md
@@ -149,6 +149,29 @@ stormlight delete <id>
 stormlight logs
 ```
 
+Manage workspaces without opening the dashboard:
+
+```bash
+stormlight workspace add ~/src/project
+stormlight workspace list --json
+stormlight workspace roots ~/src/project --json
+```
+
+Managed agents receive `$STORMLIGHT_BIN`, so they can add workspaces and create
+peer agents when a task calls for parallel work:
+
+```bash
+"$STORMLIGHT_BIN" workspace add ~/src/project
+"$STORMLIGHT_BIN" dispatch --cwd ~/src/project \
+  "Investigate the failing integration test"
+```
+
+`workspace roots` defaults to the current directory and emits every runnable
+location in the resolved workspace. An orchestrating agent can use that
+inventory to dispatch one peer per checkout. The dashboard polls the same
+workspace catalog, root inventory, and managed-agent roster, so all changes
+appear without a restart.
+
 Agent renames set the stored name, which the dashboard prefers over the
 generated task title. Workspace renames (press `R` in the Workspaces pane)
 are display-name overrides stored in the workspace catalog; the directory on
@@ -275,6 +298,12 @@ active agents remain visible even when they are not in the catalog, so the
 ordinary confirmation only removes agent-free workspaces. For a workspace
 that still has agents, the confirmation demands a deliberate capital `X`,
 which deletes the workspace and every agent in it.
+
+Executable workspace resolvers may enumerate execution roots as well as resolve
+individual paths. The New Agent location picker shows those roots before they
+contain an agent, while proprietary and environment-specific workspace
+semantics remain outside Stormlight. See
+[workspace resolvers](docs/workspace-resolvers.md).
 
 Compact rows are the default and show the primary workspace or agent line.
 Press `z` to reveal the path and resolver or provider details. Narrow

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -52,8 +52,13 @@ do not currently contain an agent.
 
 Workspace resolvers return a stable group ID, a group root, an execution root,
 and optional component metadata. External executable resolvers run before the
-built-in Git resolver, followed by a canonical-directory fallback. This keeps
-environment-specific workspace semantics outside the public runtime.
+built-in Git resolver, followed by a canonical-directory fallback.
+Resolvers may also enumerate a group's current execution roots; the application
+service exposes that same inventory to the CLI and dashboard directory picker.
+Enumeration is routed back to the resolver that claimed the workspace and is
+bounded, cached, and best-effort, so a failed external integration cannot block
+dashboard refresh. This keeps environment-specific workspace semantics outside
+the public runtime.
 
 ### windrunner runtime
 

--- a/docs/workspace-resolvers.md
+++ b/docs/workspace-resolvers.md
@@ -65,6 +65,25 @@ defaults to the root directory name, and `execution_root` defaults to `root`.
 All returned paths must exist and be directories. IDs must remain stable for
 directories that belong in the same workspace group.
 
+Resolvers may also enumerate every runnable location in a workspace:
+
+```text
+resolver roots <canonical-workspace-root>
+```
+
+Exit status `0` must emit a JSON array of workspace context objects. Every
+object must carry the same workspace ID and root, with its own
+`execution_root`. Exit status `2` means enumeration is not applicable. Other
+failures are logged and Stormlight falls back to the resolved context.
+
+An execution-root context may set `metadata.execution_root_label` to control
+the directory picker's label and the agent's dashboard badge, including for
+the primary root. Without it, custom non-primary roots use
+`root <directory-name>`.
+
 Resolvers are trusted local executables and run during dispatch and workspace
-catalog loading. Stormlight caches successful results for the life of the
-process.
+catalog loading. Stormlight caches successful resolution for the life of the
+process. Root enumeration runs only on the resolver that claimed the workspace,
+has a one-second deadline, and caches successful, unsupported, and failed
+outcomes for five seconds. A failed or timed-out inventory never blocks
+dashboard refresh; it logs the failure and exposes the resolved primary root.

--- a/internal/app/service.go
+++ b/internal/app/service.go
@@ -238,6 +238,72 @@ func (s *Service) ListWorkspaces(ctx context.Context) ([]workspace.Context, erro
 	return values, nil
 }
 
+// ListWorkspaceRoots expands every catalog workspace into its currently
+// available execution roots. It is the shared source for headless callers and
+// the dashboard's dispatch picker.
+func (s *Service) ListWorkspaceRoots(ctx context.Context) ([]workspace.Context, error) {
+	workspaces, err := s.ListWorkspaces(ctx)
+	if err != nil {
+		return nil, err
+	}
+	var roots []workspace.Context
+	for _, value := range workspaces {
+		values, rootErr := s.workspaces.ExecutionRoots(ctx, value)
+		if rootErr != nil {
+			return nil, rootErr
+		}
+		roots = append(roots, values...)
+	}
+	s.applyWorkspaceNames(roots)
+	sortWorkspaceRoots(roots)
+	return roots, nil
+}
+
+// WorkspaceRoots resolves one path without adding it to the catalog, then
+// returns all execution roots belonging to the same workspace.
+func (s *Service) WorkspaceRoots(
+	ctx context.Context,
+	path string,
+) ([]workspace.Context, error) {
+	value, err := s.workspaces.Resolve(ctx, path)
+	if err != nil {
+		return nil, err
+	}
+	values, err := s.workspaces.ExecutionRoots(ctx, value)
+	if err != nil {
+		return nil, err
+	}
+	s.applyWorkspaceNames(values)
+	sortWorkspaceRoots(values)
+	return values, nil
+}
+
+func sortWorkspaceRoots(values []workspace.Context) {
+	slices.SortStableFunc(values, func(a, b workspace.Context) int {
+		if order := cmp.Compare(strings.ToLower(a.Name), strings.ToLower(b.Name)); order != 0 {
+			return order
+		}
+		if order := cmp.Compare(strings.ToLower(a.Root), strings.ToLower(b.Root)); order != 0 {
+			return order
+		}
+		if order := cmp.Compare(a.ID, b.ID); order != 0 {
+			return order
+		}
+		aPrimary := a.ExecutionRoot == a.Root
+		bPrimary := b.ExecutionRoot == b.Root
+		if aPrimary != bPrimary {
+			if aPrimary {
+				return -1
+			}
+			return 1
+		}
+		return cmp.Compare(
+			strings.ToLower(a.ExecutionRoot),
+			strings.ToLower(b.ExecutionRoot),
+		)
+	})
+}
+
 func (s *Service) resolveCached(
 	ctx context.Context,
 	path string,

--- a/internal/app/service_test.go
+++ b/internal/app/service_test.go
@@ -2,7 +2,10 @@ package app
 
 import (
 	"context"
+	"errors"
+	"os"
 	"path/filepath"
+	"slices"
 	"testing"
 
 	"github.com/trentkm/stormlight/internal/agent"
@@ -16,6 +19,30 @@ type recordingRuntime struct {
 	session.Runtime
 	agents      []agent.Agent
 	workspaceID string
+}
+
+type rootsResolver struct {
+	root  workspace.Context
+	roots []workspace.Context
+	err   error
+}
+
+func (r rootsResolver) Name() string {
+	return "roots"
+}
+
+func (r rootsResolver) Resolve(
+	context.Context,
+	string,
+) (workspace.Context, bool, error) {
+	return r.root, true, nil
+}
+
+func (r rootsResolver) ExecutionRoots(
+	context.Context,
+	workspace.Context,
+) ([]workspace.Context, bool, error) {
+	return r.roots, true, r.err
 }
 
 func (r *recordingRuntime) Update(
@@ -126,5 +153,108 @@ func TestUpdateRecordsSessionHistory(t *testing.T) {
 	}
 	if len(past) != 1 || past[0].SessionID != records[0].SessionID {
 		t.Fatalf("past = %#v", past)
+	}
+}
+
+func TestListWorkspaceRootsExpandsCatalogWorkspaces(t *testing.T) {
+	root, err := filepath.EvalSymlinks(t.TempDir())
+	if err != nil {
+		t.Fatal(err)
+	}
+	worktreeBase, err := filepath.EvalSymlinks(t.TempDir())
+	if err != nil {
+		t.Fatal(err)
+	}
+	worktree := filepath.Join(worktreeBase, "feature")
+	if err := os.MkdirAll(worktree, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	value := workspace.Context{
+		ID:            "example:" + root,
+		Kind:          "example",
+		Name:          "example",
+		Root:          root,
+		ExecutionRoot: root,
+	}
+	linked := value
+	linked.ExecutionRoot = worktree
+	catalog := workspace.NewCatalogAt(filepath.Join(t.TempDir(), "workspaces.json"))
+	if err := catalog.Add(root); err != nil {
+		t.Fatal(err)
+	}
+	service := NewServiceWithCatalog(
+		&recordingRuntime{},
+		provider.NewRegistry(),
+		workspace.NewRegistryWithResolvers(rootsResolver{
+			root:  value,
+			roots: []workspace.Context{linked, value},
+		}),
+		catalog,
+		history.NewLogAt(filepath.Join(t.TempDir(), "sessions.jsonl")),
+	)
+
+	roots, err := service.ListWorkspaceRoots(context.Background())
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(roots) != 2 ||
+		roots[0].ExecutionRoot != root ||
+		roots[1].ExecutionRoot != worktree {
+		t.Fatalf("roots = %#v", roots)
+	}
+}
+
+func TestListWorkspaceRootsDegradesOnResolverFailure(t *testing.T) {
+	root, err := filepath.EvalSymlinks(t.TempDir())
+	if err != nil {
+		t.Fatal(err)
+	}
+	value := workspace.Context{
+		ID:            "example:" + root,
+		Kind:          "example",
+		Name:          "example",
+		Root:          root,
+		ExecutionRoot: root,
+	}
+	catalog := workspace.NewCatalogAt(filepath.Join(t.TempDir(), "workspaces.json"))
+	if err := catalog.Add(root); err != nil {
+		t.Fatal(err)
+	}
+	service := NewServiceWithCatalog(
+		&recordingRuntime{},
+		provider.NewRegistry(),
+		workspace.NewRegistryWithResolvers(rootsResolver{
+			root: value,
+			err:  errors.New("enumeration failed"),
+		}),
+		catalog,
+		history.NewLogAt(filepath.Join(t.TempDir(), "sessions.jsonl")),
+	)
+
+	roots, err := service.ListWorkspaceRoots(context.Background())
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(roots) != 1 || roots[0].ExecutionRoot != root {
+		t.Fatalf("roots = %#v", roots)
+	}
+}
+
+func TestSortWorkspaceRootsGroupsEachWorkspace(t *testing.T) {
+	values := []workspace.Context{
+		{ID: "a", Name: "alpha", Root: "/a", ExecutionRoot: "/a/feature"},
+		{ID: "b", Name: "beta", Root: "/b", ExecutionRoot: "/b"},
+		{ID: "a", Name: "alpha", Root: "/a", ExecutionRoot: "/a"},
+		{ID: "b", Name: "beta", Root: "/b", ExecutionRoot: "/b/feature"},
+	}
+	sortWorkspaceRoots(values)
+
+	got := make([]string, 0, len(values))
+	for _, value := range values {
+		got = append(got, value.ExecutionRoot)
+	}
+	want := []string{"/a", "/a/feature", "/b", "/b/feature"}
+	if !slices.Equal(got, want) {
+		t.Fatalf("roots = %#v, want %#v", got, want)
 	}
 }

--- a/internal/filelock/filelock.go
+++ b/internal/filelock/filelock.go
@@ -1,0 +1,42 @@
+// Package filelock serializes access to atomically replaced state files.
+package filelock
+
+import (
+	"errors"
+	"fmt"
+	"os"
+	"syscall"
+	"time"
+)
+
+const retryInterval = 10 * time.Millisecond
+
+// Acquire obtains an exclusive lock on path, waiting no longer than timeout.
+func Acquire(path string, mode os.FileMode, timeout time.Duration) (func(), error) {
+	file, err := os.OpenFile(path, os.O_CREATE|os.O_RDWR, mode)
+	if err != nil {
+		return nil, fmt.Errorf("open lock file: %w", err)
+	}
+
+	deadline := time.Now().Add(timeout)
+	for {
+		err = syscall.Flock(int(file.Fd()), syscall.LOCK_EX|syscall.LOCK_NB)
+		if err == nil {
+			return func() {
+				_ = syscall.Flock(int(file.Fd()), syscall.LOCK_UN)
+				_ = file.Close()
+			}, nil
+		}
+		if !errors.Is(err, syscall.EWOULDBLOCK) &&
+			!errors.Is(err, syscall.EAGAIN) &&
+			!errors.Is(err, syscall.EINTR) {
+			_ = file.Close()
+			return nil, fmt.Errorf("acquire lock: %w", err)
+		}
+		if time.Now().After(deadline) {
+			_ = file.Close()
+			return nil, fmt.Errorf("acquire lock: timed out after %s", timeout)
+		}
+		time.Sleep(retryInterval)
+	}
+}

--- a/internal/history/history.go
+++ b/internal/history/history.go
@@ -23,10 +23,10 @@ import (
 	"path/filepath"
 	"slices"
 	"strings"
-	"syscall"
 	"time"
 
 	"github.com/trentkm/stormlight/internal/agent"
+	"github.com/trentkm/stormlight/internal/filelock"
 	"github.com/trentkm/stormlight/internal/workspace"
 )
 
@@ -177,6 +177,7 @@ func (l *Log) load() ([]Record, int, error) {
 // so the file grows past its information content by design; below this
 // floor a rewrite saves less than it costs.
 const compactionSlack = 256
+const lockTimeout = 5 * time.Second
 
 // Compact rewrites the log as one line per session when enough redundant
 // lines have accumulated. It is meant for a startup path — the dashboard
@@ -221,18 +222,11 @@ func (l *Log) Compact() error {
 // lock file's path never changes, so its inode is the one thing every
 // writer agrees on.
 func (l *Log) lock() (func(), error) {
-	file, err := os.OpenFile(l.path+".lock", os.O_CREATE|os.O_RDWR, 0o644)
+	unlock, err := filelock.Acquire(l.path+".lock", 0o644, lockTimeout)
 	if err != nil {
-		return nil, fmt.Errorf("open session history lock: %w", err)
-	}
-	if err := syscall.Flock(int(file.Fd()), syscall.LOCK_EX); err != nil {
-		file.Close()
 		return nil, fmt.Errorf("lock session history: %w", err)
 	}
-	return func() {
-		syscall.Flock(int(file.Fd()), syscall.LOCK_UN)
-		file.Close()
-	}, nil
+	return unlock, nil
 }
 
 func logPath() string {

--- a/internal/ui/commands.go
+++ b/internal/ui/commands.go
@@ -25,9 +25,18 @@ func (m Model) refreshCmd() tea.Cmd {
 		if err != nil {
 			return dashboardMsg{agents: agents, err: err}
 		}
+		roots, err := m.backend.ListWorkspaceRoots(ctx)
+		if err != nil {
+			return dashboardMsg{
+				agents:     agents,
+				workspaces: workspaces,
+				err:        err,
+			}
+		}
 		return dashboardMsg{
 			agents:     agents,
 			workspaces: workspaces,
+			roots:      roots,
 		}
 	}
 }

--- a/internal/ui/dispatch.go
+++ b/internal/ui/dispatch.go
@@ -943,6 +943,18 @@ func (m *Model) prepareDirectoryChoices(preferred string) {
 		return index
 	}
 
+	for _, value := range m.workspaceRoots {
+		label := value.Name
+		if rootLabel := strings.TrimSpace(
+			value.Metadata["execution_root_label"],
+		); rootLabel != "" {
+			label += " / " + rootLabel
+		} else if directoryKey(value.ExecutionRoot) != directoryKey(value.Root) {
+			label += " / " + filepath.Base(value.ExecutionRoot)
+		}
+		addPath(value.ExecutionRoot, label, value.Kind)
+	}
+
 	for _, group := range m.groups {
 		groupRoot := group.context.ExecutionRoot
 		if groupRoot == "" {
@@ -956,7 +968,11 @@ func (m *Model) prepareDirectoryChoices(preferred string) {
 				executionRoot = value.Root
 			}
 			label := value.Name
-			if directoryKey(executionRoot) != directoryKey(groupRoot) {
+			if rootLabel := strings.TrimSpace(
+				value.Metadata["execution_root_label"],
+			); rootLabel != "" {
+				label += " / " + rootLabel
+			} else if directoryKey(executionRoot) != directoryKey(groupRoot) {
 				label += " / " + filepath.Base(executionRoot)
 			}
 			addPath(executionRoot, label, value.Kind)

--- a/internal/ui/input_test.go
+++ b/internal/ui/input_test.go
@@ -2148,6 +2148,35 @@ func TestCheckoutBadgeColors(t *testing.T) {
 	}
 }
 
+func TestCustomAgentNamesItsExecutionRoot(t *testing.T) {
+	badge := agentCheckout(agent.Agent{Workspace: workspace.Context{
+		ID:            "custom:/workspace",
+		Kind:          "custom",
+		Name:          "workspace",
+		Root:          "/workspace",
+		ExecutionRoot: "/workspace/worktrees/fix-auth",
+	}})
+	if badge.text != "root fix-auth" || badge.primary {
+		t.Fatalf("badge = %#v", badge)
+	}
+}
+
+func TestCustomAgentHonorsPrimaryExecutionRootLabel(t *testing.T) {
+	badge := agentCheckout(agent.Agent{Workspace: workspace.Context{
+		ID:            "custom:/workspace",
+		Kind:          "custom",
+		Name:          "workspace",
+		Root:          "/workspace",
+		ExecutionRoot: "/workspace",
+		Metadata: map[string]string{
+			"execution_root_label": "development root",
+		},
+	}})
+	if badge.text != "development root" || !badge.primary {
+		t.Fatalf("badge = %#v", badge)
+	}
+}
+
 // A narrow pane drops the path before the badge: the path restates the
 // checkout, the badge is the only token that names it. Tokens fall from the
 // tail, so the state and the provider outlive both.
@@ -2273,6 +2302,43 @@ func TestAddWorkspaceCommandUpdatesDashboard(t *testing.T) {
 	}
 }
 
+func TestDirectoryPickerIncludesDiscoveredExecutionRoots(t *testing.T) {
+	root := t.TempDir()
+	worktree := filepath.Join(t.TempDir(), "feature-one")
+	if err := os.MkdirAll(worktree, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	primary := workspace.Context{
+		ID:            "custom:" + root,
+		Kind:          "custom",
+		Name:          "example",
+		Root:          root,
+		ExecutionRoot: root,
+		Metadata: map[string]string{
+			"execution_root_label": "primary root",
+		},
+	}
+	linked := primary
+	linked.ExecutionRoot = worktree
+	linked.Metadata = map[string]string{
+		"execution_root_label": "feature root",
+	}
+	model := NewModel(&recordingBackend{})
+	model.workspaceRoots = []workspace.Context{primary, linked}
+	model.prepareDirectoryChoices(root)
+
+	labels := make(map[string]string)
+	for _, choice := range model.directories {
+		if choice.kind == directoryPath {
+			labels[choice.path] = choice.label
+		}
+	}
+	if labels[root] != "example / primary root" ||
+		labels[worktree] != "example / feature root" {
+		t.Fatalf("directory labels = %#v", labels)
+	}
+}
+
 func TestActionErrorSurvivesSuccessfulRefresh(t *testing.T) {
 	model := NewModel(stubBackend{})
 	model.err = errors.New("attach failed")
@@ -2301,6 +2367,10 @@ func (stubBackend) ListAgents(context.Context) ([]agent.Agent, error) {
 }
 
 func (stubBackend) ListWorkspaces(context.Context) ([]workspace.Context, error) {
+	return nil, nil
+}
+
+func (stubBackend) ListWorkspaceRoots(context.Context) ([]workspace.Context, error) {
 	return nil, nil
 }
 
@@ -2374,12 +2444,13 @@ func (stubBackend) Resume(context.Context, history.Record) (agent.Agent, error) 
 
 type recordingBackend struct {
 	stubBackend
-	providers   []provider.Info
-	request     app.DispatchRequest
-	addedPath   string
-	sentID      string
-	sentMessage string
-	attachedID  string
+	providers      []provider.Info
+	workspaceRoots []workspace.Context
+	request        app.DispatchRequest
+	addedPath      string
+	sentID         string
+	sentMessage    string
+	attachedID     string
 }
 
 func (b *recordingBackend) Dispatch(_ context.Context, request app.DispatchRequest) (agent.Agent, error) {
@@ -2392,6 +2463,12 @@ func (b *recordingBackend) Dispatch(_ context.Context, request app.DispatchReque
 
 func (b *recordingBackend) Providers() []provider.Info {
 	return b.providers
+}
+
+func (b *recordingBackend) ListWorkspaceRoots(
+	context.Context,
+) ([]workspace.Context, error) {
+	return b.workspaceRoots, nil
 }
 
 func (b *recordingBackend) AddWorkspace(

--- a/internal/ui/model.go
+++ b/internal/ui/model.go
@@ -26,6 +26,7 @@ import (
 type Backend interface {
 	ListAgents(context.Context) ([]agent.Agent, error)
 	ListWorkspaces(context.Context) ([]workspace.Context, error)
+	ListWorkspaceRoots(context.Context) ([]workspace.Context, error)
 	AddWorkspace(context.Context, string) (workspace.Context, error)
 	RemoveWorkspace(context.Context, workspace.Context) error
 	Dispatch(context.Context, app.DispatchRequest) (agent.Agent, error)
@@ -130,6 +131,7 @@ type Model struct {
 
 	agents            []agent.Agent
 	catalogWorkspaces []workspace.Context
+	workspaceRoots    []workspace.Context
 	groups            []workspaceGroup
 	workspaceCursor   int
 	agentCursor       int
@@ -222,6 +224,7 @@ type Model struct {
 type dashboardMsg struct {
 	agents     []agent.Agent
 	workspaces []workspace.Context
+	roots      []workspace.Context
 	err        error
 }
 
@@ -441,6 +444,7 @@ func (m Model) Update(message tea.Msg) (tea.Model, tea.Cmd) {
 		} else {
 			m.agents = msg.agents
 			m.catalogWorkspaces = msg.workspaces
+			m.workspaceRoots = msg.roots
 			m.rebuildGroups(workspaceID, agentID)
 			m.initialWorkspaceID = ""
 			if m.mode == modeCompose {

--- a/internal/ui/state.go
+++ b/internal/ui/state.go
@@ -232,22 +232,28 @@ type checkoutBadge struct {
 	primary bool
 }
 
-// agentCheckout names the Git checkout an agent runs in. Linked worktrees
-// share a --git-common-dir with their checkout, so the resolver files them
-// under one workspace: Root is the checkout every worktree hangs off,
-// ExecutionRoot the tree this agent actually edits. A tree of its own is
-// named by that tree; landing on Root instead is the primary checkout, and it
-// is named too — every agent in a Git workspace gets a badge, so an absent
-// one means the agent is outside Git rather than merely unremarkable.
+// agentCheckout names the execution root an agent runs in. Git gets its
+// familiar checkout/worktree language; custom resolvers may provide an
+// execution_root_label, with a generic root label as fallback.
 func agentCheckout(managedAgent agent.Agent) checkoutBadge {
 	value := effectiveWorkspace(managedAgent)
-	if value.Kind != workspace.KindGit || value.ExecutionRoot == "" {
+	if value.ExecutionRoot == "" {
 		return checkoutBadge{}
 	}
-	if directoryKey(value.ExecutionRoot) == directoryKey(value.Root) {
-		return checkoutBadge{text: "main checkout", primary: true}
+	primary := directoryKey(value.ExecutionRoot) == directoryKey(value.Root)
+	if label := strings.TrimSpace(value.Metadata["execution_root_label"]); label != "" {
+		return checkoutBadge{text: label, primary: primary}
 	}
-	return checkoutBadge{text: "worktree " + filepath.Base(value.ExecutionRoot)}
+	if primary {
+		if value.Kind == workspace.KindGit {
+			return checkoutBadge{text: "main checkout", primary: true}
+		}
+		return checkoutBadge{}
+	}
+	if value.Kind == workspace.KindGit {
+		return checkoutBadge{text: "worktree " + filepath.Base(value.ExecutionRoot)}
+	}
+	return checkoutBadge{text: "root " + filepath.Base(value.ExecutionRoot)}
 }
 
 func (m *Model) moveSelection(delta int) {

--- a/internal/workspace/catalog.go
+++ b/internal/workspace/catalog.go
@@ -10,9 +10,15 @@ import (
 	"slices"
 	"strings"
 	"sync"
+	"time"
+
+	"github.com/trentkm/stormlight/internal/filelock"
 )
 
-const catalogVersion = 1
+const (
+	catalogVersion     = 1
+	catalogLockTimeout = time.Second
+)
 
 type Catalog struct {
 	path string
@@ -52,6 +58,11 @@ func (c *Catalog) Add(path string) error {
 
 	c.mu.Lock()
 	defer c.mu.Unlock()
+	unlock, err := c.lock()
+	if err != nil {
+		return err
+	}
+	defer unlock()
 
 	data, err := c.read()
 	if err != nil {
@@ -72,6 +83,11 @@ func (c *Catalog) Remove(path string) error {
 
 	c.mu.Lock()
 	defer c.mu.Unlock()
+	unlock, err := c.lock()
+	if err != nil {
+		return err
+	}
+	defer unlock()
 
 	data, err := c.read()
 	if err != nil {
@@ -95,6 +111,11 @@ func (c *Catalog) SetName(path, name string) error {
 
 	c.mu.Lock()
 	defer c.mu.Unlock()
+	unlock, err := c.lock()
+	if err != nil {
+		return err
+	}
+	defer unlock()
 
 	data, err := c.read()
 	if err != nil {
@@ -187,6 +208,23 @@ func (c *Catalog) write(data catalogData) error {
 		return fmt.Errorf("replace workspace catalog: %w", err)
 	}
 	return nil
+}
+
+// lock serializes read-modify-write mutations across Stormlight processes.
+// The sibling lock file survives the catalog's atomic rename, so every
+// process continues to lock the same inode.
+func (c *Catalog) lock() (func(), error) {
+	if strings.TrimSpace(c.path) == "" {
+		return func() {}, nil
+	}
+	if err := os.MkdirAll(filepath.Dir(c.path), 0o700); err != nil {
+		return nil, fmt.Errorf("create workspace catalog directory: %w", err)
+	}
+	unlock, err := filelock.Acquire(c.path+".lock", 0o600, catalogLockTimeout)
+	if err != nil {
+		return nil, fmt.Errorf("lock workspace catalog: %w", err)
+	}
+	return unlock, nil
 }
 
 func catalogPath() string {

--- a/internal/workspace/catalog_test.go
+++ b/internal/workspace/catalog_test.go
@@ -1,9 +1,15 @@
 package workspace
 
 import (
+	"bytes"
 	"os"
+	"os/exec"
 	"path/filepath"
+	"strings"
 	"testing"
+	"time"
+
+	"github.com/trentkm/stormlight/internal/filelock"
 )
 
 func TestCatalogPersistsCanonicalUniquePaths(t *testing.T) {
@@ -241,5 +247,95 @@ func TestCatalogPathPrefersExplicitFileThenStateHome(t *testing.T) {
 	// silently edit the real catalog.
 	if got := NewCatalog().path; got != want {
 		t.Fatalf("NewCatalog path = %q, want %q", got, want)
+	}
+}
+
+func TestCatalogSerializesConcurrentProcesses(t *testing.T) {
+	const writers = 12
+	base := t.TempDir()
+	catalogPath := filepath.Join(base, "state", "workspaces.json")
+	barrier := filepath.Join(base, "start")
+	commands := make([]*exec.Cmd, 0, writers)
+	outputs := make([]*bytes.Buffer, 0, writers)
+	for index := range writers {
+		root := filepath.Join(base, "roots", string(rune('a'+index)))
+		if err := os.MkdirAll(root, 0o755); err != nil {
+			t.Fatal(err)
+		}
+		command := exec.Command(os.Args[0], "-test.run=^TestCatalogProcessWriter$")
+		command.Env = append(os.Environ(),
+			"STORMLIGHT_CATALOG_WRITER=1",
+			"STORMLIGHT_CATALOG_PATH="+catalogPath,
+			"STORMLIGHT_CATALOG_ROOT="+root,
+			"STORMLIGHT_CATALOG_BARRIER="+barrier,
+		)
+		output := &bytes.Buffer{}
+		command.Stdout = output
+		command.Stderr = output
+		if err := command.Start(); err != nil {
+			t.Fatal(err)
+		}
+		commands = append(commands, command)
+		outputs = append(outputs, output)
+	}
+	if err := os.WriteFile(barrier, []byte("start"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	for index, command := range commands {
+		if err := command.Wait(); err != nil {
+			t.Fatalf("writer %d: %v\n%s", index, err, outputs[index].String())
+		}
+	}
+	paths, err := NewCatalogAt(catalogPath).Paths()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(paths) != writers {
+		t.Fatalf("catalog retained %d/%d concurrent writes: %#v",
+			len(paths), writers, paths)
+	}
+}
+
+func TestCatalogLockWaitIsBounded(t *testing.T) {
+	root := t.TempDir()
+	catalogPath := filepath.Join(t.TempDir(), "workspaces.json")
+	unlock, err := filelock.Acquire(
+		catalogPath+".lock",
+		0o600,
+		100*time.Millisecond,
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer unlock()
+
+	started := time.Now()
+	err = NewCatalogAt(catalogPath).Add(root)
+	elapsed := time.Since(started)
+	if err == nil || !strings.Contains(err.Error(), "timed out") {
+		t.Fatalf("Add error = %v", err)
+	}
+	if elapsed < 900*time.Millisecond || elapsed > 3*time.Second {
+		t.Fatalf("Add waited %s for the lock", elapsed)
+	}
+}
+
+func TestCatalogProcessWriter(t *testing.T) {
+	if os.Getenv("STORMLIGHT_CATALOG_WRITER") != "1" {
+		return
+	}
+	deadline := time.Now().Add(5 * time.Second)
+	for {
+		if _, err := os.Stat(os.Getenv("STORMLIGHT_CATALOG_BARRIER")); err == nil {
+			break
+		}
+		if time.Now().After(deadline) {
+			t.Fatal("timed out waiting for process barrier")
+		}
+		time.Sleep(5 * time.Millisecond)
+	}
+	if err := NewCatalogAt(os.Getenv("STORMLIGHT_CATALOG_PATH")).
+		Add(os.Getenv("STORMLIGHT_CATALOG_ROOT")); err != nil {
+		t.Fatal(err)
 	}
 }

--- a/internal/workspace/external.go
+++ b/internal/workspace/external.go
@@ -52,6 +52,39 @@ func (r externalResolver) Resolve(ctx context.Context, path string) (Context, bo
 	return value, true, nil
 }
 
+func (r externalResolver) ExecutionRoots(
+	ctx context.Context,
+	value Context,
+) ([]Context, bool, error) {
+	command := exec.CommandContext(ctx, r.path, "roots", value.Root)
+	command.Dir = value.Root
+	var stdout bytes.Buffer
+	var stderr bytes.Buffer
+	command.Stdout = &stdout
+	command.Stderr = &stderr
+	err := command.Run()
+	if err != nil {
+		if ctx.Err() != nil {
+			return nil, false, ctx.Err()
+		}
+		var exitError *exec.ExitError
+		if errors.As(err, &exitError) && exitError.ExitCode() == 2 {
+			return nil, false, nil
+		}
+		detail := strings.TrimSpace(stderr.String())
+		if detail == "" {
+			detail = err.Error()
+		}
+		return nil, false, fmt.Errorf("%s", detail)
+	}
+
+	var values []Context
+	if err := json.Unmarshal(stdout.Bytes(), &values); err != nil {
+		return nil, false, fmt.Errorf("decode resolver roots: %w", err)
+	}
+	return values, true, nil
+}
+
 func loadExternalResolvers(directory string) ([]Resolver, error) {
 	if directory == "" {
 		return nil, nil

--- a/internal/workspace/git.go
+++ b/internal/workspace/git.go
@@ -60,3 +60,37 @@ func (gitResolver) Resolve(ctx context.Context, path string) (Context, bool, err
 		ExecutionRoot: executionRoot,
 	}, true, nil
 }
+
+func (r gitResolver) ExecutionRoots(
+	ctx context.Context,
+	value Context,
+) ([]Context, bool, error) {
+	if value.Kind != KindGit {
+		return nil, false, nil
+	}
+	command := exec.CommandContext(ctx,
+		"git", "-C", value.Root, "worktree", "list", "--porcelain",
+	)
+	output, err := command.Output()
+	if err != nil {
+		if ctx.Err() != nil {
+			return nil, true, ctx.Err()
+		}
+		return nil, true, fmt.Errorf("list Git worktrees: %w", err)
+	}
+	var values []Context
+	for _, line := range strings.Split(string(output), "\n") {
+		if !strings.HasPrefix(line, "worktree ") {
+			continue
+		}
+		path := strings.TrimSpace(strings.TrimPrefix(line, "worktree "))
+		resolved, matched, resolveErr := r.Resolve(ctx, path)
+		if resolveErr != nil {
+			continue
+		}
+		if matched && resolved.ID == value.ID {
+			values = append(values, resolved)
+		}
+	}
+	return values, true, nil
+}

--- a/internal/workspace/registry.go
+++ b/internal/workspace/registry.go
@@ -5,7 +5,9 @@ import (
 	"errors"
 	"os"
 	"path/filepath"
+	"slices"
 	"sync"
+	"time"
 
 	"github.com/trentkm/stormlight/internal/diagnostic"
 )
@@ -15,11 +17,28 @@ type Resolver interface {
 	Resolve(context.Context, string) (Context, bool, error)
 }
 
+type executionRootResolver interface {
+	ExecutionRoots(context.Context, Context) ([]Context, bool, error)
+}
+
 type Registry struct {
 	resolvers []Resolver
 	mu        sync.RWMutex
 	cache     map[string]Context
+	routes    map[string]int
+	roots     map[string]cachedExecutionRoots
 }
+
+type cachedExecutionRoots struct {
+	values []Context
+	at     time.Time
+}
+
+const (
+	executionRootCacheTTL = 5 * time.Second
+	executionRootTimeout  = time.Second
+	noResolver            = -1
+)
 
 func NewRegistry() *Registry {
 	resolvers, err := loadExternalResolvers(resolverDirectory())
@@ -34,6 +53,8 @@ func NewRegistryWithResolvers(resolvers ...Resolver) *Registry {
 	return &Registry{
 		resolvers: append([]Resolver(nil), resolvers...),
 		cache:     make(map[string]Context),
+		routes:    make(map[string]int),
+		roots:     make(map[string]cachedExecutionRoots),
 	}
 }
 
@@ -50,7 +71,7 @@ func (r *Registry) Resolve(ctx context.Context, path string) (Context, error) {
 		return cached, nil
 	}
 
-	for _, resolver := range r.resolvers {
+	for index, resolver := range r.resolvers {
 		value, matched, resolveErr := resolver.Resolve(ctx, canonical)
 		if resolveErr != nil {
 			if errors.Is(resolveErr, context.Canceled) ||
@@ -77,18 +98,108 @@ func (r *Registry) Resolve(ctx context.Context, path string) (Context, error) {
 			)
 			continue
 		}
-		r.store(canonical, value)
+		r.store(canonical, value, index)
 		return value, nil
 	}
 
 	value := DirectoryContext(canonical)
-	r.store(canonical, value)
+	r.store(canonical, value, noResolver)
 	return value, nil
 }
 
-func (r *Registry) store(path string, value Context) {
+// ExecutionRoots returns every runnable checkout currently belonging to a
+// workspace. Enumeration is best-effort: unsupported, invalid, failed, and
+// timed-out discovery all cache and return the resolved path.
+func (r *Registry) ExecutionRoots(ctx context.Context, value Context) ([]Context, error) {
+	r.mu.RLock()
+	cached, ok := r.roots[value.ID]
+	resolverIndex, routed := r.routes[value.ID]
+	r.mu.RUnlock()
+	if ok && time.Since(cached.at) < executionRootCacheTTL {
+		return slices.Clone(cached.values), nil
+	}
+
+	if !routed {
+		resolved, err := r.Resolve(ctx, value.Root)
+		if err != nil {
+			return r.cacheExecutionRoots(value.ID, []Context{value}), nil
+		}
+		value = resolved
+		r.mu.RLock()
+		resolverIndex, routed = r.routes[value.ID]
+		r.mu.RUnlock()
+	}
+	if !routed || resolverIndex == noResolver {
+		return r.cacheExecutionRoots(value.ID, []Context{value}), nil
+	}
+	resolver := r.resolvers[resolverIndex]
+	discoverer, ok := resolver.(executionRootResolver)
+	if !ok {
+		return r.cacheExecutionRoots(value.ID, []Context{value}), nil
+	}
+
+	discoveryCtx, cancel := context.WithTimeout(ctx, executionRootTimeout)
+	defer cancel()
+	values, matched, err := discoverer.ExecutionRoots(discoveryCtx, value)
+	if err != nil {
+		diagnostic.Logger().Warn("workspace execution-root discovery failed",
+			"resolver", resolver.Name(),
+			"workspace_id", value.ID,
+			"error", err,
+		)
+		return r.cacheExecutionRoots(value.ID, []Context{value}), nil
+	}
+	if !matched {
+		return r.cacheExecutionRoots(value.ID, []Context{value}), nil
+	}
+
+	normalized := make([]Context, 0, len(values))
+	seen := make(map[string]bool, len(values))
+	for _, candidate := range values {
+		candidate, err = normalizeContext(candidate)
+		if err != nil {
+			diagnostic.Logger().Warn("workspace resolver returned invalid execution root",
+				"resolver", resolver.Name(),
+				"workspace_id", value.ID,
+				"error", err,
+			)
+			continue
+		}
+		if candidate.ID != value.ID {
+			diagnostic.Logger().Warn("workspace resolver returned execution root for another workspace",
+				"resolver", resolver.Name(),
+				"workspace_id", value.ID,
+				"candidate_id", candidate.ID,
+			)
+			continue
+		}
+		if seen[candidate.ExecutionRoot] {
+			continue
+		}
+		seen[candidate.ExecutionRoot] = true
+		normalized = append(normalized, candidate)
+	}
+	if len(normalized) == 0 {
+		normalized = []Context{value}
+	}
+	return r.cacheExecutionRoots(value.ID, normalized), nil
+}
+
+func (r *Registry) cacheExecutionRoots(id string, values []Context) []Context {
+	result := slices.Clone(values)
+	r.mu.Lock()
+	r.roots[id] = cachedExecutionRoots{
+		values: slices.Clone(result),
+		at:     time.Now(),
+	}
+	r.mu.Unlock()
+	return result
+}
+
+func (r *Registry) store(path string, value Context, resolverIndex int) {
 	r.mu.Lock()
 	r.cache[path] = value
+	r.routes[value.ID] = resolverIndex
 	r.mu.Unlock()
 }
 

--- a/internal/workspace/registry_test.go
+++ b/internal/workspace/registry_test.go
@@ -2,18 +2,25 @@ package workspace
 
 import (
 	"context"
+	"errors"
 	"os"
 	"os/exec"
 	"path/filepath"
 	"testing"
+	"time"
 )
 
 type staticResolver struct {
-	name    string
-	context Context
-	matched bool
-	err     error
-	calls   int
+	name         string
+	context      Context
+	matched      bool
+	err          error
+	calls        int
+	roots        []Context
+	rootsMatched bool
+	rootsErr     error
+	rootsCalls   int
+	waitForRoots bool
 }
 
 func (r *staticResolver) Name() string {
@@ -23,6 +30,18 @@ func (r *staticResolver) Name() string {
 func (r *staticResolver) Resolve(context.Context, string) (Context, bool, error) {
 	r.calls++
 	return r.context, r.matched, r.err
+}
+
+func (r *staticResolver) ExecutionRoots(
+	ctx context.Context,
+	_ Context,
+) ([]Context, bool, error) {
+	r.rootsCalls++
+	if r.waitForRoots {
+		<-ctx.Done()
+		return nil, true, ctx.Err()
+	}
+	return r.roots, r.rootsMatched, r.rootsErr
 }
 
 func TestRegistryUsesFirstMatchingResolverAndCaches(t *testing.T) {
@@ -51,6 +70,146 @@ func TestRegistryUsesFirstMatchingResolverAndCaches(t *testing.T) {
 	}
 }
 
+func TestRegistryUsesOnlyClaimingResolverForExecutionRoots(t *testing.T) {
+	root := canonicalTempDir(t)
+	feature := canonicalTempDir(t)
+	value := Context{
+		ID:            "custom:workspace",
+		Kind:          "custom",
+		Name:          "Example",
+		Root:          root,
+		ExecutionRoot: root,
+	}
+	linked := value
+	linked.ExecutionRoot = feature
+	first := &staticResolver{
+		name:         "claiming",
+		context:      value,
+		matched:      true,
+		roots:        []Context{value, linked},
+		rootsMatched: true,
+	}
+	second := &staticResolver{
+		name:         "unrelated",
+		context:      value,
+		matched:      true,
+		roots:        []Context{value},
+		rootsMatched: true,
+	}
+	registry := NewRegistryWithResolvers(first, second)
+
+	resolved, err := registry.Resolve(context.Background(), root)
+	if err != nil {
+		t.Fatal(err)
+	}
+	roots, err := registry.ExecutionRoots(context.Background(), resolved)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(roots) != 2 {
+		t.Fatalf("roots = %#v", roots)
+	}
+	if first.rootsCalls != 1 || second.rootsCalls != 0 {
+		t.Fatalf("root calls = first:%d second:%d",
+			first.rootsCalls, second.rootsCalls)
+	}
+}
+
+func TestRegistryCachesExecutionRootFallbacks(t *testing.T) {
+	for _, testCase := range []struct {
+		name    string
+		matched bool
+		err     error
+		waits   bool
+		maximum time.Duration
+	}{
+		{name: "unsupported", matched: false},
+		{name: "failure", matched: true, err: errors.New("broken")},
+		{
+			name:    "timeout",
+			matched: true,
+			waits:   true,
+			maximum: 1500 * time.Millisecond,
+		},
+	} {
+		t.Run(testCase.name, func(t *testing.T) {
+			root := canonicalTempDir(t)
+			value := Context{
+				ID:            "custom:" + root,
+				Kind:          "custom",
+				Name:          "custom",
+				Root:          root,
+				ExecutionRoot: root,
+			}
+			resolver := &staticResolver{
+				name:         "custom",
+				context:      value,
+				matched:      true,
+				rootsMatched: testCase.matched,
+				rootsErr:     testCase.err,
+				waitForRoots: testCase.waits,
+			}
+			registry := NewRegistryWithResolvers(resolver)
+			resolved, err := registry.Resolve(context.Background(), root)
+			if err != nil {
+				t.Fatal(err)
+			}
+
+			started := time.Now()
+			for range 2 {
+				roots, err := registry.ExecutionRoots(context.Background(), resolved)
+				if err != nil {
+					t.Fatal(err)
+				}
+				if len(roots) != 1 || roots[0].ExecutionRoot != root {
+					t.Fatalf("roots = %#v", roots)
+				}
+			}
+			if resolver.rootsCalls != 1 {
+				t.Fatalf("root calls = %d, want 1", resolver.rootsCalls)
+			}
+			if testCase.maximum > 0 && time.Since(started) > testCase.maximum {
+				t.Fatalf("fallback took %s", time.Since(started))
+			}
+		})
+	}
+}
+
+func TestRegistryIgnoresRootsFromAnotherWorkspace(t *testing.T) {
+	root := canonicalTempDir(t)
+	other := canonicalTempDir(t)
+	value := Context{
+		ID:            "custom:expected",
+		Kind:          "custom",
+		Name:          "expected",
+		Root:          root,
+		ExecutionRoot: root,
+	}
+	wrong := value
+	wrong.ID = "custom:other"
+	wrong.Root = other
+	wrong.ExecutionRoot = other
+	resolver := &staticResolver{
+		name:         "custom",
+		context:      value,
+		matched:      true,
+		roots:        []Context{wrong},
+		rootsMatched: true,
+	}
+	registry := NewRegistryWithResolvers(resolver)
+	resolved, err := registry.Resolve(context.Background(), root)
+	if err != nil {
+		t.Fatal(err)
+	}
+	roots, err := registry.ExecutionRoots(context.Background(), resolved)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(roots) != 1 || roots[0].ID != value.ID {
+		t.Fatalf("roots = %#v", roots)
+	}
+}
+
 func TestRegistryFallsBackToCanonicalDirectory(t *testing.T) {
 	root := t.TempDir()
 	child := filepath.Join(root, "child")
@@ -76,7 +235,7 @@ func TestGitResolverGroupsLinkedWorktrees(t *testing.T) {
 	if _, err := exec.LookPath("git"); err != nil {
 		t.Skip("git is unavailable")
 	}
-	root := t.TempDir()
+	root := canonicalTempDir(t)
 	mainCheckout := filepath.Join(root, "main")
 	worktree := filepath.Join(root, "feature")
 	runGit(t, root, "init", mainCheckout)
@@ -107,20 +266,78 @@ func TestGitResolverGroupsLinkedWorktrees(t *testing.T) {
 	if worktreeContext.ComponentName != "" || worktreeContext.ComponentRoot != "" {
 		t.Fatalf("git resolver invented a component: %#v", worktreeContext)
 	}
+	roots, matched, err := resolver.ExecutionRoots(context.Background(), mainContext)
+	if err != nil || !matched {
+		t.Fatalf("list roots: matched=%v err=%v", matched, err)
+	}
+	if len(roots) != 2 ||
+		roots[0].ExecutionRoot != mainCheckout ||
+		roots[1].ExecutionRoot != worktree {
+		t.Fatalf("roots = %#v", roots)
+	}
+}
+
+func TestGitResolverSkipsStaleWorktrees(t *testing.T) {
+	if _, err := exec.LookPath("git"); err != nil {
+		t.Skip("git is unavailable")
+	}
+	root := canonicalTempDir(t)
+	mainCheckout := filepath.Join(root, "main")
+	liveWorktree := filepath.Join(root, "live")
+	staleWorktree := filepath.Join(root, "stale")
+	runGit(t, root, "init", mainCheckout)
+	runGit(t, mainCheckout, "config", "user.email", "stormlight@example.invalid")
+	runGit(t, mainCheckout, "config", "user.name", "stormlight test")
+	if err := os.WriteFile(filepath.Join(mainCheckout, "README"), []byte("test\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	runGit(t, mainCheckout, "add", "README")
+	runGit(t, mainCheckout, "commit", "-m", "initial")
+	runGit(t, mainCheckout, "worktree", "add", "-b", "live", liveWorktree)
+	runGit(t, mainCheckout, "worktree", "add", "-b", "stale", staleWorktree)
+	if err := os.RemoveAll(staleWorktree); err != nil {
+		t.Fatal(err)
+	}
+
+	resolver := gitResolver{}
+	value, matched, err := resolver.Resolve(context.Background(), mainCheckout)
+	if err != nil || !matched {
+		t.Fatalf("resolve main: matched=%v err=%v", matched, err)
+	}
+	roots, matched, err := resolver.ExecutionRoots(context.Background(), value)
+	if err != nil || !matched {
+		t.Fatalf("list roots: matched=%v err=%v", matched, err)
+	}
+	if len(roots) != 2 ||
+		roots[0].ExecutionRoot != mainCheckout ||
+		roots[1].ExecutionRoot != liveWorktree {
+		t.Fatalf("roots = %#v", roots)
+	}
 }
 
 func TestExternalResolverProtocol(t *testing.T) {
-	root := t.TempDir()
+	root := canonicalTempDir(t)
+	feature := filepath.Join(root, "feature")
+	if err := os.Mkdir(feature, 0o755); err != nil {
+		t.Fatal(err)
+	}
 	resolverDirectory := filepath.Join(t.TempDir(), "resolvers")
 	if err := os.Mkdir(resolverDirectory, 0755); err != nil {
 		t.Fatal(err)
 	}
 	script := filepath.Join(resolverDirectory, "10-custom")
 	body := `#!/bin/sh
-if [ "$1" != "resolve" ]; then
-  exit 64
-fi
-printf '{"kind":"custom","name":"external","root":"%s","execution_root":"%s"}\n' "$2" "$2"
+case "$1" in
+  resolve)
+    printf '{"kind":"custom","name":"external","root":"%s","execution_root":"%s"}\n' "$2" "$2"
+    ;;
+  roots)
+    printf '[{"kind":"custom","name":"external","root":"%s","execution_root":"%s"},{"kind":"custom","name":"external","root":"%s","execution_root":"%s/feature","metadata":{"execution_root_label":"feature root"}}]\n' "$2" "$2" "$2" "$2"
+    ;;
+  *)
+    exit 2
+    ;;
+esac
 `
 	if err := os.WriteFile(script, []byte(body), 0755); err != nil {
 		t.Fatal(err)
@@ -142,6 +359,51 @@ printf '{"kind":"custom","name":"external","root":"%s","execution_root":"%s"}\n'
 	if got.Kind != "custom" || got.Name != "external" || got.Root != canonical {
 		t.Fatalf("unexpected external context: %#v", got)
 	}
+	roots, err := registry.ExecutionRoots(context.Background(), got)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(roots) != 2 ||
+		roots[0].ExecutionRoot != canonical ||
+		roots[1].ExecutionRoot != feature ||
+		roots[1].Metadata["execution_root_label"] != "feature root" {
+		t.Fatalf("unexpected external roots: %#v", roots)
+	}
+}
+
+func TestExternalResolverWithoutRootsFallsBackToResolvedContext(t *testing.T) {
+	root := t.TempDir()
+	script := writeResolver(t, `#!/bin/sh
+if [ "$1" = "resolve" ]; then
+  printf '{"kind":"legacy","root":"%s"}\n' "$2"
+  exit 0
+fi
+exit 2
+`)
+	registry := NewRegistryWithResolvers(externalResolver{
+		name: "legacy",
+		path: script,
+	})
+	value, err := registry.Resolve(context.Background(), root)
+	if err != nil {
+		t.Fatal(err)
+	}
+	roots, err := registry.ExecutionRoots(context.Background(), value)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(roots) != 1 || roots[0].ExecutionRoot != value.ExecutionRoot {
+		t.Fatalf("roots = %#v", roots)
+	}
+}
+
+func canonicalTempDir(t *testing.T) string {
+	t.Helper()
+	path, err := filepath.EvalSymlinks(t.TempDir())
+	if err != nil {
+		t.Fatal(err)
+	}
+	return path
 }
 
 func TestResolverDirectoryUsesStormlightConfigLocation(t *testing.T) {
@@ -169,4 +431,13 @@ func runGit(t *testing.T, directory string, args ...string) {
 	if output, err := command.CombinedOutput(); err != nil {
 		t.Fatalf("git %v: %v\n%s", args, err, output)
 	}
+}
+
+func writeResolver(t *testing.T, body string) string {
+	t.Helper()
+	path := filepath.Join(t.TempDir(), "resolver")
+	if err := os.WriteFile(path, []byte(body), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	return path
 }

--- a/main.go
+++ b/main.go
@@ -107,6 +107,7 @@ func newRootCommand() *cobra.Command {
 		newStopCommand(cfg),
 		newDeleteCommand(cfg),
 		newMarkCommand(cfg),
+		newWorkspaceCommand(),
 		newEventCommand(cfg),
 		newProviderEventCommand(cfg),
 		newLogsCommand(&logFile),
@@ -370,6 +371,14 @@ func newService(cfg config.Config) (*app.Service, error) {
 	return app.NewService(runtime, registry, workspace.NewRegistry()), nil
 }
 
+func newWorkspaceService() *app.Service {
+	return app.NewService(
+		nil,
+		provider.NewRegistry(),
+		workspace.NewRegistry(),
+	)
+}
+
 func newDispatchCommand(cfg config.Config) *cobra.Command {
 	var providerName string
 	var cwd string
@@ -481,6 +490,117 @@ func newListCommand(cfg config.Config) *cobra.Command {
 	}
 	command.Flags().BoolVar(&asJSON, "json", false, "emit JSON")
 	return command
+}
+
+func newWorkspaceCommand() *cobra.Command {
+	command := &cobra.Command{
+		Use:   "workspace",
+		Short: "Inspect and manage workspaces",
+	}
+	command.AddCommand(
+		newWorkspaceAddCommand(),
+		newWorkspaceListCommand(),
+		newWorkspaceRootsCommand(),
+	)
+	return command
+}
+
+func newWorkspaceAddCommand() *cobra.Command {
+	var asJSON bool
+	command := &cobra.Command{
+		Use:   "add <path>",
+		Short: "Add a workspace to the dashboard",
+		Args:  cobra.ExactArgs(1),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			service := newWorkspaceService()
+			ctx, cancel := context.WithTimeout(cmd.Context(), 10*time.Second)
+			defer cancel()
+			value, err := service.AddWorkspace(ctx, args[0])
+			if err != nil {
+				return err
+			}
+			if asJSON {
+				return encodeJSON(cmd.OutOrStdout(), value)
+			}
+			fmt.Fprintf(cmd.OutOrStdout(), "%s\t%s\n", value.Name, value.Root)
+			return nil
+		},
+	}
+	command.Flags().BoolVar(&asJSON, "json", false, "emit JSON")
+	return command
+}
+
+func newWorkspaceListCommand() *cobra.Command {
+	var asJSON bool
+	command := &cobra.Command{
+		Use:   "list",
+		Short: "List catalog workspaces",
+		Args:  cobra.NoArgs,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			service := newWorkspaceService()
+			ctx, cancel := context.WithTimeout(cmd.Context(), 10*time.Second)
+			defer cancel()
+			values, err := service.ListWorkspaces(ctx)
+			if err != nil {
+				return err
+			}
+			return writeWorkspaces(cmd.OutOrStdout(), values, asJSON)
+		},
+	}
+	command.Flags().BoolVar(&asJSON, "json", false, "emit JSON")
+	return command
+}
+
+func newWorkspaceRootsCommand() *cobra.Command {
+	var asJSON bool
+	command := &cobra.Command{
+		Use:   "roots [path]",
+		Short: "List runnable roots in a workspace",
+		Args:  cobra.MaximumNArgs(1),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			service := newWorkspaceService()
+			ctx, cancel := context.WithTimeout(cmd.Context(), 10*time.Second)
+			defer cancel()
+			var values []workspace.Context
+			var err error
+			if len(args) == 1 {
+				values, err = service.WorkspaceRoots(ctx, args[0])
+			} else {
+				values, err = service.WorkspaceRoots(ctx, "")
+			}
+			if err != nil {
+				return err
+			}
+			return writeWorkspaces(cmd.OutOrStdout(), values, asJSON)
+		},
+	}
+	command.Flags().BoolVar(&asJSON, "json", false, "emit JSON")
+	return command
+}
+
+func writeWorkspaces(out io.Writer, values []workspace.Context, asJSON bool) error {
+	if asJSON {
+		return encodeJSON(out, values)
+	}
+	if len(values) == 0 {
+		fmt.Fprintln(out, "No workspaces.")
+		return nil
+	}
+	fmt.Fprintf(out, "%-12s %-24s %s\n", "KIND", "NAME", "PATH")
+	for _, value := range values {
+		fmt.Fprintf(out, "%-12s %-24s %s\n",
+			value.Kind,
+			truncatePlain(value.Name, 24),
+			value.ExecutionRoot,
+		)
+	}
+	return nil
+}
+
+func encodeJSON(out io.Writer, value any) error {
+	encoder := json.NewEncoder(out)
+	encoder.SetIndent("", "  ")
+	return encoder.Encode(value)
 }
 
 func newAttachCommand(cfg config.Config) *cobra.Command {

--- a/main_test.go
+++ b/main_test.go
@@ -1,15 +1,42 @@
 package main
 
 import (
+	"bytes"
+	"encoding/json"
 	"testing"
 
 	"github.com/trentkm/stormlight/internal/agent"
+	"github.com/trentkm/stormlight/internal/workspace"
 )
 
 func TestRootCommandUsesStormlightIdentity(t *testing.T) {
 	command := newRootCommand()
 	if command.Use != "stormlight [path]" {
 		t.Fatalf("command use = %q", command.Use)
+	}
+	for _, path := range [][]string{
+		{"workspace", "add"},
+		{"workspace", "list"},
+		{"workspace", "roots"},
+	} {
+		if _, _, err := command.Find(path); err != nil {
+			t.Fatalf("missing command %v: %v", path, err)
+		}
+	}
+}
+
+func TestWriteWorkspacesEmitsStructuredJSON(t *testing.T) {
+	value := workspace.DirectoryContext(t.TempDir())
+	var output bytes.Buffer
+	if err := writeWorkspaces(&output, []workspace.Context{value}, true); err != nil {
+		t.Fatal(err)
+	}
+	var decoded []workspace.Context
+	if err := json.Unmarshal(output.Bytes(), &decoded); err != nil {
+		t.Fatal(err)
+	}
+	if len(decoded) != 1 || decoded[0].ID != value.ID {
+		t.Fatalf("decoded = %#v", decoded)
 	}
 }
 

--- a/site/docs/architecture.html
+++ b/site/docs/architecture.html
@@ -94,8 +94,12 @@
     agent.</p>
     <p>Workspace resolvers return a stable group ID, a group root, an execution root, and
     optional component metadata. External executable resolvers run before the built-in Git
-    resolver, followed by a canonical-directory fallback. This keeps environment-specific
-    workspace semantics outside the public runtime.</p>
+    resolver, followed by a canonical-directory fallback. Resolvers may also enumerate a
+    group's current execution roots; the application service exposes that same inventory to
+    the CLI and dashboard directory picker. Enumeration is routed back to the resolver that
+    claimed the workspace and is bounded, cached, and best-effort, so a failed external
+    integration cannot block dashboard refresh. This keeps environment-specific workspace
+    semantics outside the public runtime.</p>
 
     <h3 id="windrunner-runtime">windrunner runtime</h3>
     <p>Process and terminal ownership live in a daemon built on the

--- a/site/docs/workspace-resolvers.html
+++ b/site/docs/workspace-resolvers.html
@@ -92,8 +92,23 @@
     name, and <code>execution_root</code> defaults to <code>root</code>. All returned paths
     must exist and be directories. IDs must remain stable for directories that belong in the
     same workspace group.</p>
+    <p>Resolvers may also enumerate every runnable location in a workspace:</p>
+<pre><code>resolver roots &lt;canonical-workspace-root&gt;</code></pre>
+    <p>Exit status <code>0</code> must emit a JSON array of workspace context objects.
+    Every object must carry the same workspace ID and root, with its own
+    <code>execution_root</code>. Exit status <code>2</code> means enumeration is not
+    applicable. Other failures are logged and Stormlight falls back to the resolved
+    context.</p>
+    <p>An execution-root context may set
+    <code>metadata.execution_root_label</code> to control the directory picker's label and
+    the agent's dashboard badge, including for the primary root. Without it, custom
+    non-primary roots use <code>root &lt;directory-name&gt;</code>.</p>
     <p>Resolvers are trusted local executables and run during dispatch and workspace catalog
-    loading. Stormlight caches successful results for the life of the process.</p>
+    loading. Stormlight caches successful resolution for the life of the process. Root
+    enumeration runs only on the resolver that claimed the workspace, has a one-second
+    deadline, and caches successful, unsupported, and failed outcomes for five seconds. A
+    failed or timed-out inventory never blocks dashboard refresh; it logs the failure and
+    exposes the resolved primary root.</p>
   </article>
 
   <nav class="doc-pager"><a href="architecture.html">← Architecture</a><a href="configuration.html">Configuration →</a></nav>


### PR DESCRIPTION
## Intent
A managed agent should be able to expand the work it is coordinating without requiring a human to operate the dashboard: add a directory to Stormlight, discover the runnable roots in that workspace, and dispatch peer agents into those roots. The running dashboard should then show the new workspace and agents automatically.

Managed agents already receive `$STORMLIGHT_BIN`, so the orchestration interface is the ordinary CLI:

```bash
"$STORMLIGHT_BIN" workspace add ~/src/project
"$STORMLIGHT_BIN" workspace roots ~/src/project --json
"$STORMLIGHT_BIN" dispatch --cwd ~/src/project "Investigate the failing test"
```

## Changes
- add headless `workspace add`, `workspace list`, and `workspace roots` commands with structured JSON output
- let executable workspace resolvers enumerate execution roots through a generic optional `roots` operation
- expose discovered roots in the New Agent picker and label custom execution roots without embedding environment-specific workspace knowledge
- preserve the existing `dispatch` command as the interface for creating peer agents
- make root discovery resolver-specific, bounded, cached, and best-effort so a bad integration cannot freeze dashboard refresh
- skip stale Git worktree entries while preserving live roots
- serialize workspace catalog mutations with a shared bounded file lock
- document the agent-orchestration workflow and automatic dashboard refresh in both source and website docs

Fixes #110

## Verification
- `go test ./...`
- `CGO_ENABLED=1 go test -race ./...`
- `go vet ./...`
- `go build -o stormlight .`
- regression coverage for macOS canonical temp paths, resolver routing/error/timeout caching, stale Git worktrees, bounded catalog locks, grouped sorting, and root labels
- generic external resolver against the real `synthia` workspace: parent plus four execution roots grouped under one workspace ID
- isolated tmux flow: external CLI added a workspace and dispatched a configured peer agent; the already-running dashboard showed both automatically
- isolated catalog check confirmed workspace-only commands do not start windrunner