### PR TITLE
Add Stormlight Web design mockups

### DIFF
--- a/docs/design/web/Diff.dc.html
+++ b/docs/design/web/Diff.dc.html
@@ -1,0 +1,109 @@
+<!doctype html>
+<html>
+<head>
+  <meta charset="utf-8">
+  <script src="./support.js"></script>
+</head>
+<body>
+<x-dc>
+<helmet>
+  <link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=JetBrains+Mono:ital,wght@0,400;0,500;0,700;1,400&display=swap">
+  <style>
+    body { margin: 0; background: #14181D; }
+    a { color: #62AEEF; } a:hover { color: #7DCFFF; }
+    .dl { display: flex; font-size: 12px; line-height: 1.7; }
+    .ln { width: 42px; flex: 0 0 auto; text-align: right; padding-right: 12px; color: #4A545C; font-size: 11px; }
+    .dc { white-space: pre; flex: 1 1 auto; }
+  </style>
+</helmet>
+<div style="width: 880px; height: 780px; display: flex; flex-direction: column; background: #14181D; color: #D7DEE5; font-family: 'JetBrains Mono', ui-monospace, 'SF Mono', Menlo, monospace; font-size: 13px; overflow: hidden; border: 1px solid #2A3138">
+
+  <!-- Pane header -->
+  <div style="height: 40px; flex: 0 0 auto; display: flex; align-items: center; gap: 18px; padding: 0 16px; background: #1B2126; border-bottom: 1px solid #2A3138">
+    <div style="display: flex; align-items: center; gap: 8px; min-width: 0">
+      <span style="color: #61AFEF">●</span>
+      <span style="color: #C6E9FF; font-weight: 500; white-space: nowrap">Port grid renderer to windrunner</span>
+    </div>
+    <div style="display: flex; align-items: stretch; gap: 4px; height: 100%">
+      <div style="display: flex; align-items: center; padding: 0 12px; color: #74818B; border-bottom: 2px solid transparent; font-size: 12px">Terminal</div>
+      <div style="display: flex; align-items: center; padding: 0 12px; color: #74818B; border-bottom: 2px solid transparent; font-size: 12px">Transcript</div>
+      <div style="display: flex; align-items: center; padding: 0 12px; color: #C6E9FF; border-bottom: 2px solid #7DCFFF; font-size: 12px">Diff</div>
+    </div>
+    <div style="flex: 1 1 auto"></div>
+    <span style="padding: 2px 8px; border: 1px solid #3A4046; border-radius: 4px; font-size: 11px; color: #74818B">r refresh</span>
+  </div>
+
+  <!-- Diff stat bar -->
+  <div style="flex: 0 0 auto; display: flex; align-items: center; gap: 10px; padding: 9px 16px; border-bottom: 1px solid #2A3138; font-size: 12px">
+    <span style="color: #8FDCCB">spanreed-pty</span>
+    <span style="color: #74818B">→ origin/main</span>
+    <span style="flex: 1 1 auto"></span>
+    <span style="color: #74818B">3 files</span>
+    <span style="color: #72C087">+103</span>
+    <span style="color: #E06C75">−26</span>
+  </div>
+
+  <!-- File list -->
+  <div style="flex: 1 1 auto; display: flex; flex-direction: column; gap: 10px; padding: 14px 16px; overflow: hidden">
+
+    <!-- Expanded file -->
+    <div style="display: flex; flex-direction: column; border: 1px solid #2A3138; border-radius: 6px; overflow: hidden">
+      <div style="display: flex; align-items: center; gap: 10px; padding: 8px 12px; background: #1B2126; font-size: 12px">
+        <span style="color: #74818B">▾</span>
+        <span style="color: #D7DEE5">internal/pty/terminal.go</span>
+        <span style="flex: 1 1 auto"></span>
+        <span style="color: #72C087">+31</span>
+        <span style="color: #E06C75">−12</span>
+      </div>
+      <div style="padding: 6px 0 10px; background: #10141A">
+        <div class="dl"><span class="ln"></span><span class="dc" style="color: #8FDCCB; opacity: 0.8">@@ -88,8 +88,8 @@ func (t *Terminal) seed(a *client.Attachment) error {</span></div>
+        <div class="dl"><span class="ln">88</span><span class="dc" style="color: #A9B4BC"> func (t *Terminal) seed(a *client.Attachment) error {</span></div>
+        <div class="dl" style="background: rgba(224, 108, 117, 0.10)"><span class="ln">89</span><span class="dc" style="color: #E06C75">-    raw, err := a.SnapshotBytes()</span></div>
+        <div class="dl" style="background: rgba(224, 108, 117, 0.10)"><span class="ln">90</span><span class="dc" style="color: #E06C75">-    if err != nil {</span></div>
+        <div class="dl" style="background: rgba(224, 108, 117, 0.10)"><span class="ln">91</span><span class="dc" style="color: #E06C75">-        return fmt.Errorf("snapshot bytes: %w", err)</span></div>
+        <div class="dl" style="background: rgba(224, 108, 117, 0.10)"><span class="ln">92</span><span class="dc" style="color: #E06C75">-    }</span></div>
+        <div class="dl" style="background: rgba(224, 108, 117, 0.10)"><span class="ln">93</span><span class="dc" style="color: #E06C75">-    t.vt.Write(raw) // replay through the emulator</span></div>
+        <div class="dl" style="background: rgba(114, 192, 135, 0.10)"><span class="ln">89</span><span class="dc" style="color: #72C087">+    grid, err := a.Snapshot() // cells, not bytes</span></div>
+        <div class="dl" style="background: rgba(114, 192, 135, 0.10)"><span class="ln">90</span><span class="dc" style="color: #72C087">+    if err != nil {</span></div>
+        <div class="dl" style="background: rgba(114, 192, 135, 0.10)"><span class="ln">91</span><span class="dc" style="color: #72C087">+        return fmt.Errorf("snapshot: %w", err)</span></div>
+        <div class="dl" style="background: rgba(114, 192, 135, 0.10)"><span class="ln">92</span><span class="dc" style="color: #72C087">+    }</span></div>
+        <div class="dl" style="background: rgba(114, 192, 135, 0.10)"><span class="ln">93</span><span class="dc" style="color: #72C087">+    t.screen.Restore(grid)</span></div>
+        <div class="dl"><span class="ln">94</span><span class="dc" style="color: #A9B4BC">     return nil</span></div>
+        <div class="dl"><span class="ln">95</span><span class="dc" style="color: #A9B4BC"> }</span></div>
+      </div>
+    </div>
+
+    <!-- Collapsed files -->
+    <div style="display: flex; align-items: center; gap: 10px; padding: 8px 12px; border: 1px solid #2A3138; border-radius: 6px; background: #1B2126; font-size: 12px">
+      <span style="color: #74818B">▸</span>
+      <span style="color: #D7DEE5">internal/windrun/stream.go</span>
+      <span style="flex: 1 1 auto"></span>
+      <span style="color: #72C087">+54</span>
+      <span style="color: #E06C75">−9</span>
+    </div>
+    <div style="display: flex; align-items: center; gap: 10px; padding: 8px 12px; border: 1px solid #2A3138; border-radius: 6px; background: #1B2126; font-size: 12px">
+      <span style="color: #74818B">▸</span>
+      <span style="color: #D7DEE5">internal/ui/spanreed.go</span>
+      <span style="flex: 1 1 auto"></span>
+      <span style="color: #72C087">+18</span>
+      <span style="color: #E06C75">−5</span>
+    </div>
+
+  </div>
+
+  <!-- Pane footer -->
+  <div style="height: 30px; flex: 0 0 auto; display: flex; align-items: center; padding: 0 16px; background: #1B2126; border-top: 1px solid #2A3138; font-size: 11.5px">
+    <div style="display: flex; color: #C6E9FF"><span>j/k file</span><span style="color: #74818B"> · </span><span>o expand</span><span style="color: #74818B"> · </span><span>⏎ open in terminal</span></div>
+    <div style="flex: 1 1 auto"></div>
+    <div style="color: #74818B">worktree .claude/worktrees/spanreed-pty</div>
+  </div>
+
+</div>
+</x-dc>
+<script data-dc-script data-props='{}'>
+class Component extends DCLogic {
+  renderVals() { return {}; }
+}
+</script>
+</body>
+</html>

--- a/docs/design/web/Main.dc.html
+++ b/docs/design/web/Main.dc.html
@@ -1,0 +1,185 @@
+<!doctype html>
+<html>
+<head>
+  <meta charset="utf-8">
+  <script src="./support.js"></script>
+</head>
+<body>
+<x-dc>
+<helmet>
+  <link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=JetBrains+Mono:ital,wght@0,400;0,500;0,700;1,400&display=swap">
+  <style>
+    body { margin: 0; background: #171C20; }
+    a { color: #62AEEF; } a:hover { color: #7DCFFF; }
+    .mono { font-family: 'JetBrains Mono', ui-monospace, 'SF Mono', Menlo, monospace; }
+    .tl { white-space: pre; overflow: hidden; }
+  </style>
+</helmet>
+<div class="mono" style="width: 1440px; height: 900px; display: flex; flex-direction: column; background: #171C20; color: #D7DEE5; font-family: 'JetBrains Mono', ui-monospace, 'SF Mono', Menlo, monospace; font-size: 13px; overflow: hidden">
+
+  <!-- Top bar -->
+  <div style="height: 46px; flex: 0 0 auto; display: flex; align-items: center; gap: 16px; padding: 0 16px; background: #1B2126; border-bottom: 1px solid #2A3138">
+    <div style="font-size: 15px; font-weight: 700; letter-spacing: 0.04em; background: linear-gradient(90deg, #7AA2F7, #7DCFFF, #C8F7EF); -webkit-background-clip: text; background-clip: text; color: transparent">Stormlight</div>
+    <div style="display: flex; align-items: center; gap: 2px; padding: 3px; background: #14181D; border: 1px solid #2A3138; border-radius: 6px">
+      <div style="padding: 3px 12px; border-radius: 4px; background: #C6E9FF; color: #0F2338; font-weight: 500; font-size: 12px">Roster</div>
+      <div style="padding: 3px 12px; border-radius: 4px; color: #74818B; font-size: 12px">Wall</div>
+      <div style="padding: 3px 12px; border-radius: 4px; color: #74818B; font-size: 12px">History</div>
+    </div>
+    <div style="flex: 1 1 auto"></div>
+    <div style="display: flex; align-items: center; gap: 8px; font-size: 12px; color: #74818B">
+      <span style="color: #E5C07B">◆ 1 needs input</span>
+      <span>·</span>
+      <span style="color: #61AFEF">● 3 working</span>
+    </div>
+    <div style="display: flex; align-items: center; gap: 7px; font-size: 12px; color: #74818B">
+      <span style="width: 7px; height: 7px; border-radius: 50%; background: #72C087; display: inline-block"></span>
+      <span>windrunner · 6 sessions</span>
+    </div>
+  </div>
+
+  <!-- Body -->
+  <div style="flex: 1 1 auto; display: flex; min-height: 0">
+
+    <!-- Workspace rail -->
+    <div style="width: 236px; flex: 0 0 auto; display: flex; flex-direction: column; background: #191E23; border-right: 1px solid #2A3138; padding: 12px 0">
+      <div style="padding: 0 16px 8px; font-size: 10px; letter-spacing: 0.14em; color: #74818B">WORKSPACES</div>
+      <div style="display: flex; flex-direction: column">
+        <div style="display: flex; align-items: center; gap: 8px; padding: 7px 14px; background: rgba(98, 174, 239, 0.16); border-left: 2px solid #7DCFFF; color: #F3F5F6">
+          <span style="flex: 1 1 auto">stormlight</span>
+          <span style="font-size: 11px; color: #61AFEF">●2</span>
+          <span style="font-size: 11px; color: #E5C07B">◆1</span>
+        </div>
+        <div style="display: flex; flex-direction: column; padding: 4px 0 6px; border-left: 2px solid transparent">
+          <div style="display: flex; gap: 8px; padding: 3px 14px 3px 28px; font-size: 12px; color: #74818B"><span>main</span></div>
+          <div style="display: flex; gap: 8px; padding: 3px 14px 3px 28px; font-size: 12px; color: #D7DEE5"><span style="color: #61AFEF">●</span><span>spanreed-pty</span></div>
+          <div style="display: flex; gap: 8px; padding: 3px 14px 3px 28px; font-size: 12px; color: #D7DEE5"><span style="color: #E5C07B">◆</span><span>footer-hints</span></div>
+          <div style="display: flex; gap: 8px; padding: 3px 14px 3px 28px; font-size: 12px; color: #D7DEE5"><span style="color: #61AFEF">●</span><span>site-docs</span></div>
+          <div style="display: flex; gap: 8px; padding: 3px 14px 3px 28px; font-size: 12px; color: #74818B"><span style="color: #72C087">✓</span><span>history-resume</span></div>
+        </div>
+        <div style="display: flex; align-items: center; gap: 8px; padding: 7px 14px; border-left: 2px solid transparent; color: #D7DEE5">
+          <span style="flex: 1 1 auto">windrunner</span>
+          <span style="font-size: 11px; color: #61AFEF">●1</span>
+        </div>
+        <div style="display: flex; align-items: center; gap: 8px; padding: 7px 14px; border-left: 2px solid transparent; color: #D7DEE5">
+          <span style="flex: 1 1 auto">oathgate</span>
+          <span style="font-size: 11px; color: #E5C07B">○</span>
+        </div>
+      </div>
+      <div style="flex: 1 1 auto"></div>
+      <div style="padding: 8px 16px; font-size: 12px; color: #74818B; border-top: 1px solid #2A3138">a add workspace</div>
+    </div>
+
+    <!-- Agent roster -->
+    <div style="width: 348px; flex: 0 0 auto; display: flex; flex-direction: column; background: #171C20; border-right: 1px solid #2A3138; padding: 12px 0">
+      <div style="display: flex; align-items: baseline; gap: 8px; padding: 0 16px 8px">
+        <span style="font-size: 10px; letter-spacing: 0.14em; color: #74818B">AGENTS</span>
+        <span style="font-size: 11px; color: #74818B">5 of 6 · by attention</span>
+      </div>
+      <div style="display: flex; flex-direction: column">
+
+        <div style="display: flex; gap: 10px; padding: 9px 14px; background: rgba(98, 174, 239, 0.16); border-left: 2px solid #7DCFFF">
+          <span style="color: #61AFEF; flex: 0 0 auto">●</span>
+          <div style="display: flex; flex-direction: column; gap: 3px; min-width: 0">
+            <div style="color: #F3F5F6; font-weight: 500">Port grid renderer to windrunner</div>
+            <div style="font-size: 11px; color: #8AB3D1">spanreed-pty · claude · 12m</div>
+          </div>
+        </div>
+
+        <div style="display: flex; gap: 10px; padding: 9px 14px; background: #E5C07B; border-left: 2px solid #E5C07B">
+          <span style="color: #1F2328; flex: 0 0 auto; font-weight: 700">◆</span>
+          <div style="display: flex; flex-direction: column; gap: 3px; min-width: 0">
+            <div style="color: #1F2328; font-weight: 700">Footer hint mirroring</div>
+            <div style="font-size: 11px; color: #4A3E1E; white-space: nowrap; overflow: hidden; text-overflow: ellipsis">footer-hints · waiting 3m — git push?</div>
+          </div>
+        </div>
+
+        <div style="display: flex; gap: 10px; padding: 9px 14px; border-left: 2px solid transparent">
+          <span style="color: #61AFEF; flex: 0 0 auto">●</span>
+          <div style="display: flex; flex-direction: column; gap: 3px; min-width: 0">
+            <div style="color: #D7DEE5">Docs drift pass on site/</div>
+            <div style="font-size: 11px; color: #74818B">site-docs · claude · 41m</div>
+          </div>
+        </div>
+
+        <div style="display: flex; gap: 10px; padding: 9px 14px; border-left: 2px solid transparent">
+          <span style="color: #72C087; flex: 0 0 auto">✓</span>
+          <div style="display: flex; flex-direction: column; gap: 3px; min-width: 0">
+            <div style="color: #D7DEE5">History resume flow</div>
+            <div style="font-size: 11px; color: #74818B">history-resume · claude · done · 1h</div>
+          </div>
+        </div>
+
+        <div style="display: flex; gap: 10px; padding: 9px 14px; border-left: 2px solid transparent">
+          <span style="color: #61AFEF; flex: 0 0 auto">●</span>
+          <div style="display: flex; flex-direction: column; gap: 3px; min-width: 0">
+            <div style="color: #D7DEE5">Attach backpressure design</div>
+            <div style="font-size: 11px; color: #74818B">windrunner · claude · 22m</div>
+          </div>
+        </div>
+
+      </div>
+      <div style="flex: 1 1 auto"></div>
+      <div style="padding: 8px 16px; font-size: 12px; color: #74818B; border-top: 1px solid #2A3138">n new agent · m message · x delete</div>
+    </div>
+
+    <!-- Spanreed pane -->
+    <div style="flex: 1 1 auto; display: flex; flex-direction: column; min-width: 0; background: #14181D">
+      <div style="height: 40px; flex: 0 0 auto; display: flex; align-items: center; gap: 18px; padding: 0 16px; background: #1B2126; border-bottom: 1px solid #2A3138">
+        <div style="display: flex; align-items: center; gap: 8px; min-width: 0">
+          <span style="color: #61AFEF">●</span>
+          <span style="color: #C6E9FF; font-weight: 500; white-space: nowrap">Port grid renderer to windrunner</span>
+        </div>
+        <div style="display: flex; align-items: stretch; gap: 4px; height: 100%">
+          <div style="display: flex; align-items: center; padding: 0 12px; color: #C6E9FF; border-bottom: 2px solid #7DCFFF; font-size: 12px">Terminal</div>
+          <div style="display: flex; align-items: center; padding: 0 12px; color: #74818B; border-bottom: 2px solid transparent; font-size: 12px">Transcript</div>
+          <div style="display: flex; align-items: center; padding: 0 12px; color: #74818B; border-bottom: 2px solid transparent; font-size: 12px">Diff</div>
+        </div>
+        <div style="flex: 1 1 auto"></div>
+        <div style="display: flex; gap: 6px">
+          <span style="padding: 2px 8px; border: 1px solid #3A4046; border-radius: 4px; font-size: 11px; color: #74818B">⏎ walk in</span>
+          <span style="padding: 2px 8px; border: 1px solid #3A4046; border-radius: 4px; font-size: 11px; color: #74818B">⌥z zoom</span>
+          <span style="padding: 2px 8px; border: 1px solid #3A4046; border-radius: 4px; font-size: 11px; color: #74818B">F full</span>
+        </div>
+      </div>
+
+      <div class="tl" style="flex: 1 1 auto; padding: 16px 18px; font-size: 12.5px; line-height: 1.62; color: #D7DEE5"><span style="color: #74818B">&gt; Port the grid renderer to consume windrunner's snapshot stream
+  instead of re-parsing bytes on attach.</span>
+
+<span style="color: #72C087">⏺</span> I'll look at how the attach path seeds the emulator first.
+
+<span style="color: #72C087">⏺</span> <span style="color: #62AEEF">Read</span>(internal/pty/terminal.go)
+  <span style="color: #74818B">⎿ Read 214 lines</span>
+
+<span style="color: #72C087">⏺</span> The seed path re-parses the full snapshot through x/vt on every
+  attach. Windrunner already holds authoritative cell state, so the
+  client can request the grid directly and skip emulation entirely.
+
+<span style="color: #72C087">⏺</span> <span style="color: #62AEEF">Edit</span>(internal/pty/terminal.go)
+  <span style="color: #74818B">⎿ Updated terminal.go with 31 additions and 12 removals</span>
+
+<span style="color: #72C087">⏺</span> <span style="color: #62AEEF">Bash</span>(go test ./internal/pty/...)
+  <span style="color: #74818B">⎿ </span><span style="color: #8FDCCB">ok   github.com/trentkm/stormlight/internal/pty   0.41s</span>
+
+<span style="color: #72C087">⏺</span> Tests pass. Wiring the dashboard side next — the Gate can drop its
+  per-frame re-emulation once the grid arrives pre-rendered.
+
+  <span style="color: #61AFEF; font-style: italic">✻ Churning… (esc to interrupt · 12m 41s · ↑ 8.2k tokens)</span></div>
+    </div>
+  </div>
+
+  <!-- Footer hints -->
+  <div style="height: 30px; flex: 0 0 auto; display: flex; align-items: center; gap: 14px; padding: 0 16px; background: #1B2126; border-top: 1px solid #2A3138; font-size: 11.5px">
+    <div style="display: flex; gap: 0; color: #C6E9FF"><span>⏎ walk in</span><span style="color: #74818B"> · </span><span>⌥j/k switch</span><span style="color: #74818B"> · </span><span>⌥z zoom</span><span style="color: #74818B"> · </span><span>t transcript</span><span style="color: #74818B"> · </span><span>d diff</span><span style="color: #74818B"> · </span><span>w wall</span><span style="color: #74818B"> · </span><span>H history</span><span style="color: #74818B"> · </span><span>? keys</span></div>
+    <div style="flex: 1 1 auto"></div>
+    <div style="color: #74818B">/Volumes/repos/stormlight</div>
+  </div>
+
+</div>
+</x-dc>
+<script data-dc-script data-props='{}'>
+class Component extends DCLogic {
+  renderVals() { return {}; }
+}
+</script>
+</body>
+</html>

--- a/docs/design/web/README.md
+++ b/docs/design/web/README.md
@@ -1,0 +1,30 @@
+# Stormlight Web — design mockups
+
+Static design mockups for the Stormlight Web GUI (the epic is
+[#125](https://github.com/trentkm/stormlight/issues/125)). Each `*.dc.html`
+file is a self-contained artboard — open it directly in a browser:
+
+- `Main.dc.html` — the stage-2 main view: workspace rail, agent roster,
+  and the Spanreed pane with Terminal / Transcript / Diff tabs.
+- `Wall.dc.html` — the mission-control wall: every agent's terminal live
+  at once; waiting-for-input agents glow amber.
+- `Transcript.dc.html` — the Spanreed pane's Transcript tab: the agent's
+  transcript as rendered markdown with collapsible tool calls.
+- `Diff.dc.html` — the Diff tab: the agent's worktree diff against
+  `origin/main`.
+- `canvas.json` — layout manifest from the design-canvas tool the
+  artboards were authored in; irrelevant for viewing, kept so the set can
+  be re-imported for further design passes.
+
+These are mockups, not markup to reuse: layout and copy illustrate the
+target, and hex values are hand-inlined. The palette is lifted verbatim
+from `internal/theme` (working `#61AFEF`, waiting `#E5C07B`, done
+`#72C087`, failed `#E06C75`, band `#C6E9FF`, code `#8FDCCB`), the status
+glyphs (`● ◆ ○ ✓`) are the roster's own, and the icy band-blue family is
+the selection/focus language, kept distinct from the status colors. The
+real frontend should read its colors from one source of truth shared with
+`internal/theme` rather than copying these values.
+
+Each artboard's `<script src="./support.js">` line is scaffolding from the
+authoring tool; the file intentionally does not exist here, and browsers
+render the artboards fine without it.

--- a/docs/design/web/Transcript.dc.html
+++ b/docs/design/web/Transcript.dc.html
@@ -1,0 +1,97 @@
+<!doctype html>
+<html>
+<head>
+  <meta charset="utf-8">
+  <script src="./support.js"></script>
+</head>
+<body>
+<x-dc>
+<helmet>
+  <link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=JetBrains+Mono:ital,wght@0,400;0,500;0,700;1,400&display=swap">
+  <style>
+    body { margin: 0; background: #14181D; }
+    a { color: #62AEEF; } a:hover { color: #7DCFFF; }
+  </style>
+</helmet>
+<div style="width: 880px; height: 780px; display: flex; flex-direction: column; background: #14181D; color: #D7DEE5; font-family: 'JetBrains Mono', ui-monospace, 'SF Mono', Menlo, monospace; font-size: 13px; overflow: hidden; border: 1px solid #2A3138">
+
+  <!-- Pane header -->
+  <div style="height: 40px; flex: 0 0 auto; display: flex; align-items: center; gap: 18px; padding: 0 16px; background: #1B2126; border-bottom: 1px solid #2A3138">
+    <div style="display: flex; align-items: center; gap: 8px; min-width: 0">
+      <span style="color: #61AFEF">●</span>
+      <span style="color: #C6E9FF; font-weight: 500; white-space: nowrap">Port grid renderer to windrunner</span>
+    </div>
+    <div style="display: flex; align-items: stretch; gap: 4px; height: 100%">
+      <div style="display: flex; align-items: center; padding: 0 12px; color: #74818B; border-bottom: 2px solid transparent; font-size: 12px">Terminal</div>
+      <div style="display: flex; align-items: center; padding: 0 12px; color: #C6E9FF; border-bottom: 2px solid #7DCFFF; font-size: 12px">Transcript</div>
+      <div style="display: flex; align-items: center; padding: 0 12px; color: #74818B; border-bottom: 2px solid transparent; font-size: 12px">Diff</div>
+    </div>
+    <div style="flex: 1 1 auto"></div>
+    <span style="padding: 2px 8px; border: 1px solid #3A4046; border-radius: 4px; font-size: 11px; color: #74818B">⌥t back to terminal</span>
+  </div>
+
+  <!-- Rendered transcript -->
+  <div style="flex: 1 1 auto; display: flex; flex-direction: column; gap: 14px; padding: 18px 22px; overflow: hidden; line-height: 1.6">
+
+    <div style="display: flex; flex-direction: column; gap: 6px; padding: 12px 14px; background: #1B2126; border: 1px solid #2A3138; border-radius: 6px">
+      <div style="font-size: 10px; letter-spacing: 0.12em; color: #74818B">YOU · 14:02</div>
+      <div style="color: #D7DEE5">Port the grid renderer to consume windrunner's snapshot stream instead of re-parsing bytes on attach.</div>
+    </div>
+
+    <div style="color: #D7DEE5">I'll look at how the attach path seeds the emulator first, then swap the seed to the daemon's grid.</div>
+
+    <div style="display: flex; align-items: center; gap: 10px; padding: 7px 12px; border: 1px solid #2A3138; border-radius: 4px; font-size: 12px; color: #74818B">
+      <span>▸</span>
+      <span style="color: #62AEEF">Read</span>
+      <span style="color: #8FDCCB">internal/pty/terminal.go</span>
+      <span style="flex: 1 1 auto"></span>
+      <span>214 lines</span>
+    </div>
+
+    <div style="color: #D7DEE5">The seed path re-parses the full snapshot through <span style="color: #8FDCCB">x/vt</span> on every attach. Windrunner already holds authoritative cell state, so the client can request the grid directly and skip emulation entirely:</div>
+
+    <div style="padding: 12px 14px; background: #10141A; border: 1px solid #2A3138; border-radius: 6px; font-size: 12px; line-height: 1.65; color: #8FDCCB; white-space: pre">func (t *Terminal) seed(a *client.Attachment) error {
+    grid, err := a.Snapshot()   // cells, not bytes
+    if err != nil {
+        return fmt.Errorf("snapshot: %w", err)
+    }
+    t.screen.Restore(grid)
+    return nil
+}</div>
+
+    <div style="display: flex; align-items: center; gap: 10px; padding: 7px 12px; border: 1px solid #2A3138; border-radius: 4px; font-size: 12px; color: #74818B">
+      <span>▸</span>
+      <span style="color: #62AEEF">Edit</span>
+      <span style="color: #8FDCCB">internal/pty/terminal.go</span>
+      <span style="flex: 1 1 auto"></span>
+      <span>+31 −12</span>
+    </div>
+
+    <div style="display: flex; align-items: center; gap: 10px; padding: 7px 12px; border: 1px solid #2A3138; border-radius: 4px; font-size: 12px; color: #74818B">
+      <span>▸</span>
+      <span style="color: #62AEEF">Bash</span>
+      <span style="color: #8FDCCB">go test ./internal/pty/...</span>
+      <span style="flex: 1 1 auto"></span>
+      <span style="color: #72C087">ok · 0.41s</span>
+    </div>
+
+    <div style="color: #D7DEE5">Tests pass. Wiring the dashboard side next — the Gate can drop its per-frame re-emulation once the grid arrives pre-rendered.</div>
+
+  </div>
+
+  <!-- Pane footer -->
+  <div style="height: 30px; flex: 0 0 auto; display: flex; align-items: center; padding: 0 16px; background: #1B2126; border-top: 1px solid #2A3138; font-size: 11.5px">
+    <div style="display: flex; color: #C6E9FF"><span>j/k scroll</span><span style="color: #74818B"> · </span><span>o open tool call</span><span style="color: #74818B"> · </span><span>/ search</span><span style="color: #74818B"> · </span><span>y copy</span></div>
+    <div style="flex: 1 1 auto"></div>
+    <div style="color: #74818B">rendered from sessions.jsonl transcript</div>
+  </div>
+
+</div>
+</x-dc>
+<script data-dc-script data-props='{}'>
+class Component extends DCLogic {
+  renderVals() { return {}; }
+}
+</script>
+</body>
+</html>

--- a/docs/design/web/Wall.dc.html
+++ b/docs/design/web/Wall.dc.html
@@ -1,0 +1,173 @@
+<!doctype html>
+<html>
+<head>
+  <meta charset="utf-8">
+  <script src="./support.js"></script>
+</head>
+<body>
+<x-dc>
+<helmet>
+  <link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=JetBrains+Mono:ital,wght@0,400;0,500;0,700;1,400&display=swap">
+  <style>
+    body { margin: 0; background: #171C20; }
+    a { color: #62AEEF; } a:hover { color: #7DCFFF; }
+    .tl { white-space: pre; overflow: hidden; }
+    .card-head { height: 34px; flex: 0 0 auto; display: flex; align-items: center; gap: 8px; padding: 0 12px; background: #1B2126; border-bottom: 1px solid #2A3138; font-size: 12px; }
+    .card-body { flex: 1 1 auto; padding: 10px 12px; font-size: 10.5px; line-height: 1.6; color: #A9B4BC; }
+  </style>
+</helmet>
+<div style="width: 1440px; height: 900px; display: flex; flex-direction: column; background: #171C20; color: #D7DEE5; font-family: 'JetBrains Mono', ui-monospace, 'SF Mono', Menlo, monospace; font-size: 13px; overflow: hidden">
+
+  <!-- Top bar -->
+  <div style="height: 46px; flex: 0 0 auto; display: flex; align-items: center; gap: 16px; padding: 0 16px; background: #1B2126; border-bottom: 1px solid #2A3138">
+    <div style="font-size: 15px; font-weight: 700; letter-spacing: 0.04em; background: linear-gradient(90deg, #7AA2F7, #7DCFFF, #C8F7EF); -webkit-background-clip: text; background-clip: text; color: transparent">Stormlight</div>
+    <div style="display: flex; align-items: center; gap: 2px; padding: 3px; background: #14181D; border: 1px solid #2A3138; border-radius: 6px">
+      <div style="padding: 3px 12px; border-radius: 4px; color: #74818B; font-size: 12px">Roster</div>
+      <div style="padding: 3px 12px; border-radius: 4px; background: #C6E9FF; color: #0F2338; font-weight: 500; font-size: 12px">Wall</div>
+      <div style="padding: 3px 12px; border-radius: 4px; color: #74818B; font-size: 12px">History</div>
+    </div>
+    <div style="flex: 1 1 auto"></div>
+    <div style="display: flex; align-items: center; gap: 8px; font-size: 12px; color: #74818B">
+      <span style="color: #E5C07B">◆ 1 needs input</span>
+      <span>·</span>
+      <span style="color: #61AFEF">● 3 working</span>
+    </div>
+    <div style="display: flex; align-items: center; gap: 7px; font-size: 12px; color: #74818B">
+      <span style="width: 7px; height: 7px; border-radius: 50%; background: #72C087; display: inline-block"></span>
+      <span>windrunner · 6 sessions</span>
+    </div>
+  </div>
+
+  <!-- Wall grid -->
+  <div style="flex: 1 1 auto; display: grid; grid-template-columns: repeat(3, minmax(0, 1fr)); grid-template-rows: repeat(2, minmax(0, 1fr)); gap: 14px; padding: 16px; min-height: 0">
+
+    <!-- Card: working, selected -->
+    <div style="display: flex; flex-direction: column; background: #14181D; border: 1px solid #7DCFFF; border-radius: 6px; overflow: hidden; box-shadow: 0 0 0 1px rgba(125, 207, 255, 0.25)">
+      <div class="card-head">
+        <span style="color: #61AFEF">●</span>
+        <span style="color: #F3F5F6; font-weight: 500; flex: 1 1 auto; overflow: hidden; text-overflow: ellipsis; white-space: nowrap">Port grid renderer to windrunner</span>
+        <span style="color: #74818B; font-size: 11px">spanreed-pty · 12m</span>
+      </div>
+      <div class="card-body tl"><span style="color: #72C087">⏺</span> <span style="color: #62AEEF">Bash</span>(go test ./internal/pty/...)
+  <span style="color: #74818B">⎿ </span><span style="color: #8FDCCB">ok  internal/pty  0.41s</span>
+
+<span style="color: #72C087">⏺</span> Tests pass. Wiring the dashboard side
+  next — the Gate can drop its per-frame
+  re-emulation once the grid arrives
+  pre-rendered.
+
+  <span style="color: #61AFEF; font-style: italic">✻ Churning… (12m 41s)</span></div>
+    </div>
+
+    <!-- Card: waiting for input -->
+    <div style="display: flex; flex-direction: column; background: #14181D; border: 1px solid #E5C07B; border-radius: 6px; overflow: hidden; box-shadow: 0 0 14px rgba(229, 192, 123, 0.18)">
+      <div class="card-head">
+        <span style="color: #E5C07B">◆</span>
+        <span style="color: #F3F5F6; font-weight: 500; flex: 1 1 auto; overflow: hidden; text-overflow: ellipsis; white-space: nowrap">Footer hint mirroring</span>
+        <span style="color: #74818B; font-size: 11px">footer-hints · 3m</span>
+      </div>
+      <div class="card-body tl"><span style="color: #72C087">⏺</span> The mirrored hints need one push to
+  land on the PR branch.
+
+<span style="color: #D7DEE5">  Bash command</span>
+  <span style="color: #8FDCCB">git push -u origin footer-hints</span>
+
+  <span style="color: #D7DEE5">Do you want to proceed?</span>
+  <span style="color: #62AEEF">❯ 1. Yes</span>
+    <span style="color: #74818B">2. No, and tell Claude what to do</span></div>
+      <div style="flex: 0 0 auto; display: flex; align-items: center; gap: 8px; padding: 6px 12px; background: #E5C07B; color: #1F2328; font-size: 11.5px; font-weight: 700">
+        <span>◆ needs input — Allow Bash(git push)?</span>
+        <span style="flex: 1 1 auto"></span>
+        <span style="font-weight: 400">⏎ answer</span>
+      </div>
+    </div>
+
+    <!-- Card: working -->
+    <div style="display: flex; flex-direction: column; background: #14181D; border: 1px solid #2A3138; border-radius: 6px; overflow: hidden">
+      <div class="card-head">
+        <span style="color: #61AFEF">●</span>
+        <span style="color: #D7DEE5; font-weight: 500; flex: 1 1 auto; overflow: hidden; text-overflow: ellipsis; white-space: nowrap">Docs drift pass on site/</span>
+        <span style="color: #74818B; font-size: 11px">site-docs · 41m</span>
+      </div>
+      <div class="card-body tl"><span style="color: #72C087">⏺</span> <span style="color: #62AEEF">Read</span>(docs/workspace-resolvers.md)
+  <span style="color: #74818B">⎿ Read 180 lines</span>
+
+<span style="color: #72C087">⏺</span> <span style="color: #62AEEF">Edit</span>(site/docs/resolvers.html)
+  <span style="color: #74818B">⎿ Updated with 9 additions</span>
+
+<span style="color: #72C087">⏺</span> The resolver contract section now
+  matches the doc's three-layer story.
+
+  <span style="color: #61AFEF; font-style: italic">✻ Sifting… (41m 02s)</span></div>
+    </div>
+
+    <!-- Card: working (windrunner) -->
+    <div style="display: flex; flex-direction: column; background: #14181D; border: 1px solid #2A3138; border-radius: 6px; overflow: hidden">
+      <div class="card-head">
+        <span style="color: #61AFEF">●</span>
+        <span style="color: #D7DEE5; font-weight: 500; flex: 1 1 auto; overflow: hidden; text-overflow: ellipsis; white-space: nowrap">Attach backpressure design</span>
+        <span style="color: #74818B; font-size: 11px">windrunner · 22m</span>
+      </div>
+      <div class="card-body tl"><span style="color: #72C087">⏺</span> <span style="color: #62AEEF">Grep</span>(backlog, engine.go)
+  <span style="color: #74818B">⎿ 14 matches</span>
+
+<span style="color: #72C087">⏺</span> The attach ring already counts unread
+  bytes per client; an ack watermark can
+  ride the existing wire frames without
+  a protocol bump.
+
+  <span style="color: #61AFEF; font-style: italic">✻ Considering… (22m 18s)</span></div>
+    </div>
+
+    <!-- Card: done -->
+    <div style="display: flex; flex-direction: column; background: #14181D; border: 1px solid #2A3138; border-radius: 6px; overflow: hidden; opacity: 0.75">
+      <div class="card-head">
+        <span style="color: #72C087">✓</span>
+        <span style="color: #D7DEE5; font-weight: 500; flex: 1 1 auto; overflow: hidden; text-overflow: ellipsis; white-space: nowrap">History resume flow</span>
+        <span style="color: #74818B; font-size: 11px">history-resume · 1h</span>
+      </div>
+      <div class="card-body tl"><span style="color: #72C087">⏺</span> <span style="color: #62AEEF">Bash</span>(go test ./...)
+  <span style="color: #74818B">⎿ </span><span style="color: #8FDCCB">ok  all packages  4.2s</span>
+
+<span style="color: #72C087">⏺</span> Done. Resume now reopens the session
+  in the workspace it left, transcript
+  intact. PR #118 is up for review.
+
+  <span style="color: #72C087">✓ exited 0 · 58m total</span></div>
+    </div>
+
+    <!-- Card: idle -->
+    <div style="display: flex; flex-direction: column; background: #14181D; border: 1px solid #2A3138; border-radius: 6px; overflow: hidden; opacity: 0.75">
+      <div class="card-head">
+        <span style="color: #E5C07B">○</span>
+        <span style="color: #D7DEE5; font-weight: 500; flex: 1 1 auto; overflow: hidden; text-overflow: ellipsis; white-space: nowrap">Oathgate cursor shapes</span>
+        <span style="color: #74818B; font-size: 11px">oathgate · idle 2h</span>
+      </div>
+      <div class="card-body tl"><span style="color: #72C087">⏺</span> Cursor shape sequences (DECSCUSR) now
+  round-trip through the widget.
+
+  <span style="color: #74818B">Waiting for your reply — what should
+  the default shape be when the host
+  app never sets one?</span>
+
+<span style="color: #74818B">&gt; _</span></div>
+    </div>
+
+  </div>
+
+  <!-- Footer hints -->
+  <div style="height: 30px; flex: 0 0 auto; display: flex; align-items: center; gap: 14px; padding: 0 16px; background: #1B2126; border-top: 1px solid #2A3138; font-size: 11.5px">
+    <div style="display: flex; gap: 0; color: #C6E9FF"><span>⏎ focus agent</span><span style="color: #74818B"> · </span><span>j/k move</span><span style="color: #74818B"> · </span><span>w roster</span><span style="color: #74818B"> · </span><span>m message</span><span style="color: #74818B"> · </span><span>? keys</span></div>
+    <div style="flex: 1 1 auto"></div>
+    <div style="color: #74818B">6 agents · 1 needs input</div>
+  </div>
+
+</div>
+</x-dc>
+<script data-dc-script data-props='{}'>
+class Component extends DCLogic {
+  renderVals() { return {}; }
+}
+</script>
+</body>
+</html>

--- a/docs/design/web/canvas.json
+++ b/docs/design/web/canvas.json
@@ -1,0 +1,15 @@
+{
+  "artboards": [
+    { "file": "Main.dc.html", "x": 0, "y": 0, "w": 1440, "h": 900, "title": "Roster · Spanreed pane" },
+    { "file": "Wall.dc.html", "x": 1560, "y": 0, "w": 1440, "h": 900, "title": "The Wall" },
+    { "file": "Transcript.dc.html", "x": 0, "y": 1040, "w": 880, "h": 780, "title": "Transcript tab" },
+    { "file": "Diff.dc.html", "x": 1000, "y": 1040, "w": 880, "h": 780, "title": "Diff tab" }
+  ],
+  "annotations": [
+    { "id": "note-overview", "x": -320, "y": 0, "w": 280, "text": "Stage 2 of stormlight web — a second client on the same windrunner daemon.\n\nLayout keeps the TUI's DNA: workspaces → agent roster → Spanreed pane. Palette, status glyphs (● ◆ ○ ✓), and dot-separated footer hints lifted from internal/theme." },
+    { "id": "note-wall", "x": 3040, "y": 0, "w": 260, "text": "The Wall: every agent's terminal live at once — the thing terminal cells can't do. Each card is its own xterm.js pane on the same attach stream.\n\nAmber border + band = waiting for input. Click a card (or ⏎) to focus it." },
+    { "id": "note-transcript", "x": -320, "y": 1040, "w": 280, "text": "Transcript as rendered markdown: prose, highlighted code, tool calls as collapsible rows. Reading what an agent DID is the part cells serve worst." },
+    { "id": "note-diff", "x": 1000, "y": 1880, "w": 300, "text": "Diff tab: every agent works a worktree, so every agent has a reviewable diff — review the work product without walking into the terminal.\n\nThe one v1 scope question: this is the only tab that needs the API to know git, not just the daemon." }
+  ],
+  "launch": { "view": "canvas" }
+}


### PR DESCRIPTION
Commits the four design artboards for the Stormlight Web GUI (#125) under `docs/design/web/`, with a README explaining how to view them and how the palette maps to `internal/theme`. Self-contained HTML — open any artboard directly in a browser.

Making the visual spec repo-resident so #125 is workable by any contributor or agent without access to the private design canvas.

🤖 Generated with [Claude Code](https://claude.com/claude-code)