### PR TITLE
Keep left arrow in terminal while editing

### DIFF
--- a/internal/ui/model.go
+++ b/internal/ui/model.go
@@ -288,6 +288,9 @@ type Model struct {
 	ptyWaiting bool
 	// keys are the seam chords, config-rebindable; see KeyBindings.
 	keys KeyBindings
+	// ptyInput shadows enough of the selected terminal's edit line to keep
+	// Left available until the cursor reaches the draft's left edge.
+	ptyInput terminalInputState
 
 	// Terminal drag selection: character-precise over the grid, tmux
 	// style — first line from the anchor, middles whole, last to the
@@ -776,6 +779,7 @@ func (m Model) Update(message tea.Msg) (tea.Model, tea.Cmd) {
 			// Paste lands in the agent's terminal as one bracketed paste,
 			// the same shape Send uses — never a burst of keystrokes.
 			if widget, ok := m.selectedPTY(); ok {
+				m.trackTerminalPaste(msg.Content)
 				widget.ScrollToBottom()
 				return m, writeTerminalCmd(widget,
 					[]byte("\x1b[200~"+msg.Content+"\x1b[201~"))

--- a/internal/ui/ptykeys.go
+++ b/internal/ui/ptykeys.go
@@ -5,6 +5,8 @@ package ui
 // left arrow and the seam chords hand it back to the dashboard.
 
 import (
+	"unicode/utf8"
+
 	tea "charm.land/bubbletea/v2"
 	"github.com/trentkm/stormlight/internal/agent"
 	"github.com/trentkm/stormlight/internal/diagnostic"
@@ -24,10 +26,10 @@ import (
 func (m Model) updateTerminalKey(msg tea.KeyPressMsg) (tea.Model, tea.Cmd) {
 	key := msg.String()
 	switch {
-	case key == "left" && !m.ptyZoom:
+	case key == "left" && m.dockedLeftExits():
 		// Docked, left follows the visible pane hierarchy back to the roster.
-		// Zoomed, the hidden hierarchy cannot suggest that meaning, so the
-		// hosted terminal keeps the key for cursor movement.
+		// A draft or the zoomed view keeps it in the hosted terminal for
+		// cursor movement.
 		m.activePane = paneAgents
 		return m, nil
 	case key == "ctrl+q" || key == "ctrl+space" || key == "ctrl+@":
@@ -64,6 +66,7 @@ func (m Model) updateTerminalKey(msg tea.KeyPressMsg) (tea.Model, tea.Cmd) {
 	if len(data) == 0 {
 		return m, nil
 	}
+	m.trackTerminalKey(msg)
 	// Typing while scrolled back reads as "take me to the action".
 	widget.ScrollToBottom()
 	send := writeTerminalCmd(widget, data)
@@ -75,6 +78,70 @@ func (m Model) updateTerminalKey(msg tea.KeyPressMsg) (tea.Model, tea.Cmd) {
 		return m, tea.Batch(send, clearAttentionCmd(m.backend, selected.ID))
 	}
 	return m, send
+}
+
+type terminalInputState struct {
+	agentID        string
+	length, cursor int
+}
+
+func (m Model) dockedLeftExits() bool {
+	return !m.ptyZoom &&
+		(m.ptyInput.agentID != m.selectedAgentID() || m.ptyInput.cursor == 0)
+}
+
+func (m *Model) terminalInput() *terminalInputState {
+	agentID := m.selectedAgentID()
+	if m.ptyInput.agentID != agentID {
+		m.ptyInput = terminalInputState{agentID: agentID}
+	}
+	return &m.ptyInput
+}
+
+func (m *Model) trackTerminalPaste(content string) {
+	input := m.terminalInput()
+	count := utf8.RuneCountInString(content)
+	input.length += count
+	input.cursor += count
+}
+
+// trackTerminalKey mirrors only edit operations needed to answer whether a
+// draft exists. Unknown editing chords conservatively keep the draft active,
+// which is preferable to stealing Left from text the provider owns.
+func (m *Model) trackTerminalKey(msg tea.KeyPressMsg) {
+	input := m.terminalInput()
+	key := msg.String()
+	switch {
+	case msg.Text != "":
+		count := utf8.RuneCountInString(msg.Text)
+		input.length += count
+		input.cursor += count
+	case key == "left":
+		input.cursor = max(0, input.cursor-1)
+	case key == "right":
+		input.cursor = min(input.length, input.cursor+1)
+	case key == "home" || key == "ctrl+a":
+		input.cursor = 0
+	case key == "end" || key == "ctrl+e":
+		input.cursor = input.length
+	case key == "backspace" || key == "ctrl+backspace":
+		if input.cursor > 0 {
+			input.length--
+			input.cursor--
+		}
+	case key == "delete":
+		if input.cursor < input.length {
+			input.length--
+		}
+	case key == "ctrl+u":
+		input.length -= input.cursor
+		input.cursor = 0
+	case key == "ctrl+k":
+		input.length = input.cursor
+	case key == "enter" || key == "ctrl+c":
+		input.length = 0
+		input.cursor = 0
+	}
 }
 
 func writeTerminalCmd(widget pty.Model, data []byte) tea.Cmd {

--- a/internal/ui/ptymode_test.go
+++ b/internal/ui/ptymode_test.go
@@ -57,6 +57,28 @@ func TestLeftLeavesDockedTerminalForAgentRoster(t *testing.T) {
 	}
 }
 
+func TestLeftLeavesDockedTerminalAtDraftBoundary(t *testing.T) {
+	model := Model{}
+	model.trackTerminalKey(runeKey("draft"))
+
+	for want := 4; want >= 0; want-- {
+		if model.dockedLeftExits() {
+			t.Fatalf("left exits before cursor reaches zero: cursor=%d",
+				model.ptyInput.cursor)
+		}
+		model.trackTerminalKey(tea.KeyPressMsg{Code: tea.KeyLeft})
+		if model.ptyInput.cursor != want {
+			t.Fatalf("tracked cursor = %d, want %d", model.ptyInput.cursor, want)
+		}
+	}
+	if !model.dockedLeftExits() {
+		t.Fatal("left stays in the terminal at the draft's left edge")
+	}
+	if model.ptyInput.length != 5 {
+		t.Fatal("moving focus discarded the tracked draft")
+	}
+}
+
 func TestGridCellMapsDockedAndZoomedOrigins(t *testing.T) {
 	model := Model{width: 121, height: 40, ptyEnabled: true}
 	workspaceWidth, agentWidth, _ := model.paneWidths(120)


### PR DESCRIPTION
## Summary

- keep Left routed to the hosted terminal while its selected agent has draft text
- track typed and pasted input plus common edit operations
- retain the docked Left-to-roster shortcut when the input is empty

Follow-up to #118.

## Testing

- `go test ./...`