### PR TITLE
Drop the em dashes from page titles

### DIFF
--- a/site/docs/architecture.html
+++ b/site/docs/architecture.html
@@ -3,7 +3,7 @@
 <head>
 <meta charset="utf-8">
 <meta name="viewport" content="width=device-width, initial-scale=1">
-<title>Architecture — Stormlight</title>
+<title>Architecture · Stormlight</title>
 <meta name="description" content="How Stormlight separates agent semantics from terminal and process ownership.">
 <link rel="icon" href="../assets/favicon.svg" type="image/svg+xml">
 <link rel="icon" href="../assets/favicon-32.png" type="image/png" sizes="32x32">

--- a/site/docs/configuration.html
+++ b/site/docs/configuration.html
@@ -3,7 +3,7 @@
 <head>
 <meta charset="utf-8">
 <meta name="viewport" content="width=device-width, initial-scale=1">
-<title>Configuration — Stormlight</title>
+<title>Configuration · Stormlight</title>
 <meta name="description" content="The design rationale behind Stormlight's config.toml: zero-config defaults, one precedence rule, custom providers.">
 <link rel="icon" href="../assets/favicon.svg" type="image/svg+xml">
 <link rel="icon" href="../assets/favicon-32.png" type="image/png" sizes="32x32">

--- a/site/docs/index.html
+++ b/site/docs/index.html
@@ -3,7 +3,7 @@
 <head>
 <meta charset="utf-8">
 <meta name="viewport" content="width=device-width, initial-scale=1">
-<title>Docs — Stormlight</title>
+<title>Docs · Stormlight</title>
 <meta name="description" content="Stormlight documentation: architecture, workspace resolvers, configuration.">
 <link rel="icon" href="../assets/favicon.svg" type="image/svg+xml">
 <link rel="icon" href="../assets/favicon-32.png" type="image/png" sizes="32x32">

--- a/site/docs/workspace-resolvers.html
+++ b/site/docs/workspace-resolvers.html
@@ -3,7 +3,7 @@
 <head>
 <meta charset="utf-8">
 <meta name="viewport" content="width=device-width, initial-scale=1">
-<title>Workspace resolvers — Stormlight</title>
+<title>Workspace resolvers · Stormlight</title>
 <meta name="description" content="How Stormlight resolves directories into workspace groups, and the executable resolver protocol.">
 <link rel="icon" href="../assets/favicon.svg" type="image/svg+xml">
 <link rel="icon" href="../assets/favicon-32.png" type="image/png" sizes="32x32">

--- a/site/index.html
+++ b/site/index.html
@@ -3,8 +3,8 @@
 <head>
 <meta charset="utf-8">
 <meta name="viewport" content="width=device-width, initial-scale=1">
-<title>Stormlight — a control surface for coding agents</title>
-<meta name="description" content="Stormlight dispatches Claude, Codex, and custom coding agents onto a daemon that owns each agent's PTY and terminal — a workspace-native dashboard running in your own terminal.">
+<title>Stormlight</title>
+<meta name="description" content="A control surface for coding agents. Stormlight dispatches Claude, Codex, and custom agent CLIs onto a daemon that owns each agent's PTY and terminal, with a dashboard that runs in yours.">
 <meta property="og:title" content="Stormlight">
 <meta property="og:description" content="A workspace-native control surface for coding agents.">
 <link rel="icon" href="assets/favicon.svg" type="image/svg+xml">


### PR DESCRIPTION
Landing tab becomes just "Stormlight"; docs tabs use the site's existing middot separator ("Architecture · Stormlight"); the meta description is rewritten without the dash.

🤖 Generated with [Claude Code](https://claude.com/claude-code)