### PR TITLE
Link the demo video from the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,6 +15,11 @@ Stormlight itself is named after.
 Workspace-aware grouping keeps agents from the same repository together while
 preserving the checkout or worktree each agent is using.
 
+[![The Stormlight dashboard — live agents, the transcript view, and the
+Spanreed terminal](site/assets/poster.jpg)](https://stormlight.sh)
+
+*A 30-second tour — it plays at [stormlight.sh](https://stormlight.sh).*
+
 ## Design
 
 - A dedicated daemon owns process and terminal lifetime, and nothing else.


### PR DESCRIPTION
Adds the demo's poster frame to the README, linking to https://stormlight.sh where the recording autoplays. GitHub markdown can't render a committed video inline, so the poster-link is the reliable form.

🤖 Generated with [Claude Code](https://claude.com/claude-code)