### PR TITLE
Fix section spacing and mobile layout on the site

### DIFF
--- a/site/assets/style.css
+++ b/site/assets/style.css
@@ -247,5 +247,8 @@ pre .s { color: var(--str); }
 @media (max-width: 640px) {
   body { font-size: 16px; }
   .wrap, .wrap-narrow { padding: 0 1.1rem; }
-  .nav-links { gap: 1rem; }
+  .nav { flex-wrap: wrap; row-gap: 0.7rem; }
+  .nav-links { gap: 1rem; flex-wrap: wrap; row-gap: 0.5rem; }
+  .install { font-size: 0.75rem; }
+  .install .cmd { overflow-wrap: anywhere; }
 }

--- a/site/index.html
+++ b/site/index.html
@@ -15,7 +15,7 @@
 <style>
 /* ---------- hero ---------- */
 
-.hero { padding: 6rem 0 4rem; }
+.hero { padding-top: 6rem; padding-bottom: 4rem; }
 
 .hero h1 {
   font-size: clamp(2.6rem, 6.5vw, 4.6rem);
@@ -49,7 +49,7 @@
 
 /* ---------- demo video ---------- */
 
-.mockwrap { padding: 2.5rem 0 0; }
+.mockwrap { padding-top: 2.5rem; }
 video.demo { display: block; width: 100%; height: auto; }
 .mock-caption {
   margin-top: 1.1rem;
@@ -61,7 +61,7 @@ video.demo { display: block; width: 100%; height: auto; }
 
 /* ---------- sections ---------- */
 
-section { padding: 6.5rem 0 0; }
+section.wrap { padding-top: 6.5rem; }
 
 .section-head h2 {
   font-size: clamp(1.9rem, 4vw, 2.7rem);
@@ -193,7 +193,7 @@ section { padding: 6.5rem 0 0; }
     <p class="sub">Dispatches <strong>Claude</strong>, <strong>Codex</strong>, and any agent CLI
     onto a daemon that owns each agent's PTY and terminal. The dashboard runs in yours.</p>
     <div class="hero-actions">
-      <span class="install"><span class="p">$</span><span id="brew-cmd">brew install trentkm/stormlight/stormlight</span><button data-copy="brew-cmd">copy</button></span>
+      <span class="install"><span class="p">$</span><span class="cmd" id="brew-cmd">brew install trentkm/stormlight/stormlight</span><button data-copy="brew-cmd">copy</button></span>
       <a class="ghost-link" href="https://github.com/trentkm/stormlight">source on github →</a>
     </div>
   </div>
@@ -292,7 +292,7 @@ section { padding: 6.5rem 0 0; }
   <div class="wrap closing reveal">
     <p class="kicker">install</p>
     <div class="hero-actions">
-      <span class="install"><span class="p">$</span><span id="brew-cmd2">brew install trentkm/stormlight/stormlight</span><button data-copy="brew-cmd2">copy</button></span>
+      <span class="install"><span class="p">$</span><span class="cmd" id="brew-cmd2">brew install trentkm/stormlight/stormlight</span><button data-copy="brew-cmd2">copy</button></span>
     </div>
     <div class="docrow">
       <a href="docs/architecture.html">architecture</a>


### PR DESCRIPTION
Two specificity bugs: `.wrap { padding: 0 2rem }` overrode `section { padding: 6.5rem 0 0 }` (class beats type), so sections were never spaced apart — visible as the cramped gap above "the engine underneath". And `.hero`/`.mockwrap` shorthand padding zeroed `.wrap`'s side padding, so hero text and the video touched the screen edge on phones. Fixed with vertical-only padding (`section.wrap { padding-top }`). The nav and install command also wrap on narrow screens now. Verified in-browser at 437px CSS width: no horizontal overflow, side padding present, 104px section gaps.

🤖 Generated with [Claude Code](https://claude.com/claude-code)