### PR TITLE
Navigate agents across workspace boundaries

### DIFF
--- a/internal/ui/input_test.go
+++ b/internal/ui/input_test.go
@@ -1463,6 +1463,113 @@ func TestVimPaneNavigation(t *testing.T) {
 	}
 }
 
+func TestAgentNavigationCrossesWorkspaceBoundaries(t *testing.T) {
+	groups := []workspaceGroup{
+		{
+			context: workspace.DirectoryContext("/workspace/one"),
+			agents: []agent.Agent{
+				{ID: "one"},
+				{ID: "two"},
+			},
+		},
+		{context: workspace.DirectoryContext("/workspace/empty")},
+		{
+			context: workspace.DirectoryContext("/workspace/three"),
+			agents: []agent.Agent{
+				{ID: "three"},
+				{ID: "four"},
+			},
+		},
+	}
+	tests := []struct {
+		name            string
+		workspaceCursor int
+		agentCursor     int
+		delta           int
+		wantWorkspace   int
+		wantAgent       int
+	}{
+		{
+			name:            "down enters next non-empty workspace",
+			workspaceCursor: 0,
+			agentCursor:     1,
+			delta:           1,
+			wantWorkspace:   2,
+			wantAgent:       0,
+		},
+		{
+			name:            "up enters previous non-empty workspace",
+			workspaceCursor: 2,
+			agentCursor:     0,
+			delta:           -1,
+			wantWorkspace:   0,
+			wantAgent:       1,
+		},
+		{
+			name:            "multi-row movement crosses workspaces",
+			workspaceCursor: 0,
+			agentCursor:     0,
+			delta:           3,
+			wantWorkspace:   2,
+			wantAgent:       1,
+		},
+		{
+			name:            "down from empty workspace finds next agent",
+			workspaceCursor: 1,
+			agentCursor:     0,
+			delta:           1,
+			wantWorkspace:   2,
+			wantAgent:       0,
+		},
+		{
+			name:            "up from empty workspace finds previous agent",
+			workspaceCursor: 1,
+			agentCursor:     0,
+			delta:           -1,
+			wantWorkspace:   0,
+			wantAgent:       1,
+		},
+		{
+			name:            "top boundary clamps",
+			workspaceCursor: 0,
+			agentCursor:     0,
+			delta:           -1,
+			wantWorkspace:   0,
+			wantAgent:       0,
+		},
+		{
+			name:            "bottom boundary clamps",
+			workspaceCursor: 2,
+			agentCursor:     1,
+			delta:           1,
+			wantWorkspace:   2,
+			wantAgent:       1,
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			model := NewModel(stubBackend{})
+			model.groups = groups
+			model.workspaceCursor = test.workspaceCursor
+			model.agentCursor = test.agentCursor
+
+			model.moveSelectionIn(paneAgents, test.delta)
+
+			if model.workspaceCursor != test.wantWorkspace ||
+				model.agentCursor != test.wantAgent {
+				t.Fatalf(
+					"selection = workspace %d agent %d, want workspace %d agent %d",
+					model.workspaceCursor,
+					model.agentCursor,
+					test.wantWorkspace,
+					test.wantAgent,
+				)
+			}
+		})
+	}
+}
+
 func TestWorkspaceGroupingDrivesAgentPane(t *testing.T) {
 	gitWorkspace := workspace.Context{
 		ID:            "git:/repo/.git",

--- a/internal/ui/state.go
+++ b/internal/ui/state.go
@@ -269,11 +269,7 @@ func (m *Model) moveSelectionIn(target pane, delta int) {
 		m.workspaceCursor = clamp(m.workspaceCursor+delta, 0, len(m.groups)-1)
 		m.agentCursor = 0
 	case paneAgents:
-		agents := m.agentsForSelectedWorkspace()
-		if len(agents) == 0 {
-			return
-		}
-		m.agentCursor = clamp(m.agentCursor+delta, 0, len(agents)-1)
+		m.moveAgentSelection(delta)
 	case paneInteraction:
 		if m.ptyEnabled {
 			// The PTY view scrolls the emulator's history; positive delta
@@ -290,6 +286,42 @@ func (m *Model) moveSelectionIn(target pane, delta int) {
 		} else {
 			m.interaction.ScrollUp(-delta)
 		}
+	}
+}
+
+func (m *Model) moveAgentSelection(delta int) {
+	direction := 1
+	if delta < 0 {
+		direction = -1
+	}
+
+	for delta != 0 {
+		agents := m.agentsForSelectedWorkspace()
+		if len(agents) > 0 {
+			m.agentCursor = clamp(m.agentCursor, 0, len(agents)-1)
+			nextAgent := m.agentCursor + direction
+			if nextAgent >= 0 && nextAgent < len(agents) {
+				m.agentCursor = nextAgent
+				delta -= direction
+				continue
+			}
+		}
+
+		nextWorkspace := m.workspaceCursor + direction
+		for nextWorkspace >= 0 && nextWorkspace < len(m.groups) &&
+			len(m.groups[nextWorkspace].agents) == 0 {
+			nextWorkspace += direction
+		}
+		if nextWorkspace < 0 || nextWorkspace >= len(m.groups) {
+			return
+		}
+
+		m.workspaceCursor = nextWorkspace
+		m.agentCursor = 0
+		if direction < 0 {
+			m.agentCursor = len(m.groups[nextWorkspace].agents) - 1
+		}
+		delta -= direction
 	}
 }
 


### PR DESCRIPTION
## Summary
- continue agent-pane navigation into adjacent workspaces
- skip empty workspaces and clamp at global roster boundaries
- apply the behavior to single-step and page-sized movements

## Testing
- `go test ./...`
- `go build -o stormlight .`
- `go vet ./...`

Fixes #119