### PR TITLE
Navigate from docked terminal with left arrow

### DIFF
--- a/internal/ui/ptykeys.go
+++ b/internal/ui/ptykeys.go
@@ -1,8 +1,8 @@
 package ui
 
 // Keyboard routing for Stormlight's PTY view: while the pane holds focus the
-// keyboard belongs to the agent's terminal, byte for byte. ctrl+q hands it
-// back to the dashboard.
+// keyboard belongs to the agent's terminal, byte for byte. The docked view's
+// left arrow and the seam chords hand it back to the dashboard.
 
 import (
 	tea "charm.land/bubbletea/v2"
@@ -24,6 +24,12 @@ import (
 func (m Model) updateTerminalKey(msg tea.KeyPressMsg) (tea.Model, tea.Cmd) {
 	key := msg.String()
 	switch {
+	case key == "left" && !m.ptyZoom:
+		// Docked, left follows the visible pane hierarchy back to the roster.
+		// Zoomed, the hidden hierarchy cannot suggest that meaning, so the
+		// hosted terminal keeps the key for cursor movement.
+		m.activePane = paneAgents
+		return m, nil
 	case key == "ctrl+q" || key == "ctrl+space" || key == "ctrl+@":
 		// The seam key: one step out, from anywhere inside. Zoom collapses
 		// with it, so it always lands back on the roster.

--- a/internal/ui/ptymode.go
+++ b/internal/ui/ptymode.go
@@ -250,8 +250,12 @@ func (m Model) terminalHints() []string {
 		return []string{fmt.Sprintf(
 			"scrolled %d lines up — wheel down to follow", widget.Scrolled())}
 	}
+	out := "left/ctrl+space out"
+	if m.ptyZoom {
+		out = "ctrl+space out"
+	}
 	return []string{
-		"ctrl+space out",
+		out,
 		chordPair(m.keys.AgentsNext, m.keys.AgentsPrevious) + " agents",
 		chordPair(m.keys.QueueNext, m.keys.QueuePrevious) + " queue",
 		chordName(m.keys.Zoom[0]) + " zoom",

--- a/internal/ui/ptymode_test.go
+++ b/internal/ui/ptymode_test.go
@@ -1,9 +1,11 @@
 package ui
 
 import (
-	"github.com/charmbracelet/x/ansi"
 	"strings"
 	"testing"
+
+	tea "charm.land/bubbletea/v2"
+	"github.com/charmbracelet/x/ansi"
 )
 
 func TestTerminalControlsReplaceDashboardFooterHints(t *testing.T) {
@@ -25,6 +27,33 @@ func TestTerminalControlsReplaceDashboardFooterHints(t *testing.T) {
 	}
 	if strings.Contains(hints, "i reply") {
 		t.Fatalf("dashboard interaction hints remained in terminal footer: %q", hints)
+	}
+
+	model.ptyZoom = true
+	hints = strings.Join(model.commandHints(), " ")
+	if strings.Contains(hints, "left/") {
+		t.Fatalf("zoomed terminal advertises docked navigation: %q", hints)
+	}
+	if !strings.Contains(hints, "ctrl+space out") {
+		t.Fatalf("zoomed terminal lost its exit chord: %q", hints)
+	}
+}
+
+func TestLeftLeavesDockedTerminalForAgentRoster(t *testing.T) {
+	model := Model{
+		mode:       modeNormal,
+		activePane: paneInteraction,
+		ptyEnabled: true,
+	}
+
+	updated, cmd := model.updateTerminalKey(tea.KeyPressMsg{Code: tea.KeyLeft})
+	model = updated.(Model)
+
+	if model.activePane != paneAgents {
+		t.Fatalf("active pane = %d, want agents", model.activePane)
+	}
+	if cmd != nil {
+		t.Fatal("left produced a terminal command")
 	}
 }
 


### PR DESCRIPTION
## Summary

- make Left return from a docked terminal to the agents list
- preserve Left for terminal input while zoomed
- show the docked-only shortcut in terminal footer hints

## Testing

- `go test ./...`
- Manually tested with both Codex and Claude Code.