### PR TITLE
Footer: hints only, always in the seam's color, dot-separated

### DIFF
--- a/internal/ui/chrome.go
+++ b/internal/ui/chrome.go
@@ -1,13 +1,15 @@
 package ui
 
-// The footer: gradient rules, status row, and key hints.
+// The footer: gradient rules and key hints.
 // Split from model.go; see #34.
 
 import (
+	"fmt"
 	"math"
 	"strings"
 
 	"charm.land/lipgloss/v2"
+	"github.com/charmbracelet/x/ansi"
 	"github.com/trentkm/stormlight/internal/theme"
 )
 
@@ -18,7 +20,6 @@ func (m Model) renderFooter() string {
 	if chord := m.chordHints(); chord != "" {
 		content = chord
 	} else {
-		hints := m.commandHints()
 		hintStyle := mutedStyle()
 		switch {
 		case m.terminalFocused():
@@ -31,11 +32,10 @@ func (m Model) renderFooter() string {
 			// the footer matches whichever side of the seam is lit.
 			hintStyle = lipgloss.NewStyle().Foreground(colorBand())
 		}
-		content = hintStyle.Render(truncate(hints, inner))
+		hints := renderHints(m.commandHints(), hintStyle)
+		content = ansi.Truncate(hints, inner, "…")
 		if m.err != nil {
-			content = renderFooterStatus(inner, m.err.Error(), hints, errorStyle())
-		} else if m.status != "Ready" {
-			content = renderFooterStatus(inner, m.status, hints, successStyle())
+			content = renderFooterError(inner, m.err.Error(), hints)
 		}
 	}
 	glint := lipgloss.NewStyle().
@@ -143,70 +143,116 @@ func (m Model) chordHints() string {
 	return strings.Join(parts, "  ")
 }
 
-func renderFooterStatus(
-	width int,
-	status string,
-	hints string,
-	statusStyle lipgloss.Style,
-) string {
-	available := max(1, width)
-	statusWidth := clamp(available/3, 8, 28)
-	hintWidth := available - statusWidth - 2
-	if hintWidth < 12 {
-		return mutedStyle().Render(truncate(hints, available))
+// renderHints paints each hint as one unit and sets a muted dot between
+// neighbors, so the row reads as separate key–action pairs instead of one
+// run-on line. The items arrive unstyled; the caller picks the ink.
+func renderHints(items []string, style lipgloss.Style) string {
+	separator := mutedStyle().Render(" · ")
+	rendered := make([]string, len(items))
+	for index, item := range items {
+		rendered[index] = style.Render(item)
 	}
-	renderedStatus := statusStyle.Render(truncate(status, statusWidth))
-	renderedHints := mutedStyle().Render(truncate(hints, hintWidth))
-	return renderedStatus + "  " + renderedHints
+	return strings.Join(rendered, separator)
 }
 
-func (m Model) commandHints() string {
+// renderFooterError lets an error talk over the left end of the hint row.
+// Errors are the one message that still shares the row — everything else
+// the footer used to announce either shows where it happens or rides in
+// the hints — and the hints keep their own ink beside it rather than
+// fading to gray.
+func renderFooterError(width int, message, hints string) string {
+	available := max(1, width)
+	messageWidth := clamp(available/3, 8, 28)
+	hintWidth := available - messageWidth - 2
+	if hintWidth < 12 {
+		return errorStyle().Render(truncate(message, available))
+	}
+	return errorStyle().Render(truncate(message, messageWidth)) +
+		"  " + ansi.Truncate(hints, hintWidth, "…")
+}
+
+// searchMatchLabel is the live position among search matches; it rides in
+// the hint row because the search has no other place to answer "which of
+// how many".
+func (m Model) searchMatchLabel() string {
+	if len(m.search.matches) == 0 {
+		return "no match"
+	}
+	return fmt.Sprintf("match %d/%d", m.search.index+1, len(m.search.matches))
+}
+
+func (m Model) commandHints() []string {
 	switch m.mode {
 	case modeCompose:
-		return "Enter send  Ctrl-j newline  Ctrl-v image  Esc cancel"
+		return []string{"Enter send", "Ctrl-j newline", "Ctrl-v image", "Esc cancel"}
 	case modeSearch:
-		return "type to search  Enter keep  n/N move  Esc cancel"
-	case modeDelete:
-		if m.activePane == paneWorkspaces &&
-			m.workspaceCursor >= 0 && m.workspaceCursor < len(m.groups) &&
-			len(m.groups[m.workspaceCursor].agents) > 0 {
-			return "X delete workspace and agents  Esc cancel"
+		hints := []string{"type to search", "Enter keep", "n/N move", "Esc cancel"}
+		if m.search.query != "" {
+			hints = append([]string{m.searchMatchLabel()}, hints[1:]...)
 		}
-		return "x confirm  Esc cancel"
+		return hints
+	case modeDelete:
+		// The confirmation names its victim here: the hint row is the
+		// prompt, so what x is about to delete has to be spelled out.
+		if m.activePane == paneWorkspaces &&
+			m.workspaceCursor >= 0 && m.workspaceCursor < len(m.groups) {
+			if count := len(m.groups[m.workspaceCursor].agents); count > 0 {
+				return []string{
+					fmt.Sprintf("X delete %s and %d agent(s)",
+						m.selectedWorkspaceLabel(), count),
+					"Esc cancel",
+				}
+			}
+			return []string{
+				"x remove " + m.selectedWorkspaceLabel(), "Esc cancel",
+			}
+		}
+		if selected, ok := m.selectedAgent(); ok {
+			return []string{
+				"x delete " + agentDisplayTitle(selected), "Esc cancel",
+			}
+		}
+		return []string{"x confirm", "Esc cancel"}
 	case modeDispatch:
 		switch m.formFocus {
 		case dispatchProvider:
-			hints := "j/k choose  Enter " + m.nextDispatchField() + "  m mode"
+			hints := []string{"j/k choose", "Enter " + m.nextDispatchField(), "m mode"}
 			if m.nvimPath != "" {
-				hints += "  e Neovim"
+				hints = append(hints, "e Neovim")
 			}
-			return hints + "  Esc cancel"
+			return append(hints, "Esc cancel")
 		case dispatchDirectory:
-			return "j/k location  Enter " + m.nextDispatchField() +
-				"  m mode  e edit path  Esc cancel"
+			return []string{
+				"j/k location", "Enter " + m.nextDispatchField(),
+				"m mode", "e edit path", "Esc cancel",
+			}
 		case dispatchCustomPath:
-			return "Enter choose  ↑/↓ pick  Backspace up  Tab " +
-				m.nextDispatchField() + "  Esc cancel"
+			return []string{
+				"Enter choose", "↑/↓ pick", "Backspace up",
+				"Tab " + m.nextDispatchField(), "Esc cancel",
+			}
 		case dispatchName:
-			return "name this agent  Enter " + m.nextDispatchField() +
-				"  Tab fields  Esc cancel"
+			return []string{
+				"name this agent", "Enter " + m.nextDispatchField(),
+				"Tab fields", "Esc cancel",
+			}
 		default:
 			// Enter launches, so the newline key has to be spelled out
 			// here — it is the one affordance in this field with nothing
 			// on screen to suggest it. The name row keeps its own label
 			// and cursor, and the line is only so wide.
-			hints := "Enter launch  Ctrl-j newline"
+			hints := []string{"Enter launch", "Ctrl-j newline"}
 			if m.nvimPath != "" {
-				hints += "  Ctrl-o Neovim"
+				hints = append(hints, "Ctrl-o Neovim")
 			}
-			return hints + "  Esc cancel"
+			return append(hints, "Esc cancel")
 		}
 	case modeAddWorkspace:
-		return "j/k select  Enter add  e edit path  Esc cancel"
+		return []string{"j/k select", "Enter add", "e edit path", "Esc cancel"}
 	case modeRename:
-		return "Enter apply  Esc cancel"
+		return []string{"Enter apply", "Esc cancel"}
 	case modeMark:
-		return "w in progress  a needs attention  c clear  Esc cancel"
+		return []string{"w in progress", "a needs attention", "c clear", "Esc cancel"}
 	}
 	rowMode := "z expand rows"
 	if m.rowsExpanded {
@@ -221,25 +267,36 @@ func (m Model) commandHints() string {
 	if m.activePane == paneInteraction {
 		if selected, ok := m.selectedAgent(); ok &&
 			selected.ProcessLive && selected.Attention.TerminalOwned() {
-			return "Enter answer in terminal  h agents  j/k scroll  M seen"
+			return []string{"Enter answer in terminal", "h agents", "j/k scroll", "M seen"}
 		}
+	}
+	appendCompact := func(hints []string, tail ...string) []string {
+		if rowMode != "" {
+			hints = append(hints, rowMode)
+		}
+		return append(hints, tail...)
 	}
 	switch m.activePane {
 	case paneAgents:
-		return strings.TrimSpace(
-			"h/l panes  j/k select  n new  m mark  M seen  , sort  " +
-				rowMode + "  Enter open",
+		return appendCompact(
+			[]string{"h/l panes", "j/k select", "n new", "m mark", "M seen", ", sort"},
+			"Enter open",
 		)
 	case paneInteraction:
 		if m.search.query != "" {
-			return "h agents  j/k scroll  n/N match  Esc clear  Enter open"
+			return []string{
+				"h agents", "j/k scroll", "n/N " + m.searchMatchLabel(),
+				"Esc clear", "Enter open",
+			}
 		}
-		return strings.TrimSpace(
-			"h agents  j/k scroll  i reply  / search  n new  " + rowMode + "  Enter open",
+		return appendCompact(
+			[]string{"h agents", "j/k scroll", "i reply", "/ search", "n new"},
+			"Enter open",
 		)
 	default:
-		return strings.TrimSpace(
-			"j/k select  l agents  n add  K info  , sort  " + rowMode + "  ? help  q quit",
+		return appendCompact(
+			[]string{"j/k select", "l agents", "n add", "K info", ", sort"},
+			"? help", "q quit",
 		)
 	}
 }

--- a/internal/ui/chrome.go
+++ b/internal/ui/chrome.go
@@ -17,6 +17,7 @@ func (m Model) renderFooter() string {
 	width := max(1, m.width-1)
 	inner := max(1, width-3)
 	var content string
+	rightAligned := false
 	if chord := m.chordHints(); chord != "" {
 		content = chord
 	} else {
@@ -36,16 +37,29 @@ func (m Model) renderFooter() string {
 		content = ansi.Truncate(hints, inner, "…")
 		if m.err != nil {
 			content = renderFooterError(inner, m.err.Error(), hints)
+		} else {
+			// The portal is the right pane, so its controls sit under it:
+			// the footer's alignment follows the seam the same way its
+			// color does.
+			rightAligned = m.terminalFocused()
 		}
 	}
-	glint := lipgloss.NewStyle().
+	glintStyle := lipgloss.NewStyle().
 		Foreground(theme.Color(theme.Pair{
 			Light: wordmarkStopsLight[1],
 			Dark:  wordmarkStopsDark[1],
-		})).
-		Render("✦ ")
+		}))
+	row := " " + glintStyle.Render("✦ ") + content
+	if rightAligned {
+		// A true mirror of the left layout: the hints lead and the glint
+		// caps the row at the outermost position, one column in.
+		if pad := inner - lipgloss.Width(content); pad > 0 {
+			row = strings.Repeat(" ", pad) + content +
+				glintStyle.Render(" ✦") + " "
+		}
+	}
 	return lipgloss.NewStyle().Width(width).MaxHeight(2).Render(
-		renderFooterRule(width) + "\n " + glint + content,
+		renderFooterRule(width) + "\n" + row,
 	)
 }
 

--- a/internal/ui/commands.go
+++ b/internal/ui/commands.go
@@ -89,18 +89,20 @@ func shimmerTickCmd() tea.Cmd {
 	})
 }
 
-func actionCmd(status string, action func(context.Context) error) tea.Cmd {
+// actionCmd runs a backend action; label names it in the failure log only —
+// the dashboard does not announce successes.
+func actionCmd(label string, action func(context.Context) error) tea.Cmd {
 	return func() tea.Msg {
 		ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
 		defer cancel()
 		err := action(ctx)
 		if err != nil {
 			diagnostic.Logger().Error("dashboard command failed",
-				"action", status,
+				"action", label,
 				"error", err,
 			)
 		}
-		return actionMsg{status: status, err: err}
+		return actionMsg{err: err}
 	}
 }
 
@@ -126,7 +128,7 @@ func dispatchCmd(backend Backend, request app.DispatchRequest) tea.Cmd {
 	return func() tea.Msg {
 		ctx, cancel := context.WithTimeout(context.Background(), 15*time.Second)
 		defer cancel()
-		managedAgent, err := backend.Dispatch(ctx, request)
+		_, err := backend.Dispatch(ctx, request)
 		if err != nil {
 			diagnostic.Logger().Error("dashboard dispatch failed",
 				"provider", request.Provider,
@@ -134,6 +136,6 @@ func dispatchCmd(backend Backend, request app.DispatchRequest) tea.Cmd {
 			)
 			return actionMsg{err: err}
 		}
-		return actionMsg{status: "Dispatched " + agentDisplayTitle(managedAgent)}
+		return actionMsg{}
 	}
 }

--- a/internal/ui/compose.go
+++ b/internal/ui/compose.go
@@ -66,7 +66,6 @@ func (m Model) updateCompose(msg tea.KeyPressMsg) (tea.Model, tea.Cmd) {
 		// conversation, Esc leaves it.
 		m.sendInput.SetValue("")
 		m.syncComposerSize()
-		m.status = "Sending to " + selected.Name
 		return m, actionCmd("Message sent", func(ctx context.Context) error {
 			return m.backend.Send(ctx, selected.ID, text)
 		})
@@ -83,7 +82,6 @@ func (m Model) updateCompose(msg tea.KeyPressMsg) (tea.Model, tea.Cmd) {
 func (m Model) closeComposer() Model {
 	m.mode = modeNormal
 	m.sendInput.Blur()
-	m.status = "Ready"
 	return m
 }
 

--- a/internal/ui/dispatch.go
+++ b/internal/ui/dispatch.go
@@ -66,7 +66,6 @@ func (m Model) dispatchKey(msg tea.KeyPressMsg) (tea.Model, tea.Cmd) {
 	case "esc", "ctrl+c", "ctrl+[":
 		m.mode = modeNormal
 		m.blurForm()
-		m.status = "Ready"
 		return m, nil
 	case "tab":
 		m.moveDispatchFocus(1)
@@ -385,7 +384,7 @@ func (m Model) renderDispatchAt(width, height int) string {
 		tail = append(tail, "")
 	}
 	tail = append(tail,
-		"  "+mutedStyle().Render(truncate(m.commandHints(), contentWidth)),
+		"  "+ansi.Truncate(renderHints(m.commandHints(), mutedStyle()), contentWidth, "…"),
 	)
 
 	return strings.Join(
@@ -1165,7 +1164,6 @@ func (m Model) submitDispatch() (tea.Model, tea.Cmd) {
 	}
 	m.mode = modeNormal
 	m.blurForm()
-	m.status = "Dispatching " + m.providers[m.providerIndex].Label
 	m.taskInput.SetValue("")
 	m.nameInput.SetValue("")
 	return m, dispatchCmd(m.backend, request)
@@ -1209,7 +1207,6 @@ func (m Model) beginDispatch(chooseDirectory bool) (tea.Model, tea.Cmd) {
 	m.focusForm()
 	m.syncTaskComposerSize()
 	m.err = nil
-	m.status = "New agent"
 	return m, nil
 }
 

--- a/internal/ui/flows_test.go
+++ b/internal/ui/flows_test.go
@@ -112,11 +112,13 @@ func TestDeleteFlowGuardsWorkspaceWithAgents(t *testing.T) {
 	model.activePane = paneWorkspaces
 	model.mode = modeDelete
 
-	next, _ := model.updateDelete(runeKey("x"))
+	next, cmdX := model.updateDelete(runeKey("x"))
 	model = next.(Model)
-	if model.mode != modeDelete || !strings.Contains(model.status, "press X") {
-		t.Fatalf("x skipped the agent guard: mode=%d status=%q",
-			model.mode, model.status)
+	if model.mode != modeDelete || cmdX != nil {
+		t.Fatalf("x skipped the agent guard: mode=%d", model.mode)
+	}
+	if hints := strings.Join(model.commandHints(), " "); !strings.Contains(hints, "X delete") {
+		t.Fatalf("hint row does not ask for X: %q", hints)
 	}
 
 	next, cmd := model.updateDelete(runeKey("X"))
@@ -567,13 +569,13 @@ func TestDispatchNameAcceptsTypedRunes(t *testing.T) {
 func TestDispatchHintsNameTheNextField(t *testing.T) {
 	model := dispatchFixture(t)
 	model.mode = modeDispatch
-	if hints := model.commandHints(); !strings.Contains(hints, "Enter name") {
+	if hints := strings.Join(model.commandHints(), " "); !strings.Contains(hints, "Enter name") {
 		t.Fatalf("directory hints hide the name field: %q", hints)
 	}
 	selectCustomDirectory(t, &model)
 	next, _ := model.updateDispatch(tea.KeyPressMsg{Code: tea.KeyEnter})
 	model = next.(Model)
-	if hints := model.commandHints(); !strings.Contains(hints, "Tab name") {
+	if hints := strings.Join(model.commandHints(), " "); !strings.Contains(hints, "Tab name") {
 		t.Fatalf("picker hints hide the way out: %q", hints)
 	}
 }

--- a/internal/ui/input_test.go
+++ b/internal/ui/input_test.go
@@ -795,16 +795,26 @@ func TestAddWorkspaceOnlyOffersNewDirectoryActions(t *testing.T) {
 	assertViewFitsPane(t, model, 100, 28)
 }
 
-func TestFooterKeepsCommandsVisibleWithStatus(t *testing.T) {
+func TestFooterKeepsCommandsVisibleWithError(t *testing.T) {
 	model := NewModel(stubBackend{})
 	model.width = 100
-	model.status = "Workspace added"
+	model.err = errors.New("attach failed")
 
 	footer := ansi.Strip(model.renderFooter())
-	if !strings.Contains(footer, "Workspace added") ||
+	if !strings.Contains(footer, "attach failed") ||
 		!strings.Contains(footer, "j/k select") ||
 		!strings.Contains(footer, "n add") {
-		t.Fatalf("status displaced contextual commands: %q", footer)
+		t.Fatalf("error displaced contextual commands: %q", footer)
+	}
+}
+
+func TestFooterSeparatesHints(t *testing.T) {
+	model := NewModel(stubBackend{})
+	model.width = 100
+
+	footer := ansi.Strip(model.renderFooter())
+	if !strings.Contains(footer, "j/k select · l agents") {
+		t.Fatalf("hints are not dot-separated: %q", footer)
 	}
 }
 
@@ -828,7 +838,7 @@ func TestFooterShowsOnlyChordOptionsWhilePending(t *testing.T) {
 	updated, _ = model.updateNormal(runeKey("n"))
 	model = updated.(Model)
 	footer = ansi.Strip(model.renderFooter())
-	if !strings.Contains(footer, "Sorted by name") ||
+	if strings.Contains(footer, "Sort:") ||
 		!strings.Contains(footer, "j/k select") {
 		t.Fatalf("resolved chord did not restore normal footer: %q", footer)
 	}
@@ -990,7 +1000,7 @@ func TestRowDensityTogglesWithoutHidingPanes(t *testing.T) {
 		!strings.Contains(header, "Agents") {
 		t.Fatalf("density toggle hid dashboard panes: %q", header)
 	}
-	if !strings.Contains(model.commandHints(), "z compact rows") {
+	if !slices.Contains(model.commandHints(), "z compact rows") {
 		t.Fatalf("expanded hint = %q", model.commandHints())
 	}
 
@@ -1104,9 +1114,6 @@ func TestProviderSelectorDispatchesHighlightedProvider(t *testing.T) {
 	}
 	if backend.request.Provider != agent.ProviderCodex {
 		t.Fatalf("dispatched provider = %q, want codex", backend.request.Provider)
-	}
-	if model.status != "Dispatching Codex" {
-		t.Fatalf("status = %q", model.status)
 	}
 }
 
@@ -1724,9 +1731,6 @@ func TestSortChordChangesMode(t *testing.T) {
 	if model.sortMode != sortByAttention {
 		t.Fatalf("sort mode = %v, want attention", model.sortMode)
 	}
-	if !strings.Contains(model.status, "attention") {
-		t.Fatalf("status = %q", model.status)
-	}
 }
 
 func TestHierarchyConnectorBridgesDifferentRows(t *testing.T) {
@@ -2021,8 +2025,8 @@ func TestEnterOpensSelectedAgentTerminal(t *testing.T) {
 
 	updated, cmd := model.updateNormal(tea.KeyPressMsg{Code: tea.KeyEnter})
 	model = updated.(Model)
-	if cmd == nil || model.status != "Opening agent-one" {
-		t.Fatalf("terminal open was not started: status=%q", model.status)
+	if cmd == nil {
+		t.Fatal("terminal open was not started")
 	}
 	message := cmd()
 	attached, ok := message.(attachMsg)
@@ -2272,7 +2276,6 @@ func TestAddWorkspaceCommandUpdatesDashboard(t *testing.T) {
 func TestActionErrorSurvivesSuccessfulRefresh(t *testing.T) {
 	model := NewModel(stubBackend{})
 	model.err = errors.New("attach failed")
-	model.status = "Action failed"
 
 	updated, _ := model.Update(dashboardMsg{})
 	model = updated.(Model)
@@ -2282,8 +2285,8 @@ func TestActionErrorSurvivesSuccessfulRefresh(t *testing.T) {
 
 	updated, _ = model.Update(runeKey("j"))
 	model = updated.(Model)
-	if model.err != nil || model.status != "Ready" {
-		t.Fatalf("key did not clear action error: err=%v status=%q", model.err, model.status)
+	if model.err != nil {
+		t.Fatalf("key did not clear action error: err=%v", model.err)
 	}
 }
 

--- a/internal/ui/layout.go
+++ b/internal/ui/layout.go
@@ -645,7 +645,6 @@ func (m Model) resizeColumns(key string) (tea.Model, tea.Cmd) {
 	interactionWidth, contentHeight := m.interactionDimensions()
 	m.interaction.SetWidth(interactionWidth)
 	m.interaction.SetHeight(contentHeight)
-	m.status = fmt.Sprintf("Columns %d · %d · %d", afterW, afterA, afterI)
 	if m.ptyEnabled {
 		return m, m.ensurePTYCmd()
 	}

--- a/internal/ui/marks.go
+++ b/internal/ui/marks.go
@@ -65,7 +65,6 @@ func (m Model) beginMark() (tea.Model, tea.Cmd) {
 	m.markIndex = markChoiceIndex(selected.EffectiveMark())
 	m.mode = modeMark
 	m.err = nil
-	m.status = "Mark " + agentDisplayTitle(selected)
 	return m, nil
 }
 
@@ -74,7 +73,6 @@ func (m Model) updateMark(msg tea.KeyPressMsg) (tea.Model, tea.Cmd) {
 	switch key {
 	case "esc", "ctrl+c", "ctrl+[":
 		m.mode = modeNormal
-		m.status = "Ready"
 		return m, nil
 	case "j", "down":
 		m.markIndex = clamp(m.markIndex+1, 0, len(markChoices)-1)
@@ -97,22 +95,20 @@ func (m Model) submitMark(mark agent.Mark) (tea.Model, tea.Cmd) {
 	m.mode = modeNormal
 	id := m.markAgentID
 	if id == "" {
-		m.status = "Ready"
 		return m, nil
 	}
 	// Apply locally first so the row reports the human's reading on the very
 	// next frame; the backend write follows.
 	m.applyMark(id, mark)
-	status := "Marked in progress"
+	label := "Marked in progress"
 	switch mark {
 	case agent.MarkAttention:
-		status = "Marked needs attention"
+		label = "Marked needs attention"
 	case agent.MarkNone:
-		status = "Mark cleared"
+		label = "Mark cleared"
 	}
-	m.status = status
 	backend := m.backend
-	return m, actionCmd(status, func(ctx context.Context) error {
+	return m, actionCmd(label, func(ctx context.Context) error {
 		return backend.SetMark(ctx, id, mark)
 	})
 }

--- a/internal/ui/modals.go
+++ b/internal/ui/modals.go
@@ -24,18 +24,12 @@ func (m Model) updateDelete(msg tea.KeyPressMsg) (tea.Model, tea.Cmd) {
 				m.mode = modeNormal
 				return m, nil
 			}
-			if count := len(m.groups[m.workspaceCursor].agents); count > 0 {
+			if len(m.groups[m.workspaceCursor].agents) > 0 {
 				// Deleting agents needs the deliberate keystroke; stay in
-				// the confirmation and say so.
-				m.status = fmt.Sprintf(
-					"%s has %d agent(s) — press X to delete everything",
-					m.selectedWorkspaceLabel(),
-					count,
-				)
+				// the confirmation — the hint row is already asking for X.
 				return m, nil
 			}
 			m.mode = modeNormal
-			m.status = "Removing " + selected.Name
 			return m, actionCmd("Workspace removed", func(ctx context.Context) error {
 				return m.backend.RemoveWorkspace(ctx, selected)
 			})
@@ -45,7 +39,6 @@ func (m Model) updateDelete(msg tea.KeyPressMsg) (tea.Model, tea.Cmd) {
 		if !ok {
 			return m, nil
 		}
-		m.status = "Deleting " + agentDisplayTitle(selected)
 		return m, actionCmd("Agent deleted", func(ctx context.Context) error {
 			return m.backend.Delete(ctx, selected.ID)
 		})
@@ -59,9 +52,7 @@ func (m Model) updateDelete(msg tea.KeyPressMsg) (tea.Model, tea.Cmd) {
 			return m, nil
 		}
 		doomed := slices.Clone(m.groups[m.workspaceCursor].agents)
-		label := m.selectedWorkspaceLabel()
 		m.mode = modeNormal
-		m.status = fmt.Sprintf("Deleting %s and %d agent(s)", label, len(doomed))
 		backend := m.backend
 		return m, actionCmd("Workspace and agents deleted",
 			func(ctx context.Context) error {
@@ -78,7 +69,6 @@ func (m Model) updateDelete(msg tea.KeyPressMsg) (tea.Model, tea.Cmd) {
 			})
 	case "n", "esc", "ctrl+c", "ctrl+[":
 		m.mode = modeNormal
-		m.status = "Ready"
 	}
 	return m, nil
 }
@@ -222,7 +212,6 @@ func (m Model) beginRename() (tea.Model, tea.Cmd) {
 	m.renameInput.Focus()
 	m.mode = modeRename
 	m.err = nil
-	m.status = "Rename"
 	return m, nil
 }
 
@@ -230,7 +219,6 @@ func (m Model) updateRename(msg tea.KeyPressMsg) (tea.Model, tea.Cmd) {
 	switch msg.String() {
 	case "esc", "ctrl+c", "ctrl+[":
 		m.mode = modeNormal
-		m.status = "Ready"
 		return m, nil
 	case "enter":
 		name := strings.TrimSpace(m.renameInput.Value())
@@ -242,13 +230,11 @@ func (m Model) updateRename(msg tea.KeyPressMsg) (tea.Model, tea.Cmd) {
 		backend := m.backend
 		if m.renameAgentID != "" {
 			id := m.renameAgentID
-			m.status = "Renaming agent"
 			return m, actionCmd("Agent renamed", func(ctx context.Context) error {
 				return backend.Rename(ctx, id, name)
 			})
 		}
 		target := m.renameWorkspace
-		m.status = "Renaming workspace"
 		return m, actionCmd("Workspace renamed", func(ctx context.Context) error {
 			return backend.RenameWorkspace(ctx, target, name)
 		})

--- a/internal/ui/model.go
+++ b/internal/ui/model.go
@@ -179,7 +179,6 @@ type Model struct {
 
 	interactionID       string
 	interactionLoadedAt time.Time
-	status              string
 	err                 error
 	shimmerPhase        int
 	shimmerRunning      bool
@@ -233,8 +232,7 @@ type interactionMsg struct {
 }
 
 type actionMsg struct {
-	status string
-	err    error
+	err error
 }
 
 type attachMsg struct {
@@ -335,7 +333,6 @@ func NewModelWithOptions(backend Backend, options Options) Model {
 		modeForDir:         options.ModeForDir,
 		providerForDir:     options.ProviderForDir,
 		shimmerRunning:     true,
-		status:             "Ready",
 		columns:            options.Columns,
 		ptyEnabled:         true,
 		ptyManager:         ptyview.NewManager(backend),
@@ -455,7 +452,6 @@ func (m Model) Update(message tea.Msg) (tea.Model, tea.Cmd) {
 					// the box.
 					m.mode = modeNormal
 					m.sendInput.Blur()
-					m.status = "Agent needs input"
 				}
 			}
 		}
@@ -471,15 +467,6 @@ func (m Model) Update(message tea.Msg) (tea.Model, tea.Cmd) {
 		if !m.ptyEnabled && m.shouldReloadInteraction(previous) {
 			m.interactionLoadedAt = time.Now()
 			cmds = append(cmds, m.loadInteractionCmd())
-		}
-		if m.ptyEnabled {
-			if selected, ok := m.selectedAgent(); ok &&
-				!selected.ProcessLive && previous.ProcessLive &&
-				selected.ID == previous.ID {
-				// remain-on-exit keeps the pane, so the frame freezes on
-				// the death screen; say why nothing moves anymore.
-				m.status = "Process exited — terminal view frozen"
-			}
 		}
 		return m, tea.Batch(cmds...)
 
@@ -532,7 +519,6 @@ func (m Model) Update(message tea.Msg) (tea.Model, tea.Cmd) {
 	case attachMsg:
 		if msg.err != nil {
 			m.err = msg.err
-			m.status = "Action failed"
 			diagnostic.Logger().Error("dashboard open failed",
 				"agent", msg.name,
 				"error", msg.err,
@@ -540,7 +526,6 @@ func (m Model) Update(message tea.Msg) (tea.Model, tea.Cmd) {
 			return m, nil
 		}
 		if msg.result.Command != nil {
-			m.status = "Opening " + msg.name
 			return m, tea.ExecProcess(msg.result.Command, func(err error) tea.Msg {
 				if err != nil {
 					diagnostic.Logger().Error("external attach failed",
@@ -552,16 +537,10 @@ func (m Model) Update(message tea.Msg) (tea.Model, tea.Cmd) {
 			})
 		}
 		m.err = nil
-		m.status = "Attached"
 		return m, nil
 
 	case attachReturnedMsg:
 		m.err = msg.err
-		if msg.err != nil {
-			m.status = "Action failed"
-		} else {
-			m.status = "Returned from " + msg.name
-		}
 		// The attached client owned the window sizes while it looked;
 		// reassert the herd's 1:1 grid now that the dashboard is back.
 		return m, tea.Batch(m.refreshCmd(), resizeAllPTYCmd(m.ptyManager))
@@ -569,31 +548,21 @@ func (m Model) Update(message tea.Msg) (tea.Model, tea.Cmd) {
 	case actionMsg:
 		m.err = msg.err
 		if msg.err != nil {
-			m.status = "Action failed"
 			diagnostic.Logger().Error("dashboard action failed", "error", msg.err)
-		} else {
-			m.status = msg.status
 		}
 		return m, m.refreshCmd()
 
 	case directoryPickedMsg:
 		if msg.err != nil {
 			m.err = msg.err
-			m.status = "Action failed"
 			diagnostic.Logger().Error("directory picker failed", "error", msg.err)
 			return m, nil
 		}
 		if msg.path == "" {
-			if m.mode == modeAddWorkspace {
-				m.status = "Add workspace"
-			} else {
-				m.status = "New agent"
-			}
 			return m, nil
 		}
 		if m.mode == modeAddWorkspace {
 			m.cwdInput.SetValue(msg.path)
-			m.status = "Adding workspace"
 			return m, addWorkspaceCmd(m.backend, msg.path)
 		}
 		m.prepareDirectoryChoices(msg.path)
@@ -601,13 +570,11 @@ func (m Model) Update(message tea.Msg) (tea.Model, tea.Cmd) {
 		m.formFocus = dispatchTask
 		m.focusForm()
 		m.syncTaskComposerSize()
-		m.status = "Directory selected"
 		return m, nil
 
 	case taskEditedMsg:
 		if msg.err != nil {
 			m.err = msg.err
-			m.status = "Action failed"
 			diagnostic.Logger().Error("task editor failed", "error", msg.err)
 			return m, nil
 		}
@@ -616,13 +583,11 @@ func (m Model) Update(message tea.Msg) (tea.Model, tea.Cmd) {
 		m.focusForm()
 		m.syncTaskComposerSize()
 		m.err = nil
-		m.status = "Task updated"
 		return m, nil
 
 	case workspaceAddedMsg:
 		if msg.err != nil {
 			m.err = msg.err
-			m.status = "Action failed"
 			diagnostic.Logger().Error("add workspace failed", "error", msg.err)
 			return m, nil
 		}
@@ -631,7 +596,6 @@ func (m Model) Update(message tea.Msg) (tea.Model, tea.Cmd) {
 		m.catalogWorkspaces = appendWorkspace(m.catalogWorkspaces, msg.value)
 		m.rebuildGroups(msg.value.ID, "")
 		m.activePane = paneWorkspaces
-		m.status = "Workspace added"
 		return m, nil
 
 	case overlayOpenedMsg:
@@ -669,12 +633,7 @@ func (m Model) Update(message tea.Msg) (tea.Model, tea.Cmd) {
 		return m.updatePaste(msg)
 
 	case tea.KeyPressMsg:
-		if m.err != nil {
-			m.err = nil
-			if m.status == "Action failed" {
-				m.status = "Ready"
-			}
-		}
+		m.err = nil
 		if m.overlay != nil {
 			// The floating program owns the keyboard while it is up;
 			// ctrl+q cancels it.
@@ -707,7 +666,6 @@ func (m Model) Update(message tea.Msg) (tea.Model, tea.Cmd) {
 		case modeInfo, modeHelp:
 			// Any key dismisses an informational overlay.
 			m.mode = modeNormal
-			m.status = "Ready"
 			return m, nil
 		default:
 			// Reading the result is the presence proof: if an unseen result
@@ -810,12 +768,10 @@ func (m Model) updateNormal(msg tea.KeyPressMsg) (tea.Model, tea.Cmd) {
 		case "c":
 			mode = sortByCreated
 		default:
-			m.status = "Sort unchanged"
 			return m, nil
 		}
 		m.sortMode = mode
 		m.rebuildGroups(m.selectedWorkspaceID(), m.selectedAgentID())
-		m.status = "Sorted by " + mode.label()
 		return m, m.interactionFollowCmd()
 	}
 	if m.normalPrefix == "g" {
@@ -845,7 +801,6 @@ func (m Model) updateNormal(msg tea.KeyPressMsg) (tea.Model, tea.Cmd) {
 		// of the display, via an interactive attachment.
 		if selected, ok := m.selectedAgent(); ok {
 			displayTitle := agentDisplayTitle(selected)
-			m.status = "Opening " + displayTitle
 			return m, attachCmd(m.backend, selected.ID, displayTitle)
 		}
 	case "j", "down":
@@ -898,7 +853,6 @@ func (m Model) updateNormal(msg tea.KeyPressMsg) (tea.Model, tea.Cmd) {
 			m.ptyEnabled = true
 			m.ptyZoom = true
 			m.activePane = paneInteraction
-			m.status = "Ready"
 			return m, tea.Batch(m.ensurePTYCmd(), m.armPTYWait())
 		}
 		return m, nil
@@ -907,7 +861,6 @@ func (m Model) updateNormal(msg tea.KeyPressMsg) (tea.Model, tea.Cmd) {
 		if m.ptyEnabled {
 			if _, ok := m.selectedAgent(); ok {
 				m.activePane = paneInteraction
-				m.status = "Ready"
 				return m, m.armPTYWait()
 			}
 		}
@@ -924,14 +877,12 @@ func (m Model) updateNormal(msg tea.KeyPressMsg) (tea.Model, tea.Cmd) {
 			// zoomed version.
 			if _, ok := m.selectedAgent(); ok {
 				m.activePane = paneInteraction
-				m.status = "Ready"
 				return m, m.armPTYWait()
 			}
 			return m, nil
 		}
 		if selected, ok := m.selectedAgent(); ok {
 			displayTitle := agentDisplayTitle(selected)
-			m.status = "Opening " + displayTitle
 			return m, attachCmd(m.backend, selected.ID, displayTitle)
 		}
 	case "/":
@@ -960,7 +911,6 @@ func (m Model) updateNormal(msg tea.KeyPressMsg) (tea.Model, tea.Cmd) {
 		}
 		if m.activePane == paneInteraction && m.search.query != "" {
 			m.clearSearch()
-			m.status = "Ready"
 			return m, nil
 		}
 	case "o":
@@ -970,7 +920,6 @@ func (m Model) updateNormal(msg tea.KeyPressMsg) (tea.Model, tea.Cmd) {
 			// The live terminal is the composer; walking in is replying.
 			if _, ok := m.selectedAgent(); ok {
 				m.activePane = paneInteraction
-				m.status = "Ready"
 				return m, m.armPTYWait()
 			}
 			return m, nil
@@ -995,38 +944,27 @@ func (m Model) updateNormal(msg tea.KeyPressMsg) (tea.Model, tea.Cmd) {
 		}
 	case "x":
 		if selected, ok := m.selectedAgent(); ok {
-			m.status = "Interrupting " + agentDisplayTitle(selected)
 			return m, actionCmd("Interrupted", func(ctx context.Context) error {
 				return m.backend.Interrupt(ctx, selected.ID)
 			})
 		}
 	case "ctrl+x":
+		// The hint row names the victim while modeDelete holds; nothing
+		// else to announce here.
 		if m.activePane == paneWorkspaces {
-			selected, ok := m.selectedWorkspace()
-			if !ok {
+			if _, ok := m.selectedWorkspace(); !ok {
 				return m, nil
 			}
 			m.mode = modeDelete
 			m.err = nil
-			if count := len(m.groups[m.workspaceCursor].agents); count > 0 {
-				m.status = fmt.Sprintf(
-					"Delete %s and %d agent(s)? press X",
-					m.selectedWorkspaceLabel(),
-					count,
-				)
-			} else {
-				m.status = "Remove " + selected.Name + "? press again"
-			}
 			return m, nil
 		}
-		if selected, ok := m.selectedAgent(); ok {
+		if _, ok := m.selectedAgent(); ok {
 			m.mode = modeDelete
 			m.err = nil
-			m.status = "Delete " + agentDisplayTitle(selected) + "? press again"
 			return m, nil
 		}
 	case "r", "ctrl+l":
-		m.status = "Refreshing"
 		return m, tea.Batch(m.refreshCmd(), m.loadInteractionCmd())
 	case "R":
 		return m.beginRename()
@@ -1038,7 +976,6 @@ func (m Model) updateNormal(msg tea.KeyPressMsg) (tea.Model, tea.Cmd) {
 		if m.activePane == paneWorkspaces {
 			if _, ok := m.selectedWorkspace(); ok {
 				m.mode = modeInfo
-				m.status = "Workspace info"
 			}
 			return m, nil
 		}
@@ -1046,7 +983,6 @@ func (m Model) updateNormal(msg tea.KeyPressMsg) (tea.Model, tea.Cmd) {
 		return m.beginHistory()
 	case "?":
 		m.mode = modeHelp
-		m.status = "Keys"
 		return m, nil
 	}
 

--- a/internal/ui/overlays.go
+++ b/internal/ui/overlays.go
@@ -72,7 +72,6 @@ func (m *Model) openOverlay(spec overlaySpec) tea.Cmd {
 		Rows: max(2, outerHeight-2),
 	}
 	backend := m.backend
-	m.status = "Opening " + strings.TrimSpace(spec.title)
 	return func() tea.Msg {
 		ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
 		defer cancel()
@@ -93,7 +92,6 @@ func (m Model) handleOverlayOpened(msg overlayOpenedMsg) (tea.Model, tea.Cmd) {
 	if msg.err != nil {
 		msg.spec.cleanup()
 		m.err = msg.err
-		m.status = "Action failed"
 		return m, nil
 	}
 	if msg.generation != m.overlayGeneration || m.overlay != nil {
@@ -157,7 +155,6 @@ func (m Model) cancelOverlay() (tea.Model, tea.Cmd) {
 	view := m.overlay
 	m.overlay = nil
 	m.overlayGeneration++
-	m.status = "Cancelled"
 	return m, func() tea.Msg {
 		view.widget.Close()
 		view.spec.cleanup()
@@ -190,7 +187,6 @@ func (m Model) overlayCursor() *tea.Cursor {
 func (m Model) openTaskEditor() (tea.Model, tea.Cmd) {
 	if m.nvimPath == "" {
 		m.err = fmt.Errorf("Neovim is not installed or not on PATH")
-		m.status = "Action failed"
 		return m, nil
 	}
 	cwd := strings.TrimSpace(m.cwdInput.Value())
@@ -200,7 +196,6 @@ func (m Model) openTaskEditor() (tea.Model, tea.Cmd) {
 	spec, err := taskEditorSpec(m.nvimPath, cwd, m.taskInput.Value())
 	if err != nil {
 		m.err = err
-		m.status = "Action failed"
 		return m, nil
 	}
 	return m, m.openOverlay(spec)
@@ -258,7 +253,6 @@ func taskEditorSpec(binary, cwd, task string) (overlaySpec, error) {
 func (m Model) openYazi() (tea.Model, tea.Cmd) {
 	if m.yaziPath == "" {
 		m.err = fmt.Errorf("yazi is not installed or not on PATH")
-		m.status = "Action failed"
 		return m, nil
 	}
 	start := strings.TrimSpace(m.pickerStart)
@@ -271,7 +265,6 @@ func (m Model) openYazi() (tea.Model, tea.Cmd) {
 	spec, err := yaziPickerSpec(m.yaziPath, start)
 	if err != nil {
 		m.err = err
-		m.status = "Action failed"
 		return m, nil
 	}
 	return m, m.openOverlay(spec)

--- a/internal/ui/ptykeys.go
+++ b/internal/ui/ptykeys.go
@@ -29,7 +29,6 @@ func (m Model) updateTerminalKey(msg tea.KeyPressMsg) (tea.Model, tea.Cmd) {
 		// with it, so it always lands back on the roster.
 		m.ptyZoom = false
 		m.activePane = paneAgents
-		m.status = "Ready"
 		return m, m.ensurePTYCmd()
 	case slices.Contains(m.keys.AgentsNext, key):
 		// Switch agents without stepping out: the portal swaps terminals

--- a/internal/ui/ptymode.go
+++ b/internal/ui/ptymode.go
@@ -201,7 +201,6 @@ func (m Model) jumpQueue(step agent.QueueStep) (tea.Model, tea.Cmd) {
 	queue := agent.Queue(m.agents)
 	next, ok := agent.StepInQueue(queue, m.selectedAgentID(), step)
 	if !ok {
-		m.status = "Nobody is waiting on you"
 		return m, nil
 	}
 	m.rebuildGroups(next.Workspace.ID, next.ID)
@@ -223,12 +222,10 @@ func (m *Model) interactionFollowCmd() tea.Cmd {
 func (m *Model) togglePTY() tea.Cmd {
 	if m.ptyEnabled {
 		m.ptyEnabled = false
-		m.status = "Ready"
 		return m.loadInteractionCmd()
 	}
 	m.ptyEnabled = true
 	m.activePane = paneInteraction
-	m.status = "Ready"
 	return m.armPTYWait()
 }
 
@@ -248,15 +245,17 @@ func (m Model) renderPTYInteraction(managedAgent agent.Agent, _, _ int) string {
 	return grid
 }
 
-func (m Model) terminalHints() string {
+func (m Model) terminalHints() []string {
 	if widget, ok := m.selectedPTY(); ok && widget.Scrolled() > 0 {
-		return fmt.Sprintf("scrolled %d lines up — wheel down to follow", widget.Scrolled())
+		return []string{fmt.Sprintf(
+			"scrolled %d lines up — wheel down to follow", widget.Scrolled())}
 	}
-	return fmt.Sprintf(
-		"ctrl+space out  %s agents  %s queue  %s zoom",
-		chordPair(m.keys.AgentsNext, m.keys.AgentsPrevious),
-		chordPair(m.keys.QueueNext, m.keys.QueuePrevious),
-		chordName(m.keys.Zoom[0]))
+	return []string{
+		"ctrl+space out",
+		chordPair(m.keys.AgentsNext, m.keys.AgentsPrevious) + " agents",
+		chordPair(m.keys.QueueNext, m.keys.QueuePrevious) + " queue",
+		chordName(m.keys.Zoom[0]) + " zoom",
+	}
 }
 
 // renderTerminalBar is the window bar over the terminal grid, and the only

--- a/internal/ui/ptymode_test.go
+++ b/internal/ui/ptymode_test.go
@@ -14,7 +14,7 @@ func TestTerminalControlsReplaceDashboardFooterHints(t *testing.T) {
 		width:      120,
 		keys:       defaultKeyBindings(),
 	}
-	hints := model.commandHints()
+	hints := strings.Join(model.commandHints(), " ")
 	for _, want := range []string{"ctrl+space out", "+j/k agents", "+n/p queue", "+z zoom"} {
 		if !strings.Contains(hints, want) {
 			t.Fatalf("terminal footer hints missing %q: %q", want, hints)

--- a/internal/ui/search.go
+++ b/internal/ui/search.go
@@ -1,7 +1,6 @@
 package ui
 
 import (
-	"fmt"
 	"strings"
 
 	tea "charm.land/bubbletea/v2"
@@ -115,7 +114,6 @@ func (m *Model) beginSearch() {
 	m.search.matches = nil
 	m.search.index = 0
 	m.search.anchor = m.interaction.YOffset()
-	m.status = "Search"
 }
 
 // clearSearch drops the query and repaints the transcript unhighlighted.
@@ -173,21 +171,16 @@ func (m *Model) seekSearchFromAnchor() {
 	}
 }
 
-// jumpSearchMatch moves n/N style through the matches, wrapping at the ends.
+// jumpSearchMatch moves n/N style through the matches, wrapping at the
+// ends. The hint row reports the position (see searchMatchLabel).
 func (m *Model) jumpSearchMatch(delta int) {
 	count := len(m.search.matches)
 	if count == 0 {
-		m.status = "No match: " + m.search.query
 		return
 	}
 	m.search.index = (m.search.index + delta + count) % count
 	m.repaintSearch()
 	m.centerSearchMatch()
-	m.status = m.searchPosition()
-}
-
-func (m Model) searchPosition() string {
-	return fmt.Sprintf("Match %d/%d", m.search.index+1, len(m.search.matches))
 }
 
 // updateSearch drives the prompt: matching narrows live, Enter keeps the
@@ -199,21 +192,13 @@ func (m Model) updateSearch(msg tea.KeyPressMsg) (tea.Model, tea.Cmd) {
 		m.search.input.Blur()
 		m.clearSearch()
 		m.interaction.SetYOffset(m.search.anchor)
-		m.status = "Ready"
 		return m, nil
 	case "enter":
 		m.mode = modeNormal
 		m.search.input.Blur()
 		if m.search.query == "" {
 			m.clearSearch()
-			m.status = "Ready"
-			return m, nil
 		}
-		if len(m.search.matches) == 0 {
-			m.status = "No match: " + m.search.query
-			return m, nil
-		}
-		m.status = m.searchPosition()
 		return m, nil
 	}
 	m.search.input = m.search.input.Update(msg)

--- a/internal/ui/search_test.go
+++ b/internal/ui/search_test.go
@@ -89,8 +89,9 @@ func TestSlashSearchFlowMatchesJumpsAndClears(t *testing.T) {
 
 	next, _ = model.updateSearch(tea.KeyPressMsg{Code: tea.KeyEnter})
 	model = next.(Model)
-	if model.mode != modeNormal || model.status != "Match 1/2" {
-		t.Fatalf("confirm state: mode=%d status=%q", model.mode, model.status)
+	if model.mode != modeNormal || model.searchMatchLabel() != "match 1/2" {
+		t.Fatalf("confirm state: mode=%d label=%q",
+			model.mode, model.searchMatchLabel())
 	}
 	if !strings.Contains(model.searchDecorated(), "\x1b[7m") {
 		t.Fatal("transcript is not highlighted after confirm")
@@ -98,18 +99,18 @@ func TestSlashSearchFlowMatchesJumpsAndClears(t *testing.T) {
 
 	updated, _ = model.updateNormal(runeKey("n"))
 	model = updated.(Model)
-	if model.status != "Match 2/2" {
-		t.Fatalf("n did not advance: %q", model.status)
+	if model.searchMatchLabel() != "match 2/2" {
+		t.Fatalf("n did not advance: %q", model.searchMatchLabel())
 	}
 	updated, _ = model.updateNormal(runeKey("n"))
 	model = updated.(Model)
-	if model.status != "Match 1/2" {
-		t.Fatalf("n did not wrap: %q", model.status)
+	if model.searchMatchLabel() != "match 1/2" {
+		t.Fatalf("n did not wrap: %q", model.searchMatchLabel())
 	}
 	updated, _ = model.updateNormal(runeKey("N"))
 	model = updated.(Model)
-	if model.status != "Match 2/2" {
-		t.Fatalf("N did not go back: %q", model.status)
+	if model.searchMatchLabel() != "match 2/2" {
+		t.Fatalf("N did not go back: %q", model.searchMatchLabel())
 	}
 
 	updated, _ = model.updateNormal(tea.KeyPressMsg{Code: tea.KeyEscape})

--- a/internal/ui/selection.go
+++ b/internal/ui/selection.go
@@ -234,9 +234,7 @@ func (m Model) copyTerminalSelectionCmd() tea.Cmd {
 		selected = append(selected,
 			strings.TrimRight(ansi.Cut(line, from, to), " "))
 	}
-	text := strings.Join(selected, "\n")
-	count := len(selected)
-	return copyToClipboardCmd(text, count)
+	return copyToClipboardCmd(strings.Join(selected, "\n"))
 }
 
 // paintTerminalSelection reverses the video of the selected span over the
@@ -366,17 +364,11 @@ func (m Model) copySelectionCmd() tea.Cmd {
 	for _, line := range lines[start : end+1] {
 		selected = append(selected, strings.TrimRight(line, " "))
 	}
-	text := strings.Join(selected, "\n")
-	count := end - start + 1
-	return copyToClipboardCmd(text, count)
+	return copyToClipboardCmd(strings.Join(selected, "\n"))
 }
 
-func copyToClipboardCmd(text string, count int) tea.Cmd {
-	label := "line"
-	if count != 1 {
-		label = "lines"
-	}
-	success := actionMsg{status: fmt.Sprintf("Copied %d %s", count, label)}
+func copyToClipboardCmd(text string) tea.Cmd {
+	success := actionMsg{}
 	return func() tea.Msg {
 		if os.Getenv("TMUX") != "" {
 			if err := runClipboardCommand(

--- a/internal/ui/selection_test.go
+++ b/internal/ui/selection_test.go
@@ -16,17 +16,15 @@ const (
 )
 
 type clipboardCopyModel struct {
-	status string
-	err    error
+	err error
 }
 
 func (m clipboardCopyModel) Init() tea.Cmd {
-	return copyToClipboardCmd(clipboardTestText, 2)
+	return copyToClipboardCmd(clipboardTestText)
 }
 
 func (m clipboardCopyModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 	if action, ok := msg.(actionMsg); ok {
-		m.status = action.status
 		m.err = action.err
 		return m, tea.Quit
 	}
@@ -106,9 +104,6 @@ func assertClipboardSuccess(t *testing.T, model clipboardCopyModel) {
 	t.Helper()
 	if model.err != nil {
 		t.Fatalf("copy failed: %v", model.err)
-	}
-	if model.status != "Copied 2 lines" {
-		t.Fatalf("status = %q, want %q", model.status, "Copied 2 lines")
 	}
 }
 

--- a/internal/ui/sessions.go
+++ b/internal/ui/sessions.go
@@ -24,7 +24,6 @@ import (
 func (m Model) beginHistory() (tea.Model, tea.Cmd) {
 	m.mode = modeHistory
 	m.err = nil
-	m.status = "Session history"
 	m.historyCursor = 0
 	m.historyRecords = nil
 	m.historyLoading = true
@@ -50,7 +49,6 @@ func (m Model) updateHistory(msg tea.KeyPressMsg) (tea.Model, tea.Cmd) {
 			return m, nil
 		}
 		m.mode = modeNormal
-		m.status = "Ready"
 		return m, nil
 	case "/":
 		m.historyFiltering = true
@@ -116,20 +114,14 @@ func (m Model) resumeSelectedHistory() (tea.Model, tea.Cmd) {
 	}
 	record := visible[min(m.historyCursor, len(visible)-1)]
 	m.mode = modeNormal
-	m.status = "Resuming " + historyTitle(record)
 	backend := m.backend
 	return m, tea.Batch(
 		func() tea.Msg {
 			ctx, cancel := context.WithTimeout(
 				context.Background(), resumeTimeout)
 			defer cancel()
-			managedAgent, err := backend.Resume(ctx, record)
-			if err != nil {
-				return actionMsg{err: err}
-			}
-			return actionMsg{
-				status: "Resumed " + agentDisplayTitle(managedAgent),
-			}
+			_, err := backend.Resume(ctx, record)
+			return actionMsg{err: err}
 		},
 		m.refreshCmd(),
 	)

--- a/internal/ui/state.go
+++ b/internal/ui/state.go
@@ -367,7 +367,7 @@ func clearAttentionCmd(backend Backend, ids ...string) tea.Cmd {
 			}
 		}
 		if err := errors.Join(failures...); err != nil {
-			return actionMsg{status: "Attention cleared", err: err}
+			return actionMsg{err: err}
 		}
 		// No actionMsg on success: seen-clearing is ambient, not an
 		// action worth announcing or refreshing over.
@@ -397,6 +397,5 @@ func (m Model) clearAttention() (tea.Model, tea.Cmd) {
 		return m, nil
 	}
 	m.markAttentionSeen(ids...)
-	m.status = "Marked seen"
 	return m, clearAttentionCmd(m.backend, ids...)
 }

--- a/internal/ui/workspaces.go
+++ b/internal/ui/workspaces.go
@@ -43,7 +43,6 @@ func (m Model) updateAddWorkspace(msg tea.KeyPressMsg) (tea.Model, tea.Cmd) {
 	case "esc", "ctrl+c", "ctrl+[":
 		m.mode = modeNormal
 		m.blurForm()
-		m.status = "Ready"
 		return m, nil
 	case "j", "down":
 		if m.formFocus == dispatchDirectory {
@@ -423,7 +422,6 @@ func (m Model) beginAddWorkspace() (tea.Model, tea.Cmd) {
 	m.dispatchPrefix = ""
 	m.focusForm()
 	m.err = nil
-	m.status = "Add workspace"
 	return m, nil
 }
 
@@ -434,6 +432,5 @@ func (m Model) submitAddWorkspace(path string) (tea.Model, tea.Cmd) {
 		return m, nil
 	}
 	m.blurForm()
-	m.status = "Adding workspace"
 	return m, addWorkspaceCmd(m.backend, path)
 }


### PR DESCRIPTION
The footer's hint row had two problems: prepended action statuses ("Dispatching Claude", "Opening X", …) re-rendered the hints in muted gray, wiping out the focus color scheme; and the hints themselves read as one run-on line — \`truncate()\` was even collapsing the double-space padding between them.

## What changed

- **The action status is gone from the footer.** The hint row always wears the seam's ink: the portal's blue while the terminal holds the keyboard, the band's ice on the roster side. Errors are the one message still allowed to share the row, and the hints keep their color beside them instead of fading to gray.
- **Hints are dot-separated.** Each key–action pair renders as its own unit with a muted \`·\` between neighbors.
- **Status text that carried real information moved into the hints.** modeDelete's confirmation hint names its victim (\`x delete claude-a1b2\`, \`X delete web and 3 agent(s)\`); the search position rides the n/N hint (\`n/N match 2/5\`, \`no match\`).
- **The write-only plumbing is deleted.** \`Model.status\`, \`actionMsg.status\`, and every assignment (~90 sites) are gone; \`actionCmd\`'s label survives purely as the failure-log name.

Verified with the full test suite and a headless tmux run: hints render in 256-color 189 (band ice) with separators in 244 (muted gray) on the roster side.

🤖 Generated with [Claude Code](https://claude.com/claude-code)