### PR TITLE
Add the public site: landing page, docs, and Pages deploy

### DIFF
--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -1,0 +1,31 @@
+name: pages
+
+on:
+  push:
+    branches: [main]
+    paths: ["site/**", ".github/workflows/pages.yml"]
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  pages: write
+  id-token: write
+
+concurrency:
+  group: pages
+  cancel-in-progress: true
+
+jobs:
+  deploy:
+    runs-on: ubuntu-latest
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/configure-pages@v5
+      - uses: actions/upload-pages-artifact@v3
+        with:
+          path: site
+      - id: deployment
+        uses: actions/deploy-pages@v4

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -208,6 +208,29 @@ format, the state files — is stable enough that breaking it costs a major
 bump. Cut it when that promise is one worth keeping, not when the minor
 number looks large.
 
+## The website
+
+`site/` is the public site, deployed to GitHub Pages by `pages.yml` whenever
+a push to `main` touches it. It is plain static HTML — no build step — and
+its docs pages are hand-rendered copies of `docs/*.md`, not generated from
+them, so nothing keeps the two in sync automatically.
+
+That makes drift the failure mode to watch for. A change that lands in
+`docs/architecture.md`, `docs/workspace-resolvers.md`, or the config design
+doc without reaching its `site/docs/*.html` counterpart leaves the website
+describing an architecture that no longer exists — worse than no docs,
+because it reads as authoritative. When a PR materially changes what those
+documents say — new layers, renamed contracts, changed state semantics —
+update the matching site page in the same PR. Section headings in the site's
+pages carry `id` anchors that the sidebar links target; keep them consistent
+when adding or removing sections. The landing page (`site/index.html`) tells
+the shorter story and only needs touching when the user-facing pitch changes:
+a new pane, a renamed concept, a different install path.
+
+Cosmetic drift matters less than semantic drift. Wording differences between
+a doc and its site rendering are fine; a site page claiming a contract the
+code no longer honors is not.
+
 ## Headless TUI testing
 
 The dashboard and agent lifecycle can be exercised without a real terminal.

--- a/site/assets/docs.css
+++ b/site/assets/docs.css
@@ -1,0 +1,173 @@
+/* docs — traditional two-column documentation layout */
+
+.docwrap {
+  display: grid;
+  grid-template-columns: 15rem minmax(0, 1fr);
+  gap: 4.5rem;
+  max-width: 74rem;
+  margin: 0 auto;
+  padding: 0 2rem;
+}
+
+/* ---------- left sidebar ---------- */
+
+.side {
+  position: sticky;
+  top: 0;
+  align-self: start;
+  max-height: 100vh;
+  overflow-y: auto;
+  padding: 2.8rem 0 2rem;
+  font-family: var(--mono);
+  font-size: 0.78rem;
+  line-height: 1.5;
+}
+
+.side-title {
+  font-size: 0.66rem;
+  letter-spacing: 0.22em;
+  text-transform: uppercase;
+  color: var(--ink-faint);
+  margin-bottom: 1rem;
+}
+
+.side ul { list-style: none; margin: 0; padding: 0; }
+.side > ul > li { margin-bottom: 0.15rem; }
+.side > ul > li > a {
+  display: block;
+  padding: 0.35rem 0.7rem;
+  border-radius: 6px;
+  color: var(--ink-dim);
+}
+.side > ul > li > a:hover { color: var(--cyan); background: var(--hover-bg); text-decoration: none; }
+.side > ul > li.current > a {
+  color: var(--cyan-deep);
+  background: rgba(98, 174, 239, 0.12);
+  font-weight: 500;
+}
+
+/* nested section links for the current page */
+.side .sections {
+  margin: 0.3rem 0 0.6rem 0.7rem;
+  padding-left: 0.85rem;
+  border-left: 1px solid var(--line);
+}
+.side .sections li a {
+  display: block;
+  padding: 0.22rem 0.55rem 0.22rem 1.4rem;
+  margin-left: -0.9rem;
+  color: var(--ink-faint);
+  border-left: 1px solid transparent;
+}
+.side .sections li a:hover { color: var(--cyan); text-decoration: none; }
+.side .sections li a.active {
+  color: var(--cyan-deep);
+  border-left-color: var(--cyan-deep);
+}
+.side .sections li.sub a { padding-left: 2.2rem; font-size: 0.72rem; }
+
+/* ---------- content column ---------- */
+
+.doc { padding: 2.8rem 0 2rem; min-width: 0; }
+
+.doc-title { font-size: clamp(1.9rem, 4vw, 2.6rem); color: var(--heading); margin: 0.5rem 0 0.8rem; }
+.doc-lede { color: var(--ink-dim); font-size: 1.08rem; max-width: 40em; }
+
+article { padding-top: 1.8rem; max-width: 46rem; }
+
+article h2, article h3, article h4 { scroll-margin-top: 2rem; }
+
+article h2 {
+  font-size: 1.5rem;
+  color: var(--heading);
+  margin: 3rem 0 1rem;
+  padding-top: 1.5rem;
+  border-top: 1px solid var(--line-soft);
+}
+article h3 {
+  font-family: var(--mono);
+  font-size: 0.95rem;
+  font-weight: 500;
+  letter-spacing: 0.03em;
+  color: var(--cyan);
+  margin: 2.2rem 0 0.8rem;
+}
+article h4 {
+  font-family: var(--mono);
+  font-size: 0.85rem;
+  font-weight: 500;
+  color: var(--ink);
+  margin: 1.8rem 0 0.6rem;
+}
+article p { margin-bottom: 1.1rem; color: var(--prose); }
+article ul, article ol { margin: 0 0 1.2rem 1.4rem; color: var(--prose); }
+article li { margin-bottom: 0.5rem; }
+article pre { margin: 1.4rem 0; }
+article strong { color: var(--ink); font-weight: 500; }
+article em { color: var(--ink); }
+
+article table {
+  width: 100%;
+  border-collapse: collapse;
+  margin: 1.5rem 0;
+  font-size: 0.92rem;
+}
+article th {
+  font-family: var(--mono);
+  font-size: 0.72rem;
+  letter-spacing: 0.1em;
+  text-transform: uppercase;
+  text-align: left;
+  color: var(--ink-faint);
+  padding: 0.5rem 0.8rem;
+  border-bottom: 1px solid var(--line);
+}
+article td {
+  padding: 0.6rem 0.8rem;
+  border-bottom: 1px solid var(--line-soft);
+  color: var(--ink-dim);
+  vertical-align: top;
+}
+
+/* prev / next footer links */
+.doc-pager {
+  display: flex;
+  justify-content: space-between;
+  gap: 1rem;
+  max-width: 46rem;
+  margin-top: 4rem;
+  padding-top: 1.5rem;
+  border-top: 1px solid var(--line-soft);
+  font-family: var(--mono);
+  font-size: 0.8rem;
+}
+.doc-pager a { color: var(--ink-dim); }
+.doc-pager a:hover { color: var(--cyan); text-decoration: none; }
+
+/* ---------- responsive ---------- */
+
+@media (max-width: 900px) {
+  .docwrap { grid-template-columns: 1fr; gap: 0; }
+  .side {
+    position: static;
+    max-height: none;
+    padding-bottom: 1rem;
+    border-bottom: 1px solid var(--line-soft);
+  }
+  .doc { padding-top: 2rem; }
+}
+
+/* docs hub cards (Overview page) */
+.doc-list { margin-top: 2.5rem; display: grid; gap: 1.2rem; max-width: 46rem; }
+.doc-card {
+  display: block;
+  border: 1px solid var(--line);
+  border-radius: 10px;
+  background: var(--bg-raised);
+  padding: 1.6rem 1.8rem;
+  transition: border-color 0.2s, background 0.2s;
+}
+.doc-card:hover { border-color: rgba(38, 121, 157, 0.35); background: var(--hover-bg); text-decoration: none; }
+.doc-card h3 { font-size: 1.25rem; font-weight: 400; color: var(--heading); margin-bottom: 0.4rem; font-family: var(--serif); }
+.doc-card p { color: var(--ink-dim); font-size: 0.95rem; }
+.doc-card .go { font-family: var(--mono); font-size: 0.72rem; color: var(--cyan-deep); }

--- a/site/assets/docs.js
+++ b/site/assets/docs.js
@@ -1,0 +1,21 @@
+/* scrollspy: highlight the sidebar section link for the heading in view */
+(function () {
+  var links = Array.prototype.slice.call(document.querySelectorAll(".side .sections a"));
+  if (!links.length) return;
+  var pairs = links
+    .map(function (a) {
+      var el = document.getElementById(a.getAttribute("href").slice(1));
+      return el ? [el, a] : null;
+    })
+    .filter(Boolean);
+  function spy() {
+    var cur = null;
+    for (var i = 0; i < pairs.length; i++) {
+      if (pairs[i][0].getBoundingClientRect().top <= 96) cur = pairs[i][1];
+    }
+    links.forEach(function (a) { a.classList.toggle("active", a === cur); });
+  }
+  addEventListener("scroll", spy, { passive: true });
+  addEventListener("hashchange", spy);
+  spy();
+})();

--- a/site/assets/style.css
+++ b/site/assets/style.css
@@ -1,0 +1,251 @@
+/* Stormlight site — light trapped in ice.
+   Values from internal/theme's Light pairs: Text #24323A, Muted #70808A,
+   Working #26799D, Waiting #A86600, Accent #62AEEF, Band #B9D9EF,
+   Code #0E7C6B, PortalInk #0F2338 */
+:root {
+  --bg: #f2f6fa;
+  --bg-raised: #ffffff;
+  --bg-panel: #fbfdff;
+  --line: #cfdbe7;
+  --line-soft: #dfe8f0;
+  --ink: #24323a;
+  --ink-dim: #59707f;
+  --ink-faint: #8ba1b4;
+  --cyan: #26799d;
+  --cyan-deep: #1d6485;
+  --ice: #0f2338;
+  --amber: #a86600;
+  --amber-deep: #8f5800;
+  --heading: #17262e;
+  --lit: #0f2338;
+  --prose: #35485a;
+  --dot: #d7e2ec;
+  --pre-ink: #33475c;
+  --code-ink: #0e7c6b;
+  --str: #a86600;
+  --hover-bg: #eef4f9;
+  --sel-bg: #e1e9f0;
+  --sweep-hi: #26799d;
+  --sweep-hi-sel: #0f2338;
+  --term-ink: #3d5468;
+  --tool-ink: #7c93ab;
+  --ok-ink: #257a4a;
+  --serif: "Newsreader", "Iowan Old Style", Georgia, serif;
+  --mono: "Geist Mono", "SFMono-Regular", Menlo, Consolas, monospace;
+}
+
+* { margin: 0; padding: 0; box-sizing: border-box; }
+
+html { scroll-behavior: smooth; }
+
+body {
+  background: var(--bg);
+  color: var(--ink);
+  font-family: var(--serif);
+  font-size: 18px;
+  line-height: 1.65;
+  -webkit-font-smoothing: antialiased;
+  overflow-x: hidden;
+}
+
+::selection { background: rgba(98, 174, 239, 0.3); color: #0f2338; }
+
+a { color: var(--cyan); text-decoration: none; }
+a:hover { text-decoration: underline; text-underline-offset: 3px; }
+
+/* ---------- atmosphere ---------- */
+
+.storm {
+  position: fixed;
+  inset: 0;
+  z-index: -2;
+  background:
+    radial-gradient(60rem 40rem at 85% -10%, rgba(98, 174, 239, 0.16), transparent 60%),
+    radial-gradient(50rem 36rem at -10% 20%, rgba(185, 217, 239, 0.45), transparent 60%),
+    radial-gradient(40rem 30rem at 70% 110%, rgba(168, 102, 0, 0.05), transparent 60%),
+    var(--bg);
+}
+
+.grain {
+  position: fixed;
+  inset: 0;
+  z-index: -1;
+  opacity: 0.3;
+  filter: invert(1);
+  pointer-events: none;
+  background-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='140' height='140'%3E%3Cfilter id='n'%3E%3CfeTurbulence type='fractalNoise' baseFrequency='0.9' numOctaves='2'/%3E%3CfeColorMatrix values='0 0 0 0 1 0 0 0 0 1 0 0 0 0 1 0 0 0 0.028 0'/%3E%3C/filter%3E%3Crect width='140' height='140' filter='url(%23n)'/%3E%3C/svg%3E");
+}
+
+/* ---------- layout ---------- */
+
+.wrap { max-width: 74rem; margin: 0 auto; padding: 0 2rem; }
+.wrap-narrow { max-width: 46rem; margin: 0 auto; padding: 0 2rem; }
+
+/* ---------- nav ---------- */
+
+.nav {
+  display: flex;
+  align-items: baseline;
+  justify-content: space-between;
+  padding: 1.6rem 0;
+  font-family: var(--mono);
+  font-size: 0.78rem;
+}
+
+.wordmark {
+  color: var(--ink);
+  letter-spacing: 0.42em;
+  font-weight: 500;
+}
+.wordmark:hover { text-decoration: none; color: var(--cyan); }
+.wordmark .spark { color: var(--cyan); }
+.wordmark .spark svg { vertical-align: -2px; margin-left: 0.15em; }
+
+.nav-links { display: flex; gap: 1.8rem; align-items: baseline; }
+.nav-links a { color: var(--ink-dim); letter-spacing: 0.08em; }
+.nav-links a:hover { color: var(--cyan); text-decoration: none; }
+
+/* ---------- type ---------- */
+
+h1, h2, h3 { font-weight: 400; letter-spacing: -0.01em; }
+
+.kicker {
+  font-family: var(--mono);
+  font-size: 0.72rem;
+  letter-spacing: 0.3em;
+  text-transform: uppercase;
+  color: var(--cyan-deep);
+  margin-bottom: 1.2rem;
+}
+.kicker.amber { color: var(--amber-deep); }
+
+em.lit {
+  font-style: italic;
+  color: var(--lit);
+  text-shadow: 0 0 24px rgba(98, 174, 239, 0.4);
+}
+
+/* ---------- buttons / install ---------- */
+
+.install {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.9rem;
+  font-family: var(--mono);
+  font-size: 0.85rem;
+  background: var(--bg-raised);
+  border: 1px solid var(--line);
+  border-radius: 8px;
+  padding: 0.75rem 1.1rem;
+  color: var(--ink);
+}
+.install .p { color: var(--ink-faint); user-select: none; }
+.install button {
+  font-family: var(--mono);
+  font-size: 0.7rem;
+  letter-spacing: 0.08em;
+  background: none;
+  border: 1px solid var(--line);
+  border-radius: 5px;
+  color: var(--ink-dim);
+  padding: 0.25rem 0.55rem;
+  cursor: pointer;
+  transition: color 0.15s, border-color 0.15s;
+}
+.install button:hover { color: var(--cyan); border-color: var(--cyan-deep); }
+
+/* ---------- terminal chrome ---------- */
+
+.term {
+  background: var(--bg-panel);
+  border: 1px solid var(--line);
+  border-radius: 10px;
+  box-shadow:
+    0 1px 2px rgba(15, 35, 56, 0.06),
+    0 24px 60px -24px rgba(15, 35, 56, 0.28),
+    0 0 90px -30px rgba(98, 174, 239, 0.4);
+  font-family: var(--mono);
+  overflow: hidden;
+}
+
+.term-bar {
+  display: flex;
+  align-items: center;
+  gap: 0.45rem;
+  padding: 0.6rem 0.9rem;
+  border-bottom: 1px solid var(--line-soft);
+}
+.term-bar .dot { width: 11px; height: 11px; border-radius: 50%; background: var(--dot); }
+.term-bar .title {
+  margin-left: auto; margin-right: auto;
+  font-size: 0.72rem;
+  color: var(--ink-faint);
+  letter-spacing: 0.06em;
+}
+
+/* ---------- code blocks (docs + landing) ---------- */
+
+pre {
+  font-family: var(--mono);
+  font-size: 0.8rem;
+  line-height: 1.7;
+  background: var(--bg-raised);
+  border: 1px solid var(--line);
+  border-radius: 8px;
+  padding: 1rem 1.2rem;
+  overflow-x: auto;
+  color: var(--pre-ink);
+}
+code {
+  font-family: var(--mono);
+  font-size: 0.85em;
+  color: var(--code-ink);
+  background: rgba(38, 121, 157, 0.07);
+  border: 1px solid rgba(38, 121, 157, 0.16);
+  border-radius: 4px;
+  padding: 0.08em 0.35em;
+}
+pre code { background: none; border: none; padding: 0; color: inherit; font-size: 1em; }
+kbd {
+  font-family: var(--mono);
+  color: var(--cyan);
+  background: rgba(38, 121, 157, 0.07);
+  border: 1px solid rgba(38, 121, 157, 0.22);
+  border-radius: 4px;
+  padding: 0.05em 0.45em;
+  font-size: 0.8em;
+  white-space: nowrap;
+}
+pre .c { color: var(--ink-faint); }
+pre .k { color: var(--cyan); }
+pre .s { color: var(--str); }
+
+/* ---------- footer ---------- */
+
+.footer {
+  border-top: 1px solid var(--line-soft);
+  margin-top: 8rem;
+  padding: 3rem 0 4rem;
+  font-family: var(--mono);
+  font-size: 0.78rem;
+  color: var(--ink-faint);
+}
+.footer .wrap { display: flex; justify-content: space-between; flex-wrap: wrap; gap: 1rem; }
+.footer a { color: var(--ink-dim); }
+.footer a:hover { color: var(--cyan); }
+
+/* ---------- reveal on scroll ---------- */
+
+.reveal { opacity: 0; transform: translateY(18px); transition: opacity 0.7s ease, transform 0.7s ease; }
+.reveal.in { opacity: 1; transform: none; }
+
+@media (prefers-reduced-motion: reduce) {
+  .reveal { opacity: 1; transform: none; transition: none; }
+  * { animation-duration: 0.01ms !important; animation-iteration-count: 1 !important; }
+}
+
+@media (max-width: 640px) {
+  body { font-size: 16px; }
+  .wrap, .wrap-narrow { padding: 0 1.1rem; }
+  .nav-links { gap: 1rem; }
+}

--- a/site/docs/architecture.html
+++ b/site/docs/architecture.html
@@ -1,0 +1,290 @@
+<!doctype html>
+<html lang="en">
+<head>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width, initial-scale=1">
+<title>Architecture — Stormlight</title>
+<meta name="description" content="How Stormlight separates agent semantics from terminal and process ownership.">
+<link rel="icon" href="data:image/svg+xml,%3Csvg%20xmlns%3D%22http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg%22%20viewBox%3D%220%200%2024%2024%22%20fill%3D%22none%22%20stroke-linecap%3D%22round%22%20stroke-linejoin%3D%22round%22%20stroke-width%3D%222%22%3E%3Cpath%20stroke%3D%22%2362aeef%22%20d%3D%22M6%2016.326A7%207%200%201%201%2015.71%208h1.79a4.5%204.5%200%200%201%20.5%208.973%22%2F%3E%3Cpath%20stroke%3D%22%2326799d%22%20d%3D%22m13%2012-3%205h4l-3%205%22%2F%3E%3C%2Fsvg%3E">
+<link rel="preconnect" href="https://fonts.googleapis.com">
+<link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+<link href="https://fonts.googleapis.com/css2?family=Newsreader:ital,opsz,wght@0,6..72,300..600;1,6..72,300..600&family=Geist+Mono:wght@300..600&display=swap" rel="stylesheet">
+<link rel="stylesheet" href="../assets/style.css">
+<link rel="stylesheet" href="../assets/docs.css">
+</head>
+<body>
+<div class="storm"></div>
+<div class="grain"></div>
+
+<header class="wrap nav">
+  <a class="wordmark" href="../">STORMLIGHT<span class="spark"><svg viewBox="0 0 24 24" width="13" height="13" fill="none" stroke="currentColor" stroke-width="2.2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><path d="M6 16.326A7 7 0 1 1 15.71 8h1.79a4.5 4.5 0 0 1 .5 8.973"/><path d="m13 12-3 5h4l-3 5"/></svg></span></a>
+  <nav class="nav-links">
+    <a href="../#design">design</a>
+    <a href="../#windrunner">windrunner</a>
+    <a href="./">docs</a>
+    <a href="https://github.com/trentkm/stormlight">github</a>
+  </nav>
+</header>
+
+<div class="docwrap">
+<aside class="side">
+  <p class="side-title">Documentation</p>
+  <ul>
+    <li><a href="./">Overview</a></li>
+    <li class="current"><a href="architecture.html">Architecture</a><ul class="sections">
+    <li><a href="#layers">Layers</a></li>
+    <li class="sub"><a href="#provider-adapters">Provider adapters</a></li>
+    <li class="sub"><a href="#application-service">Application service</a></li>
+    <li class="sub"><a href="#windrunner-runtime">windrunner runtime</a></li>
+    <li class="sub"><a href="#terminal-seam">The terminal seam</a></li>
+    <li><a href="#state-model">State model</a></li>
+    <li><a href="#persistence">Persistence</a></li>
+    <li><a href="#workspace-boundary">Workspace boundary</a></li>
+    </ul></li>
+    <li><a href="workspace-resolvers.html">Workspace resolvers</a></li>
+    <li><a href="configuration.html">Configuration</a></li>
+  </ul>
+</aside>
+<main class="doc">
+  <h1 class="doc-title">Architecture</h1>
+  <p class="doc-lede"><code>stormlight</code> separates agent semantics from terminal and
+  process ownership.</p>
+
+  <article>
+    <h2 id="layers">Layers</h2>
+
+    <h3 id="provider-adapters">Provider adapters</h3>
+    <p>Provider adapters translate a task into an executable plus arguments. The built-ins
+    are Claude and Codex; custom provider specs cover other agent CLIs. Adapters
+    deliberately do not own process or terminal behavior.</p>
+    <p>The CLI adapters currently add provider-native lifecycle callbacks:</p>
+    <ul>
+      <li><strong>Codex:</strong> per-launch prompt and stop hooks report state, passed as a
+      <code>-c</code> config override, over the external completion notifier. The notifier
+      alone carried only turn ends, so a turn begun in the agent's own terminal was
+      invisible; it is retained because Codex holds injected hooks inert behind a one-time
+      trust review, and an agent reporting nothing would sit at <code>working</code> until
+      its process exited. The notifier has no trust gate, so it is the floor and the hooks
+      are the ceiling. Both surfaces report a turn end once trusted; the two events carry
+      identical state, so applying both is idempotent.</li>
+      <li><strong>Claude:</strong> per-launch prompt, notification, and stop hooks report
+      state. Permission prompts raise attention through the notification hook; they are
+      answered in the agent's own terminal, never intercepted.</li>
+      <li><strong>Generic agents:</strong> PTY state and optional lifecycle hooks.</li>
+    </ul>
+    <p>Both CLIs accept the same hook schema — an event name mapping to matcher groups of
+    command handlers, with the payload arriving on the handler's stdin — so one set of types
+    describes both and only the encoding differs: Claude takes JSON through
+    <code>--settings</code>, Codex takes inline TOML through <code>-c</code>. Codex parses
+    that value as TOML and rejects JSON, so the override has to encode to a single inline
+    line.</p>
+    <p>Hooks that resolve rather than observe are deliberately left unregistered for both
+    providers. Claude's <code>PreToolUse</code> and Codex's <code>PermissionRequest</code>
+    answer whether a tool call may proceed, and an approval Stormlight never answers is an
+    agent stuck waiting on it.</p>
+    <p>The next Codex revision should use App Server JSON-RPC for threads, turns, approvals,
+    and streamed items. Claude background-agent discovery or the Agent SDK can similarly
+    replace its CLI hook bridge. The runtime exposes <code>stormlight event</code> so
+    generic providers can report semantic state.</p>
+
+    <h3 id="application-service">Application service</h3>
+    <p>The application service validates requests, resolves a provider and workspace, and
+    delegates terminal operations to the runtime. The TUI and CLI use the same service. A
+    persistent workspace catalog supplies workspaces that do not currently contain an
+    agent.</p>
+    <p>Workspace resolvers return a stable group ID, a group root, an execution root, and
+    optional component metadata. External executable resolvers run before the built-in Git
+    resolver, followed by a canonical-directory fallback. This keeps environment-specific
+    workspace semantics outside the public runtime.</p>
+
+    <h3 id="windrunner-runtime">windrunner runtime</h3>
+    <p>Process and terminal ownership live in a daemon built on the
+    <a href="https://github.com/trentkm/windrunner">windrunner</a> session engine. Each
+    session the daemon holds is one PTY plus an authoritative terminal emulator, so a
+    snapshot of an agent's screen and scrollback is exact serialized state, and attaching is
+    a byte stream from that state forward — never a capture of whatever happened to be
+    visible.</p>
+    <p>The daemon is Stormlight itself: <code>internal/windrun.NewRuntime</code> connects to
+    a unix socket (<code>daemon.sock</code> under <code>$WINDRUNNER_DIR</code>, else
+    <code>$XDG_STATE_HOME/windrunner</code>, else <code>~/.local/state/windrunner</code> —
+    the windrunner library's own default, so <code>windrunner ls</code> lists Stormlight's
+    agents too) and, when nothing answers, starts <code>stormlight _wrdaemon</code> from the
+    running binary's resolved path (<code>internal/selfpath</code>) and waits for it to come
+    up. The daemon outlives every dashboard: agents, their terminals, and their scrollback
+    persist across dashboard restarts, and the daemon's sessions are the roster — there is
+    no second record to reconcile.</p>
+    <p>The daemon never learns what an agent is; that is the library's boundary. Agent
+    identity and state ride in the session's opaque metadata as one JSON document under the
+    <code>stormlight_agent</code> key — the serialized <code>agent.Agent</code>: id,
+    provider, task, name, workspace context, permission mode, activity, attention, mark,
+    session id, and transcript path. Two rules keep the document honest:</p>
+    <ul>
+      <li>Liveness and exit are the daemon's facts. Listing decodes the document and then
+      overwrites process state from the session itself — <code>Alive</code>,
+      <code>ExitCode</code> — so stale metadata can never claim a dead agent is working. An
+      exited process with no recorded completion is classified from its exit code.</li>
+      <li>Updates are read-modify-write on the whole document
+      (<code>Runtime.mutateAgent</code>). Two near-simultaneous writers — a hook event
+      racing the dashboard — can lose one update; events are sparse enough that the next one
+      repairs it, and a daemon-side compare-and-swap is noted for later.</li>
+    </ul>
+    <p>Dispatch spawns the provider directly: the adapter's launch command becomes the
+    session's process, with <code>STORMLIGHT_ID</code> (how hook subprocesses name their
+    agent), <code>STORMLIGHT_BIN</code> (how they find Stormlight across upgrades), and
+    <code>WINDRUNNER_DIR</code> (how a hook's own <code>stormlight _provider-event</code>
+    invocation reaches the same daemon) in its environment. There is no supervisor process
+    between the daemon and the provider; exit state is read from the daemon. The daemon
+    names the session; that id is not adopted as the agent's id — the metadata carries
+    Stormlight's id, and the session id fills the display fields that expect a pane
+    handle.</p>
+    <p>Messages are delivered as terminal input: multi-line messages inside a bracketed
+    paste so they arrive as one message, slash commands typed verbatim (providers ignore
+    pasted slash commands), then a beat later the Enter that submits. Nothing is ever
+    interpolated into a shell command string.</p>
+
+    <h4 id="terminal-seam">The terminal seam</h4>
+    <p>Live terminals reach the dashboard through one narrow seam, declared as an optional
+    runtime capability:</p>
+    <ul>
+      <li><code>session.TerminalStreamer</code> (<code>internal/session</code>) is the
+      contract: attach to an agent's terminal at a size and get a
+      <code>TerminalStream</code> — an exact snapshot seed, a channel of everything after
+      it, and input and resize flowing back.</li>
+      <li><code>windrun.Runtime.AttachTerminal</code> implements it over one dedicated
+      daemon connection per attachment, resizing first so the snapshot arrives pre-wrapped
+      for the view it is about to fill.</li>
+      <li><code>app.Service.AttachTerminal</code> surfaces the capability to the UI as a
+      <code>pty.Transport</code>, failing cleanly when a runtime cannot stream.</li>
+      <li><code>ptyview.Manager</code> keeps one live terminal per agent for the agent's
+      whole life, reconciling the set against the roster on every refresh: agents without a
+      terminal get one, departed agents lose theirs, and all of them follow the pane's
+      dimensions. Selecting an agent switches which terminal is rendered; it never starts
+      one.</li>
+      <li><code>pty.Model</code> (<code>internal/pty</code>) is the widget: a
+      <code>charmbracelet/x/vt</code> emulator fed by the transport, with scrollback,
+      coalesced frame notifications (~30fps) so a chatty agent cannot flood the event loop,
+      and wheel-burst batching for high-resolution scrolling.</li>
+    </ul>
+    <p>The Spanreed pane renders the selected agent's widget. While the pane holds focus the
+    keyboard belongs to the agent's terminal byte for byte, and the real terminal cursor is
+    placed where the agent's program put it — the pane is the terminal, not a picture of
+    one. The dashboard's own keys in that mode are modifier chords the hosted TUIs don't
+    bind: <code>ctrl+space</code> steps out, <code>alt+j</code>/<code>k</code> moves the
+    roster cursor so the portal swaps terminals under the keyboard, <code>alt+z</code> zooms
+    the grid over the full body, and <code>alt+t</code> flips to the transcript reading
+    view. Typing into an agent's terminal is the strongest form of having seen its result,
+    so attention clears on the way through.</p>
+    <p><code>F</code> is the full-screen escape hatch: the runtime's <code>Attach</code>
+    returns a command (<code>stormlight _wrattach &lt;session&gt;</code>) that the dashboard
+    runs through <code>tea.ExecProcess</code>, suspending itself while the attachment owns
+    the whole terminal; <code>ctrl+q</code> detaches and the dashboard returns, reasserting
+    every widget's size because the attached client resized the daemon's sessions.</p>
+    <p>The transcript view renders the conversation from the provider's own JSONL transcript
+    once hooks have reported its path — the terminal screen is all a snapshot can see of an
+    alternate-screen agent, so the transcript file is the only complete history. The
+    renderer paints it: prompts, replies, tool calls, and trimmed results take the palette
+    in <code>internal/theme</code>, and the markdown Claude writes is read back as styling
+    by Glamour, against a stylesheet built from that same palette in
+    <code>internal/provider/markdown.go</code>. Glamour's own wrapping is switched off — the
+    pane is resizable, so line breaking belongs to the pane, which knows the current width.
+    While a turn is in flight the live screen is appended under a divider so streaming
+    output stays visible; an agent with no transcript falls back to its terminal
+    snapshot.</p>
+    <p>External overlays — the Yazi directory picker and the Neovim task editor — float over
+    the dashboard in a popup: the program runs in its own runtime-owned session
+    (<code>session.OverlayHost</code>, a runtime capability beside
+    <code>TerminalStreamer</code>), and the dashboard renders its terminal through the same
+    widget as the Spanreed, composited into a modal frame. The keyboard belongs to the
+    floating program while it is up — <code>Ctrl-q</code> cancels, which destroys the
+    session — and results return through permission-restricted temporary handoff files when
+    the program exits. Overlay sessions carry no agent document, so the roster never sees
+    them, and Close always removes them from the daemon: an overlay resurrected from
+    persistence would be a ghost with nothing waiting on its exit.</p>
+
+    <h2 id="state-model">State model</h2>
+    <p>The public agent record keeps process lifetime, activity, and attention separate,
+    with a fourth axis for the human's own reading:</p>
+    <ul>
+      <li><strong>Process:</strong> live or exited, with an optional exit code.</li>
+      <li><strong>Activity:</strong> starting, working, idle, completed, failed, or
+      stopped.</li>
+      <li><strong>Attention:</strong> question, approval, authentication, waiting, or
+      none.</li>
+      <li><strong>Mark:</strong> working, attention, or none — set by a human, never
+      derived.</li>
+    </ul>
+    <p>Attention is tiered. Question, approval, and authentication are urgent — the agent is
+    blocked on an explicit human decision. Waiting is soft — the turn finished with a result
+    the human has not seen. Every turn end is classified from the final assistant message
+    (providers emit one event for both "done" and "asked a question", so content is the only
+    instant discriminator): a closing question is urgent, anything else is an unseen result.
+    The provider's delayed idle notification is deliberately ignored — it would re-raise
+    attention the human already cleared. Attention clears on engagement: a new prompt,
+    typing into the agent's terminal, replying, interrupting, paging through the result
+    while it is on screen, or an explicit mark-seen. Navigating between panes and rows is
+    deliberately not engagement — those are the keys a human presses on the way past a
+    result, and counting them cleared the amber before it was ever read. The runtime refuses
+    to let a soft signal downgrade an urgent state. Exited agents carry no attention — their
+    exit status is the story.</p>
+    <p>This prevents a resumable completed conversation from being conflated with a
+    currently running process, and keeps "needs me now" distinct from "idle on me" and from
+    "just idle".</p>
+    <p>Entry into the amber inbox is stamped, by either route, and the stamp is what the
+    attention sort orders by: first in, first out. It records entry rather than the latest
+    signal, so a summary or an escalation arriving mid-wait does not send an agent to the
+    back of a line it never left. An agent leaves the inbox only through engagement, never
+    through mere navigation.</p>
+    <p>A mark is the one signal nothing derives. Everything above is inference, and
+    inference is sometimes wrong, so a human can say otherwise (<code>m</code> in the
+    dashboard, <code>stormlight mark</code> outside it) and the mark outranks the derived
+    reading everywhere it is displayed or counted. The two marks retire differently, because
+    different parties can answer them: a working mark claims the agent is still running,
+    which the agent settles as soon as it reports anything, so the next state-bearing update
+    retires it; an attention mark claims the human has something to return to, which no
+    provider event can answer, so only an explicit clear or the same engagement that clears
+    amber takes it down. Like attention, a mark stops applying once the process has
+    exited.</p>
+
+    <h2 id="persistence">Persistence</h2>
+    <p>Session metadata in the daemon is the source of truth for the running roster, and the
+    daemon's persistence is what makes it durable: agents outlive every dashboard because
+    their PTYs and terminals never belonged to one. The workspace catalog is an atomic JSON
+    file independent of the daemon, as are the dashboard's column preferences.</p>
+    <p>The daemon's lifetime bounds the roster's. A reboot or a killed daemon takes the
+    processes and their terminals with it — but not the conversations.
+    <code>internal/history</code> keeps an append-only session log
+    (<code>sessions.jsonl</code>) recording every session id the providers ever report, with
+    the task, workspace, and transcript path; the log is compacted once per dashboard
+    launch, off every event path. A provider adapter's <code>Resume</code> maps a session
+    id — the one the agent's hooks reported, or failing that the one the provider's
+    transcript naming encodes — to a launch that reopens the conversation, and that launch
+    carries no prompt: a resumed agent idles at its composer. Nothing resumes work by
+    itself. An agent that never reported a turn has no session id and no transcript, so
+    there is nothing to reopen — re-dispatching its original task would be a materially
+    different act performed under the same name. The dashboard's history browser
+    (<code>H</code>) serves the same records long after their agents are deleted.</p>
+
+    <h2 id="workspace-boundary">Workspace boundary</h2>
+    <p>Workspace discovery is intentionally outside provider adapters. Provisioning and
+    cleanup remain separate concerns: a future worktree manager can prepare a directory
+    before dispatch and pass it through the same resolver and runtime. Cleanup must refuse
+    to remove worktrees containing uncommitted changes or unpushed commits.</p>
+  </article>
+
+  <nav class="doc-pager"><span></span><a href="workspace-resolvers.html">Workspace resolvers →</a></nav>
+</main>
+</div>
+
+<footer class="footer">
+  <div class="wrap">
+    <span>stormlight · pre-1.0, moving fast</span>
+    <span>
+      <a href="https://github.com/trentkm/stormlight">stormlight</a> ·
+      <a href="https://github.com/trentkm/windrunner">windrunner</a> ·
+      <a href="./">docs</a>
+    </span>
+  </div>
+</footer>
+<script src="../assets/docs.js"></script>
+</body>
+</html>

--- a/site/docs/configuration.html
+++ b/site/docs/configuration.html
@@ -1,0 +1,179 @@
+<!doctype html>
+<html lang="en">
+<head>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width, initial-scale=1">
+<title>Configuration — Stormlight</title>
+<meta name="description" content="The design rationale behind Stormlight's config.toml: zero-config defaults, one precedence rule, custom providers.">
+<link rel="icon" href="data:image/svg+xml,%3Csvg%20xmlns%3D%22http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg%22%20viewBox%3D%220%200%2024%2024%22%20fill%3D%22none%22%20stroke-linecap%3D%22round%22%20stroke-linejoin%3D%22round%22%20stroke-width%3D%222%22%3E%3Cpath%20stroke%3D%22%2362aeef%22%20d%3D%22M6%2016.326A7%207%200%201%201%2015.71%208h1.79a4.5%204.5%200%200%201%20.5%208.973%22%2F%3E%3Cpath%20stroke%3D%22%2326799d%22%20d%3D%22m13%2012-3%205h4l-3%205%22%2F%3E%3C%2Fsvg%3E">
+<link rel="preconnect" href="https://fonts.googleapis.com">
+<link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+<link href="https://fonts.googleapis.com/css2?family=Newsreader:ital,opsz,wght@0,6..72,300..600;1,6..72,300..600&family=Geist+Mono:wght@300..600&display=swap" rel="stylesheet">
+<link rel="stylesheet" href="../assets/style.css">
+<link rel="stylesheet" href="../assets/docs.css">
+</head>
+<body>
+<div class="storm"></div>
+<div class="grain"></div>
+
+<header class="wrap nav">
+  <a class="wordmark" href="../">STORMLIGHT<span class="spark"><svg viewBox="0 0 24 24" width="13" height="13" fill="none" stroke="currentColor" stroke-width="2.2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><path d="M6 16.326A7 7 0 1 1 15.71 8h1.79a4.5 4.5 0 0 1 .5 8.973"/><path d="m13 12-3 5h4l-3 5"/></svg></span></a>
+  <nav class="nav-links">
+    <a href="../#design">design</a>
+    <a href="../#windrunner">windrunner</a>
+    <a href="./">docs</a>
+    <a href="https://github.com/trentkm/stormlight">github</a>
+  </nav>
+</header>
+
+<div class="docwrap">
+<aside class="side">
+  <p class="side-title">Documentation</p>
+  <ul>
+    <li><a href="./">Overview</a></li>
+    <li><a href="architecture.html">Architecture</a></li>
+    <li><a href="workspace-resolvers.html">Workspace resolvers</a></li>
+    <li class="current"><a href="configuration.html">Configuration</a><ul class="sections">
+    <li><a href="#purpose">What config is for</a></li>
+    <li><a href="#principles">Principles</a></li>
+    <li><a href="#file-location">File location</a></li>
+    <li><a href="#format">Format</a></li>
+    <li><a href="#schema">Schema</a></li>
+    <li><a href="#wiring">Wiring</a></li>
+    <li><a href="#project-local">Project-local config</a></li>
+    </ul></li>
+  </ul>
+</aside>
+<main class="doc">
+  <h1 class="doc-title">Configuration</h1>
+  <p class="doc-lede">The design rationale behind <code>config.toml</code> —
+  <code>internal/config</code>, <code>stormlight config</code>, and
+  <code>stormlight config init</code>. The
+  <a href="https://github.com/trentkm/stormlight#configuration">README's Configuration
+  section</a> is the user-facing reference.</p>
+
+  <article>
+    <h2 id="purpose">What config is — and is not — for</h2>
+    <p>A workspace is a directory. How agents behave inside it belongs to the tree itself
+    (<code>CLAUDE.md</code> / <code>AGENTS.md</code>, read natively by the provider CLIs),
+    and what groups directories into one workspace belongs to resolvers. The config file
+    therefore holds only <em>user preferences about Stormlight's own behavior</em>: which
+    provider and permission mode to reach for, how the UI looks, where the logs go. It never
+    defines workspace semantics and never injects agent context.</p>
+
+    <h2 id="principles">Principles</h2>
+    <ol>
+      <li><strong>Zero-config.</strong> The file is optional; every setting has the default
+      the binary ships with. <code>brew install</code> → <code>stormlight</code> must keep
+      working with no file present.</li>
+      <li><strong>One precedence rule everywhere:</strong> <code>flags &gt; environment &gt;
+      config file &gt; built-in defaults</code>.</li>
+      <li><strong>Config never breaks determinism.</strong> Config keys select among
+      behaviors Stormlight owns (which mode, which provider, which binary) — they do not
+      open the door to arbitrary per-machine drift in how managed agents run.</li>
+      <li><strong>Config cannot silently escalate permissions.</strong> Nothing a repository
+      checkout contains may raise an agent's permission mode (see "Project-local config"
+      below).</li>
+    </ol>
+
+    <h2 id="file-location">File location</h2>
+    <p><code>~/.config/stormlight/config.toml</code>, honoring
+    <code>$XDG_CONFIG_HOME</code>. Everything Stormlight owns lives under one directory each
+    for config and state — dev-tool convention (git, gh, nvim do the same on macOS), and one
+    directory to document:</p>
+<pre><code>~/.config/stormlight/
+  config.toml     <span class="c"># user configuration</span>
+  resolvers/      <span class="c"># executable workspace resolvers</span>
+~/.local/state/stormlight/
+  workspaces.json <span class="c"># workspace catalog</span>
+  sessions.jsonl  <span class="c"># session history log</span></code></pre>
+
+    <h2 id="format">Format</h2>
+    <p>TOML, parsed with <code>pelletier/go-toml/v2</code>. Rationale: comments (a config
+    file that can't explain itself is a bug), obvious sectioning, no significant whitespace,
+    the standard choice in the Go/Homebrew tooling ecosystem. JSON has no comments; YAML has
+    too many footguns for a file this small.</p>
+
+    <h2 id="schema">Schema</h2>
+<pre><code><span class="c"># ~/.config/stormlight/config.toml — all keys optional.</span>
+
+<span class="k">[defaults]</span>
+provider = <span class="s">"claude"</span>            <span class="c"># codex | claude | shell</span>
+mode     = <span class="s">"edits"</span>             <span class="c"># ask | edits | auto</span>
+
+<span class="k">[ui]</span>
+rows = <span class="s">"compact"</span>               <span class="c"># compact | expanded</span>
+
+<span class="k">[log]</span>
+level = <span class="s">"info"</span>                 <span class="c"># debug | info | warn | error</span>
+<span class="c"># file = "…"                   # overrides the default log location</span>
+
+<span class="k">[tools]</span>
+<span class="c"># yazi = "/opt/homebrew/bin/yazi"   # override PATH lookup</span>
+<span class="c"># nvim = "/opt/homebrew/bin/nvim"</span>
+
+<span class="c"># Per-workspace overrides, keyed by workspace root.</span>
+<span class="k">[workspaces."/Volumes/repos/stormlight"]</span>
+mode     = <span class="s">"auto"</span>
+provider = <span class="s">"claude"</span>
+
+<span class="c"># Provider adapter tweaks. extra_args append after Stormlight's own</span>
+<span class="c"># flags, so they can refine but not remove lifecycle hooks.</span>
+<span class="k">[providers.codex]</span>
+<span class="c"># binary     = "codex"</span>
+<span class="c"># extra_args = ["--model", "o4"]</span>
+
+<span class="c"># User-defined providers. args is an exec-style array with a {task}</span>
+<span class="c"># placeholder — never a shell string.</span>
+<span class="k">[providers.aider]</span>
+<span class="c"># label  = "Aider"</span>
+<span class="c"># binary = "aider"</span>
+<span class="c"># args   = ["--message", "{task}"]</span>
+<span class="c"># [providers.aider.mode_args]</span>
+<span class="c"># auto = ["--yes-always"]</span></code></pre>
+    <p>Custom providers appear in the New Agent picker and dispatch like any other.
+    Lifecycle integration is the public contract: managed processes receive
+    <code>STORMLIGHT_ID</code> and can report state with <code>stormlight event</code> from
+    any hook mechanism the CLI provides. Stormlight never reimplements an agent.</p>
+
+    <h2 id="wiring">Wiring</h2>
+    <ul>
+      <li><code>internal/config</code>: <code>config.Load()</code> → <code>Config</code>
+      struct with the defaults filled in, called once before command construction.</li>
+      <li>Cobra flag defaults are <em>initialized from</em> the loaded config, so the
+      precedence rule falls out of the existing machinery instead of being reimplemented per
+      flag.</li>
+      <li>Validation errors name the key and file
+      (<code>config.toml: defaults.mode: invalid permission mode "always"</code>), and a
+      broken config falls back to defaults with a visible warning rather than refusing to
+      start — the dashboard is also how you'd notice the problem.</li>
+      <li><code>stormlight config</code> prints the effective merged config and the file
+      path; <code>stormlight config init</code> writes a fully commented template.</li>
+    </ul>
+
+    <h2 id="project-local">Project-local config (deliberately deferred)</h2>
+    <p>A <code>.stormlight.toml</code> in a repo root ("this project defaults to codex") is
+    attractive for teams but dangerous: a cloned repository must never be able to grant
+    itself <code>mode = "auto"</code>. If it is added later, it needs direnv-style trust
+    ("stormlight noticed project config, run <code>stormlight trust</code> to apply") and a
+    hard rule that permission mode can only be <em>lowered</em> by untrusted project files.
+    For now, overrides live in the user's own config file, keyed by path.</p>
+  </article>
+
+  <nav class="doc-pager"><a href="workspace-resolvers.html">← Workspace resolvers</a><span></span></nav>
+</main>
+</div>
+
+<footer class="footer">
+  <div class="wrap">
+    <span>stormlight · pre-1.0, moving fast</span>
+    <span>
+      <a href="https://github.com/trentkm/stormlight">stormlight</a> ·
+      <a href="https://github.com/trentkm/windrunner">windrunner</a> ·
+      <a href="./">docs</a>
+    </span>
+  </div>
+</footer>
+<script src="../assets/docs.js"></script>
+</body>
+</html>

--- a/site/docs/index.html
+++ b/site/docs/index.html
@@ -1,0 +1,84 @@
+<!doctype html>
+<html lang="en">
+<head>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width, initial-scale=1">
+<title>Docs — Stormlight</title>
+<meta name="description" content="Stormlight documentation: architecture, workspace resolvers, configuration.">
+<link rel="icon" href="data:image/svg+xml,%3Csvg%20xmlns%3D%22http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg%22%20viewBox%3D%220%200%2024%2024%22%20fill%3D%22none%22%20stroke-linecap%3D%22round%22%20stroke-linejoin%3D%22round%22%20stroke-width%3D%222%22%3E%3Cpath%20stroke%3D%22%2362aeef%22%20d%3D%22M6%2016.326A7%207%200%201%201%2015.71%208h1.79a4.5%204.5%200%200%201%20.5%208.973%22%2F%3E%3Cpath%20stroke%3D%22%2326799d%22%20d%3D%22m13%2012-3%205h4l-3%205%22%2F%3E%3C%2Fsvg%3E">
+<link rel="preconnect" href="https://fonts.googleapis.com">
+<link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+<link href="https://fonts.googleapis.com/css2?family=Newsreader:ital,opsz,wght@0,6..72,300..600;1,6..72,300..600&family=Geist+Mono:wght@300..600&display=swap" rel="stylesheet">
+<link rel="stylesheet" href="../assets/style.css">
+<link rel="stylesheet" href="../assets/docs.css">
+</head>
+<body>
+<div class="storm"></div>
+<div class="grain"></div>
+
+<header class="wrap nav">
+  <a class="wordmark" href="../">STORMLIGHT<span class="spark"><svg viewBox="0 0 24 24" width="13" height="13" fill="none" stroke="currentColor" stroke-width="2.2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><path d="M6 16.326A7 7 0 1 1 15.71 8h1.79a4.5 4.5 0 0 1 .5 8.973"/><path d="m13 12-3 5h4l-3 5"/></svg></span></a>
+  <nav class="nav-links">
+    <a href="../#design">design</a>
+    <a href="../#windrunner">windrunner</a>
+    <a href="./">docs</a>
+    <a href="https://github.com/trentkm/stormlight">github</a>
+  </nav>
+</header>
+
+<div class="docwrap">
+<aside class="side">
+  <p class="side-title">Documentation</p>
+  <ul>
+    <li class="current"><a href="./">Overview</a></li>
+    <li><a href="architecture.html">Architecture</a></li>
+    <li><a href="workspace-resolvers.html">Workspace resolvers</a></li>
+    <li><a href="configuration.html">Configuration</a></li>
+  </ul>
+</aside>
+<main class="doc">
+  <p class="kicker">documentation</p>
+  <h1 class="doc-title">Docs</h1>
+  <p class="doc-lede">How Stormlight is put together, and the two public contracts —
+  workspace resolution and configuration. The
+  <a href="https://github.com/trentkm/stormlight#readme">README</a> is the user-facing
+  reference for the dashboard itself.</p>
+
+  <div class="doc-list">
+    <a class="doc-card" href="architecture.html">
+      <h3>Architecture</h3>
+      <p>Provider adapters, the application service, the windrunner runtime, the terminal
+      seam, the state model, and persistence — how agent semantics stay separate from
+      terminal and process ownership.</p>
+      <p class="go">read →</p>
+    </a>
+    <a class="doc-card" href="workspace-resolvers.html">
+      <h3>Workspace resolvers</h3>
+      <p>How directories resolve into workspace groups and execution roots, and the
+      executable protocol that lets a monorepo or proprietary layout define its own
+      workspace semantics — no Stormlight-specific code required.</p>
+      <p class="go">read →</p>
+    </a>
+    <a class="doc-card" href="configuration.html">
+      <h3>Configuration</h3>
+      <p>The design rationale behind <code>config.toml</code>: what config is and is not
+      for, the precedence rule, custom providers, and why project-local config is
+      deliberately deferred.</p>
+      <p class="go">read →</p>
+    </a>
+  </div>
+
+</main>
+</div>
+
+<footer class="footer">
+  <div class="wrap">
+    <span>stormlight · pre-1.0, moving fast</span>
+    <span>
+      <a href="https://github.com/trentkm/stormlight">stormlight</a> ·
+      <a href="https://github.com/trentkm/windrunner">windrunner</a>
+    </span>
+  </div>
+</footer>
+</body>
+</html>

--- a/site/docs/workspace-resolvers.html
+++ b/site/docs/workspace-resolvers.html
@@ -1,0 +1,115 @@
+<!doctype html>
+<html lang="en">
+<head>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width, initial-scale=1">
+<title>Workspace resolvers — Stormlight</title>
+<meta name="description" content="How Stormlight resolves directories into workspace groups, and the executable resolver protocol.">
+<link rel="icon" href="data:image/svg+xml,%3Csvg%20xmlns%3D%22http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg%22%20viewBox%3D%220%200%2024%2024%22%20fill%3D%22none%22%20stroke-linecap%3D%22round%22%20stroke-linejoin%3D%22round%22%20stroke-width%3D%222%22%3E%3Cpath%20stroke%3D%22%2362aeef%22%20d%3D%22M6%2016.326A7%207%200%201%201%2015.71%208h1.79a4.5%204.5%200%200%201%20.5%208.973%22%2F%3E%3Cpath%20stroke%3D%22%2326799d%22%20d%3D%22m13%2012-3%205h4l-3%205%22%2F%3E%3C%2Fsvg%3E">
+<link rel="preconnect" href="https://fonts.googleapis.com">
+<link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+<link href="https://fonts.googleapis.com/css2?family=Newsreader:ital,opsz,wght@0,6..72,300..600;1,6..72,300..600&family=Geist+Mono:wght@300..600&display=swap" rel="stylesheet">
+<link rel="stylesheet" href="../assets/style.css">
+<link rel="stylesheet" href="../assets/docs.css">
+</head>
+<body>
+<div class="storm"></div>
+<div class="grain"></div>
+
+<header class="wrap nav">
+  <a class="wordmark" href="../">STORMLIGHT<span class="spark"><svg viewBox="0 0 24 24" width="13" height="13" fill="none" stroke="currentColor" stroke-width="2.2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><path d="M6 16.326A7 7 0 1 1 15.71 8h1.79a4.5 4.5 0 0 1 .5 8.973"/><path d="m13 12-3 5h4l-3 5"/></svg></span></a>
+  <nav class="nav-links">
+    <a href="../#design">design</a>
+    <a href="../#windrunner">windrunner</a>
+    <a href="./">docs</a>
+    <a href="https://github.com/trentkm/stormlight">github</a>
+  </nav>
+</header>
+
+<div class="docwrap">
+<aside class="side">
+  <p class="side-title">Documentation</p>
+  <ul>
+    <li><a href="./">Overview</a></li>
+    <li><a href="architecture.html">Architecture</a></li>
+    <li class="current"><a href="workspace-resolvers.html">Workspace resolvers</a><ul class="sections">
+    <li><a href="#resolution-order">Resolution order</a></li>
+    <li><a href="#executable-protocol">Executable protocol</a></li>
+    </ul></li>
+    <li><a href="configuration.html">Configuration</a></li>
+  </ul>
+</aside>
+<main class="doc">
+  <h1 class="doc-title">Workspace resolvers</h1>
+  <p class="doc-lede">Stormlight resolves every working directory into three levels:</p>
+
+  <article>
+<pre><code>workspace group
+  execution root
+    agent</code></pre>
+    <p>The workspace ID controls grouping. The execution root identifies the checkout,
+    worktree, or other runnable directory used by an agent. An optional component describes
+    a package inside a larger workspace.</p>
+
+    <h2 id="resolution-order">Resolution order</h2>
+    <p>Resolvers run in this order:</p>
+    <ol>
+      <li>Executable resolvers from <code>~/.config/stormlight/resolvers</code>, sorted by
+      filename.</li>
+      <li>The built-in Git resolver.</li>
+      <li>A canonical-directory fallback.</li>
+    </ol>
+    <p>Set <code>STORMLIGHT_RESOLVERS_DIR</code> to use a different executable directory.
+    External resolvers run first so a monorepo or proprietary workspace can take precedence
+    over Git repositories nested inside it.</p>
+    <p>The Git resolver derives the workspace ID from the canonical
+    <code>git rev-parse --git-common-dir</code> path. Linked worktrees therefore appear in
+    one workspace group with distinct execution roots. Independent clones remain separate
+    groups.</p>
+
+    <h2 id="executable-protocol">Executable protocol</h2>
+    <p>Each non-hidden executable in the resolver directory is invoked as:</p>
+<pre><code>resolver resolve &lt;canonical-directory&gt;</code></pre>
+    <p>The process working directory is also set to the canonical directory.</p>
+    <p>Exit status <code>0</code> means the resolver matched and must emit one JSON object
+    on standard output. Exit status <code>2</code> means the resolver is not applicable. Any
+    other status is logged as a resolver failure and resolution continues.</p>
+    <p>Example:</p>
+<pre><code>{
+  "id": "monorepo:/home/me/src/example",
+  "kind": "monorepo",
+  "name": "example",
+  "root": "/home/me/src/example",
+  "execution_root": "/home/me/src/example",
+  "component_name": "payments",
+  "component_root": "/home/me/src/example/services/payments",
+  "metadata": {
+    "profile": "development"
+  }
+}</code></pre>
+    <p><code>kind</code> and <code>root</code> are required. <code>id</code> defaults to
+    <code>&lt;kind&gt;:&lt;root&gt;</code>, <code>name</code> defaults to the root directory
+    name, and <code>execution_root</code> defaults to <code>root</code>. All returned paths
+    must exist and be directories. IDs must remain stable for directories that belong in the
+    same workspace group.</p>
+    <p>Resolvers are trusted local executables and run during dispatch and workspace catalog
+    loading. Stormlight caches successful results for the life of the process.</p>
+  </article>
+
+  <nav class="doc-pager"><a href="architecture.html">← Architecture</a><a href="configuration.html">Configuration →</a></nav>
+</main>
+</div>
+
+<footer class="footer">
+  <div class="wrap">
+    <span>stormlight · pre-1.0, moving fast</span>
+    <span>
+      <a href="https://github.com/trentkm/stormlight">stormlight</a> ·
+      <a href="https://github.com/trentkm/windrunner">windrunner</a> ·
+      <a href="./">docs</a>
+    </span>
+  </div>
+</footer>
+<script src="../assets/docs.js"></script>
+</body>
+</html>

--- a/site/index.html
+++ b/site/index.html
@@ -1,0 +1,449 @@
+<!doctype html>
+<html lang="en">
+<head>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width, initial-scale=1">
+<title>Stormlight — a control surface for coding agents</title>
+<meta name="description" content="Stormlight dispatches Claude, Codex, and custom coding agents onto a daemon that owns each agent's PTY and terminal — a workspace-native dashboard running in your own terminal.">
+<meta property="og:title" content="Stormlight">
+<meta property="og:description" content="A workspace-native control surface for coding agents.">
+<link rel="icon" href="data:image/svg+xml,%3Csvg%20xmlns%3D%22http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg%22%20viewBox%3D%220%200%2024%2024%22%20fill%3D%22none%22%20stroke-linecap%3D%22round%22%20stroke-linejoin%3D%22round%22%20stroke-width%3D%222%22%3E%3Cpath%20stroke%3D%22%2362aeef%22%20d%3D%22M6%2016.326A7%207%200%201%201%2015.71%208h1.79a4.5%204.5%200%200%201%20.5%208.973%22%2F%3E%3Cpath%20stroke%3D%22%2326799d%22%20d%3D%22m13%2012-3%205h4l-3%205%22%2F%3E%3C%2Fsvg%3E">
+<link rel="preconnect" href="https://fonts.googleapis.com">
+<link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+<link href="https://fonts.googleapis.com/css2?family=Newsreader:ital,opsz,wght@0,6..72,300..600;1,6..72,300..600&family=Geist+Mono:wght@300..600&display=swap" rel="stylesheet">
+<link rel="stylesheet" href="assets/style.css">
+<style>
+/* ---------- hero ---------- */
+
+.hero { padding: 6rem 0 4rem; }
+
+.hero h1 {
+  font-size: clamp(2.6rem, 6.5vw, 4.6rem);
+  line-height: 1.08;
+  max-width: 18em;
+  font-weight: 300;
+  color: var(--heading);
+}
+
+.hero .sub {
+  margin-top: 1.6rem;
+  max-width: 36em;
+  font-size: 1.12rem;
+  color: var(--ink-dim);
+}
+.hero .sub strong { font-weight: 500; color: var(--ink); }
+
+.hero-actions {
+  margin-top: 2.4rem;
+  display: flex;
+  align-items: center;
+  gap: 1.4rem;
+  flex-wrap: wrap;
+}
+.ghost-link {
+  font-family: var(--mono);
+  font-size: 0.8rem;
+  letter-spacing: 0.06em;
+  color: var(--ink-dim);
+}
+
+/* ---------- dashboard mock ---------- */
+
+.mockwrap { padding: 2.5rem 0 0; }
+
+.dash {
+  display: grid;
+  grid-template-columns: 15rem 19rem 1fr;
+  min-height: 26rem;
+  font-size: 0.78rem;
+  line-height: 1.85;
+}
+
+.pane { border-right: 1px solid var(--line-soft); padding: 0.7rem 0; min-width: 0; }
+.pane:last-child { border-right: none; }
+
+.pane-title {
+  font-size: 0.66rem;
+  letter-spacing: 0.22em;
+  text-transform: uppercase;
+  color: var(--ink-faint);
+  padding: 0 1rem 0.5rem;
+}
+.pane-title .n { color: var(--ink-dim); }
+.pane.focused .pane-title { color: var(--cyan-deep); }
+
+.row { padding: 0 1rem; white-space: nowrap; overflow: hidden; text-overflow: ellipsis; color: var(--ink-dim); }
+.row .glyph { display: inline-block; width: 1.1em; }
+.row.sel { background: var(--sel-bg); color: var(--ink); }
+.row .meta { color: var(--ink-faint); font-size: 0.9em; }
+
+.g-work { color: var(--cyan-deep); }
+.g-wait { color: var(--amber); }
+.g-loud { color: var(--amber); font-weight: 600; }
+.row.loud { color: var(--amber); }
+
+/* the working glow: a light sweeping through the agent's name */
+.glowname {
+  background: linear-gradient(100deg,
+    var(--ink-dim) 0%, var(--ink-dim) 38%,
+    var(--sweep-hi) 50%,
+    var(--ink-dim) 62%, var(--ink-dim) 100%);
+  background-size: 260% 100%;
+  -webkit-background-clip: text;
+  background-clip: text;
+  color: transparent;
+  animation: sweep 3.2s linear infinite;
+}
+.row.sel .glowname {
+  background-image: linear-gradient(100deg,
+    var(--ink) 0%, var(--ink) 38%, var(--sweep-hi-sel) 50%, var(--ink) 62%, var(--ink) 100%);
+}
+@keyframes sweep {
+  from { background-position: 130% 0; }
+  to { background-position: -130% 0; }
+}
+
+/* spanreed pane */
+.span-head { padding: 0 1rem 0.4rem; color: var(--ink-faint); font-size: 0.72rem; }
+.span-head .prov { color: var(--cyan-deep); }
+.span-body { padding: 0.2rem 1rem; color: var(--term-ink); }
+.span-body .you { color: var(--ink-faint); }
+.span-body .tool { color: var(--tool-ink); }
+.span-body .ok { color: var(--ok-ink); }
+.cursor {
+  display: inline-block; width: 0.55em; height: 1.05em;
+  background: var(--cyan); vertical-align: text-bottom;
+  animation: blink 1.1s steps(1) infinite;
+  box-shadow: 0 0 8px rgba(38, 121, 157, 0.5);
+}
+@keyframes blink { 50% { opacity: 0; } }
+
+.dash-foot {
+  border-top: 1px solid var(--line-soft);
+  padding: 0.45rem 1rem;
+  font-size: 0.68rem;
+  color: var(--ink-faint);
+  display: flex;
+  gap: 1.3rem;
+  overflow: hidden;
+  white-space: nowrap;
+}
+.dash-foot b { color: var(--ink-dim); font-weight: 500; }
+
+.mock-caption {
+  margin-top: 1.1rem;
+  text-align: center;
+  font-family: var(--mono);
+  font-size: 0.72rem;
+  color: var(--ink-faint);
+}
+
+@media (max-width: 900px) {
+  .dash { grid-template-columns: 1fr; }
+  .pane { border-right: none; border-bottom: 1px solid var(--line-soft); }
+  .pane:last-child { border-bottom: none; }
+}
+
+/* ---------- sections ---------- */
+
+section { padding: 6.5rem 0 0; }
+
+.section-head h2 {
+  font-size: clamp(1.9rem, 4vw, 2.7rem);
+  color: var(--heading);
+  max-width: 20em;
+}
+.section-head p.lede {
+  margin-top: 1.1rem;
+  max-width: 38em;
+  color: var(--ink-dim);
+  font-size: 1.08rem;
+}
+
+/* principle cards */
+.grid {
+  margin-top: 3rem;
+  display: grid;
+  grid-template-columns: repeat(3, 1fr);
+  gap: 1px;
+  background: var(--line-soft);
+  border: 1px solid var(--line-soft);
+  border-radius: 10px;
+  overflow: hidden;
+}
+.cell {
+  background: var(--bg-raised);
+  padding: 1.7rem 1.6rem 1.9rem;
+  transition: background 0.25s;
+}
+.cell:hover { background: var(--hover-bg); }
+.cell h3 {
+  font-family: var(--mono);
+  font-size: 0.82rem;
+  font-weight: 500;
+  letter-spacing: 0.04em;
+  color: var(--cyan);
+  margin-bottom: 0.7rem;
+}
+.cell p { font-size: 0.95rem; color: var(--ink-dim); }
+.grid-2 { grid-template-columns: repeat(2, 1fr); }
+@media (max-width: 900px) { .grid, .grid-2 { grid-template-columns: 1fr; } }
+
+/* attention strip */
+.signals {
+  margin-top: 3rem;
+  display: grid;
+  grid-template-columns: repeat(3, 1fr);
+  gap: 1.2rem;
+}
+.signal {
+  border: 1px solid var(--line);
+  border-radius: 10px;
+  padding: 1.5rem 1.5rem 1.6rem;
+  background: var(--bg-raised);
+  font-size: 0.95rem;
+  color: var(--ink-dim);
+}
+.signal .tag {
+  font-family: var(--mono);
+  font-size: 0.75rem;
+  letter-spacing: 0.06em;
+  display: block;
+  margin-bottom: 0.7rem;
+}
+.signal.working .tag { color: var(--cyan-deep); text-shadow: 0 0 14px rgba(98,174,239,0.5); }
+.signal.waiting .tag { color: var(--amber); }
+.signal.urgent { border-color: rgba(168, 102, 0, 0.3); }
+.signal.urgent .tag { color: var(--amber); font-weight: 600; }
+@media (max-width: 900px) { .signals { grid-template-columns: 1fr; } }
+
+/* windrunner */
+.engine {
+  margin-top: 3rem;
+  border: 1px solid var(--line);
+  border-radius: 12px;
+  background:
+    radial-gradient(40rem 20rem at 110% -30%, rgba(98, 174, 239, 0.14), transparent 60%),
+    var(--bg-raised);
+  padding: 3rem;
+  display: grid;
+  grid-template-columns: 1.2fr 1fr;
+  gap: 3rem;
+}
+.engine h3 {
+  font-size: 1.7rem;
+  color: var(--heading);
+  margin-bottom: 1rem;
+}
+.engine p { color: var(--ink-dim); margin-bottom: 1rem; font-size: 1rem; }
+.engine .points { list-style: none; font-size: 0.92rem; color: var(--ink-dim); }
+.engine .points li { padding: 0.55rem 0; border-bottom: 1px solid var(--line-soft); }
+.engine .points li::before { content: "— "; color: var(--cyan-deep); }
+.engine .repo-link { font-family: var(--mono); font-size: 0.8rem; }
+@media (max-width: 900px) { .engine { grid-template-columns: 1fr; padding: 2rem 1.5rem; } }
+
+/* closing */
+.closing { text-align: center; padding-top: 8rem; }
+.closing h2 { font-size: clamp(2rem, 5vw, 3.2rem); color: var(--heading); }
+.closing .hero-actions { justify-content: center; }
+.closing .docrow {
+  margin-top: 2.2rem;
+  font-family: var(--mono);
+  font-size: 0.8rem;
+  display: flex;
+  justify-content: center;
+  gap: 2rem;
+  flex-wrap: wrap;
+}
+</style>
+</head>
+<body>
+<div class="storm"></div>
+<div class="grain"></div>
+
+<header class="wrap nav">
+  <a class="wordmark" href="./">STORMLIGHT<span class="spark"><svg viewBox="0 0 24 24" width="13" height="13" fill="none" stroke="currentColor" stroke-width="2.2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><path d="M6 16.326A7 7 0 1 1 15.71 8h1.79a4.5 4.5 0 0 1 .5 8.973"/><path d="m13 12-3 5h4l-3 5"/></svg></span></a>
+  <nav class="nav-links">
+    <a href="#design">design</a>
+    <a href="#windrunner">windrunner</a>
+    <a href="docs/">docs</a>
+    <a href="https://github.com/trentkm/stormlight">github</a>
+  </nav>
+</header>
+
+<main>
+  <div class="wrap hero">
+    <p class="kicker">workspace-native · terminal-native</p>
+    <h1>A control surface for <em class="lit">coding agents</em>.</h1>
+    <p class="sub">Dispatches <strong>Claude</strong>, <strong>Codex</strong>, and any agent CLI
+    onto a daemon that owns each agent's PTY and terminal. The dashboard runs in yours.</p>
+    <div class="hero-actions">
+      <span class="install"><span class="p">$</span><span id="brew-cmd">brew install trentkm/stormlight/stormlight</span><button data-copy="brew-cmd">copy</button></span>
+      <a class="ghost-link" href="https://github.com/trentkm/stormlight">source on github →</a>
+    </div>
+  </div>
+
+  <div class="wrap mockwrap reveal">
+    <div class="term" role="img" aria-label="The Stormlight dashboard: Workspaces, Agents, and Spanreed panes">
+      <div class="term-bar">
+        <span class="dot"></span><span class="dot"></span><span class="dot"></span>
+        <span class="title">stormlight</span>
+      </div>
+      <div class="dash" aria-hidden="true">
+        <div class="pane">
+          <div class="pane-title">Workspaces <span class="n">4</span></div>
+          <div class="row sel"><span class="glyph g-work">●</span>stormlight <span class="meta">3</span></div>
+          <div class="row"><span class="glyph g-loud">!</span>windrunner <span class="meta">1</span></div>
+          <div class="row"><span class="glyph g-wait">○</span>oathgate <span class="meta">1</span></div>
+          <div class="row"><span class="glyph"> </span>homebrew-stormlight</div>
+        </div>
+        <div class="pane focused">
+          <div class="pane-title">Agents <span class="n">3</span></div>
+          <div class="row sel"><span class="glyph g-work">●</span><span class="glowname">fix the flaky attach test</span></div>
+          <div class="row"><span class="glyph g-wait">○</span>review current branch <span class="meta">claude</span></div>
+          <div class="row loud"><span class="glyph g-loud">!</span>migrate session log <span class="meta">codex</span></div>
+        </div>
+        <div class="pane">
+          <div class="pane-title">Spanreed</div>
+          <div class="span-head"><span class="prov">claude</span> · working · worktree <span>fix-attach</span></div>
+          <div class="span-body">
+            <p class="you">&gt; the attach test flakes on resize — find out why and fix it</p>
+            <p>&nbsp;</p>
+            <p>Reproduced it. The snapshot arrives before the resize settles,</p>
+            <p>so the first frame is wrapped for the old width.</p>
+            <p>&nbsp;</p>
+            <p class="tool">⏺ Bash(go test ./internal/windrun -run TestAttachResize -count=20)</p>
+            <p class="ok">  ⎿ ok — 20/20 passed</p>
+            <p>&nbsp;</p>
+            <p>Resizing before the snapshot is requested fixes it. Running the</p>
+            <p>full suite now<span class="cursor"></span></p>
+          </div>
+        </div>
+      </div>
+      <div class="dash-foot" aria-hidden="true">
+        <span><b>enter</b> walk in</span>
+        <span><b>t</b> transcript</span>
+        <span><b>n</b> new agent</span>
+        <span><b>H</b> history</span>
+        <span><b>F</b> full-screen</span>
+        <span><b>?</b> keys</span>
+      </div>
+    </div>
+    <p class="mock-caption">workspaces · agents · spanreed — the selected agent's real terminal, live</p>
+  </div>
+
+  <section id="design" class="wrap">
+    <div class="section-head reveal">
+      <p class="kicker">design</p>
+      <h2>The daemon owns the terminals. The dashboard just <em class="lit">visits</em>.</h2>
+      <p class="lede">Each agent is one daemon session: a PTY plus an authoritative terminal
+      emulator. A snapshot is exact state; an attach is a byte stream, never a screen scrape.</p>
+    </div>
+    <div class="grid grid-2 reveal">
+      <div class="cell">
+        <h3>agents outlive the dashboard</h3>
+        <p>Close it and nothing stops. The daemon's sessions <em>are</em> the roster.</p>
+      </div>
+      <div class="cell">
+        <h3>conversations outlive agents</h3>
+        <p>Every session lands in an append-only log; <code>H</code> reopens any of them,
+        with everything already said and done.</p>
+      </div>
+      <div class="cell">
+        <h3>workspace-native</h3>
+        <p>Linked worktrees group into one workspace; each checkout stays a distinct
+        execution root.</p>
+      </div>
+      <div class="cell">
+        <h3>bytes, not strings</h3>
+        <p>Messages arrive as a bracketed paste into the PTY. Hooks are wired per launch —
+        nothing is written to <code>~/.claude</code> or <code>~/.codex</code>.</p>
+      </div>
+    </div>
+  </section>
+
+  <section id="attention" class="wrap">
+    <div class="section-head reveal">
+      <p class="kicker amber">attention</p>
+      <h2>Amber is an <em class="lit">inbox</em>.</h2>
+      <p class="lede">It clears when you engage with a result — not when you scroll past it.</p>
+    </div>
+    <div class="signals reveal">
+      <div class="signal working">
+        <span class="tag">● working</span>
+        Running. A glow sweeps the name — visible, ignorable.
+      </div>
+      <div class="signal waiting">
+        <span class="tag">○ waiting</span>
+        Finished with a result you haven't seen. First in, first out.
+      </div>
+      <div class="signal urgent">
+        <span class="tag">! question · approval · auth</span>
+        Blocked on you. The row goes loud; <kbd>Enter</kbd> walks into the prompt.
+      </div>
+    </div>
+  </section>
+
+  <section id="windrunner" class="wrap">
+    <div class="section-head reveal">
+      <p class="kicker">the engine underneath</p>
+      <h2>Built on <em class="lit">windrunner</em>.</h2>
+    </div>
+    <div class="engine reveal">
+      <div>
+        <h3>A persistent terminal session engine for Go.</h3>
+        <p>Windrunner owns PTYs, runs a real VT emulator for each one — pure Go, no cgo —
+        and keeps them alive in a daemon that outlives any client. It's the engine inside
+        tools like tmux and screen, extracted and embeddable. Stormlight is its first
+        consumer: the daemon is the <code>stormlight</code> binary itself, started on demand.
+        Nothing else to install.</p>
+        <p class="repo-link"><a href="https://github.com/trentkm/windrunner">github.com/trentkm/windrunner →</a></p>
+      </div>
+      <ul class="points">
+        <li>A library first — daemon and wire protocol are packages, not requirements</li>
+        <li>Snapshots are exact serialized state, then the live byte stream</li>
+        <li>Bytes on the wire — bring any front end: a Go TUI, xterm.js, a bot</li>
+      </ul>
+    </div>
+  </section>
+
+  <div class="wrap closing reveal">
+    <p class="kicker">install</p>
+    <div class="hero-actions">
+      <span class="install"><span class="p">$</span><span id="brew-cmd2">brew install trentkm/stormlight/stormlight</span><button data-copy="brew-cmd2">copy</button></span>
+    </div>
+    <div class="docrow">
+      <a href="docs/architecture.html">architecture</a>
+      <a href="docs/workspace-resolvers.html">workspace resolvers</a>
+      <a href="docs/configuration.html">configuration</a>
+    </div>
+  </div>
+</main>
+
+<footer class="footer">
+  <div class="wrap">
+    <span>stormlight · pre-1.0, moving fast</span>
+    <span>
+      <a href="https://github.com/trentkm/stormlight">stormlight</a> ·
+      <a href="https://github.com/trentkm/windrunner">windrunner</a> ·
+      <a href="docs/">docs</a>
+    </span>
+  </div>
+</footer>
+
+<script>
+document.querySelectorAll("[data-copy]").forEach(btn => {
+  btn.addEventListener("click", () => {
+    navigator.clipboard.writeText(document.getElementById(btn.dataset.copy).textContent).then(() => {
+      btn.textContent = "copied";
+      setTimeout(() => { btn.textContent = "copy"; }, 1500);
+    });
+  });
+});
+const io = new IntersectionObserver(entries => {
+  entries.forEach(e => { if (e.isIntersecting) { e.target.classList.add("in"); io.unobserve(e.target); } });
+}, { threshold: 0.12 });
+document.querySelectorAll(".reveal").forEach(el => io.observe(el));
+</script>
+</body>
+</html>


### PR DESCRIPTION
## What

- **`site/`** — a static site (no build step) showcasing Stormlight and windrunner:
  - Landing page: light icy theme built from `internal/theme`'s Light pairs, an animated HTML recreation of the dashboard (working glow, waiting/urgent amber), sections for the design principles, the attention model, and windrunner as the engine underneath.
  - Docs section with a traditional documentation layout — sticky sidebar hierarchy, scrollspy section highlighting, prev/next pager — hand-rendered from `docs/architecture.md`, `docs/workspace-resolvers.md`, and the config design doc.
- **`pages.yml`** — deploys `site/` to GitHub Pages on pushes to `main` that touch it. All site links are relative, so the `trentkm.github.io/stormlight` subpath works.
- **`AGENTS.md`** — new section: the site's docs pages are hand-rendered, so PRs that materially change the docs must update the matching site page; semantic drift is the failure mode to watch.

## After merging

Pages needs its source set to **GitHub Actions** once (Settings → Pages), then the first deploy runs from this workflow.

🤖 Generated with [Claude Code](https://claude.com/claude-code)