### PR TITLE
Preserve clickable links in hosted terminals

### DIFF
--- a/README.md
+++ b/README.md
@@ -193,6 +193,10 @@ open between messages. Press `Enter` to send, `Ctrl-j` for a newline, and
 Press `/` to search the transcript (`n`/`N` between matches). Drag with the
 mouse to highlight transcript lines — releasing copies them to the system
 clipboard.
+Stormlight enables terminal mouse reporting for these controls, so the
+terminal's usual hyperlink gesture needs its mouse-capture override. In
+Ghostty on macOS, open links with `Shift-Command-click`; without mouse
+reporting, the usual `Command-click` is enough.
 Provider slash commands (`/compact`, `/clear`, custom skills) work from the
 reply box too — a single-line message starting with `/` is typed into the
 agent as a command instead of pasted as text. In terminal view the agent's

--- a/internal/pty/terminal.go
+++ b/internal/pty/terminal.go
@@ -4,6 +4,7 @@ package pty
 import (
 	"context"
 	"io"
+	"net/url"
 	"strings"
 	"sync"
 	"sync/atomic"
@@ -130,7 +131,9 @@ func New(transport Transport, gate *Gate, cols, rows int) Model {
 	// vt writes query responses to its input pipe. The real terminal owns
 	// those responses, so drain this end to keep a query from blocking paint.
 	go func() { _, _ = io.Copy(io.Discard, s.emu) }()
-	seed := transport.Seed()
+	// A windrunner snapshot has already passed through x/vt once. Normalize
+	// its reversed OSC 8 fields before replaying it through this second x/vt.
+	seed := []byte(repairVTHyperlinks(string(transport.Seed())))
 	s.observeModes(seed)
 	s.emu.Write(seed)
 	model := Model{id: lastID.Add(1), state: s}
@@ -164,6 +167,9 @@ func (m Model) setTerminalSize(cols, rows int) {
 
 func (s *state) pump() {
 	for chunk := range s.transport.Output() {
+		// Most output is raw PTY data and needs no change. Resize repaints
+		// come from windrunner's x/vt and carry its reversed OSC 8 fields.
+		chunk = []byte(repairVTHyperlinks(string(chunk)))
 		s.observeModes(chunk)
 		s.mu.Lock()
 		s.emu.Write(chunk)
@@ -344,7 +350,7 @@ func (m Model) View() string {
 	}
 	var lines []string
 	if s.scroll == 0 || s.emu.IsAltScreen() {
-		lines = strings.Split(s.emu.Render(), "\n")
+		lines = strings.Split(repairVTHyperlinks(s.emu.Render()), "\n")
 		if len(lines) > s.rows {
 			bottom := len(lines)
 			if cursor := s.emu.CursorPosition().Y; cursor < bottom-s.rows {
@@ -357,10 +363,10 @@ func (m Model) View() string {
 		top := max(0, back.Len()+s.termRows-s.rows-s.scroll)
 		bottom := min(back.Len()+s.termRows, top+s.rows)
 		for i := top; i < min(bottom, back.Len()); i++ {
-			lines = append(lines, back.Line(i).Render())
+			lines = append(lines, repairVTHyperlinks(back.Line(i).Render()))
 		}
 		if bottom > back.Len() {
-			live := strings.Split(s.emu.Render(), "\n")
+			live := strings.Split(repairVTHyperlinks(s.emu.Render()), "\n")
 			for i := max(0, top-back.Len()); i < min(len(live), bottom-back.Len()); i++ {
 				lines = append(lines, live[i])
 			}
@@ -369,6 +375,50 @@ func (m Model) View() string {
 	s.view = fit(lines, s.cols, s.rows)
 	s.viewDirty = false
 	return s.view
+}
+
+// x/vt stores OSC 8's params and URI in each other's fields
+// (https://github.com/charmbracelet/x/pull/868), so its renderer emits
+// OSC 8 ; URI ; params instead of OSC 8 ; params ; URI. Raw PTY output is
+// already correct and starts with an empty params field; serialized snapshots
+// and repaints have a URI in that field. Repair only the latter form at each
+// emulator boundary until the upstream fix lands.
+func repairVTHyperlinks(value string) string {
+	const prefix = "\x1b]8;"
+	if !strings.Contains(value, prefix) {
+		return value
+	}
+
+	var repaired strings.Builder
+	repaired.Grow(len(value))
+	for {
+		start := strings.Index(value, prefix)
+		if start < 0 {
+			repaired.WriteString(value)
+			return repaired.String()
+		}
+		repaired.WriteString(value[:start])
+		value = value[start:]
+
+		end := strings.IndexByte(value, '\a')
+		if end < 0 {
+			repaired.WriteString(value)
+			return repaired.String()
+		}
+		sequence := value[:end+1]
+		uri, params, found := strings.Cut(value[len(prefix):end], ";")
+		parsed, parseErr := url.Parse(uri)
+		if !found || parseErr != nil || parsed.Scheme == "" {
+			repaired.WriteString(sequence)
+		} else {
+			repaired.WriteString(prefix)
+			repaired.WriteString(params)
+			repaired.WriteByte(';')
+			repaired.WriteString(uri)
+			repaired.WriteByte('\a')
+		}
+		value = value[end+1:]
+	}
 }
 
 // Cursor reports a visible cursor relative to this terminal's box.

--- a/internal/pty/terminal_test.go
+++ b/internal/pty/terminal_test.go
@@ -92,6 +92,51 @@ func TestViewIsCachedUntilTheTerminalChanges(t *testing.T) {
 	}
 }
 
+func TestTerminalPreservesHyperlinks(t *testing.T) {
+	const url = "https://example.com/docs"
+	correct := []string{
+		"\x1b]8;;" + url + "\aempty params\x1b]8;;\a",
+		"\x1b]8;id=docs;" + url + "\apopulated params\x1b]8;;\a",
+	}
+	for _, testCase := range []struct {
+		name, seed string
+	}{
+		{"raw PTY output", strings.Join(correct, " ")},
+		{"windrunner snapshot",
+			"\x1b]8;" + url + ";\aempty params\x1b]8;;\a " +
+				"\x1b]8;" + url + ";id=docs\apopulated params\x1b]8;;\a"},
+	} {
+		t.Run(testCase.name, func(t *testing.T) {
+			transport := newFakeTransport(testCase.seed)
+			terminal := New(transport, NewGate(), 50, 2)
+			defer terminal.Close()
+
+			view := terminal.View()
+			for _, want := range correct {
+				if !strings.Contains(view, want) {
+					t.Errorf("terminal dropped hyperlink %q from %q", want, view)
+				}
+			}
+		})
+	}
+}
+
+func TestTerminalRepairsHyperlinksInWindrunnerRepaints(t *testing.T) {
+	const url = "https://example.com/docs"
+	transport := newFakeTransport("")
+	terminal := New(transport, NewGate(), 50, 2)
+	defer terminal.Close()
+	terminal.SetVisible(true)
+
+	transport.output <- []byte("\x1b]8;" + url + ";\arepaint\x1b]8;;\a")
+	<-terminal.state.gate.frames
+	if view := terminal.View(); !strings.Contains(
+		view, "\x1b]8;;"+url+"\arepaint\x1b]8;;\a",
+	) {
+		t.Errorf("terminal dropped repaint hyperlink from %q", view)
+	}
+}
+
 func TestOnlyVisibleTerminalsKnockOnTheGate(t *testing.T) {
 	gate := NewGate()
 	transport := newFakeTransport("quiet")


### PR DESCRIPTION
## Summary

- repair malformed OSC 8 hyperlinks emitted by `x/vt` when rendering hosted terminals
- repair both live PTY output and persisted windrunner snapshot/repaint paths
- document Ghostty's `Shift-Command-click` gesture while mouse reporting is active

## Root cause

`github.com/charmbracelet/x/vt` currently swaps the OSC 8 parameter and URI fields while parsing. Stormlight serializes terminal state through that parser, so otherwise valid links become `OSC 8 ; URI ; ST` and cannot be opened by the outer terminal.

## Verification

- `go test ./...`
- verified end-to-end over SSH that the final terminal byte stream contains correctly ordered OSC 8 sequences
- verified the rendered link opens in Ghostty with `Shift-Command-click` while Stormlight mouse reporting remains enabled