### PR TITLE
A workspace knows which machine it is on

### DIFF
--- a/docs/workspace-resolvers.md
+++ b/docs/workspace-resolvers.md
@@ -87,3 +87,30 @@ process. Root enumeration runs only on the resolver that claimed the workspace,
 has a one-second deadline, and caches successful, unsupported, and failed
 outcomes for five seconds. A failed or timed-out inventory never blocks
 dashboard refresh; it logs the failure and exposes the resolved primary root.
+
+## Resolution on another machine
+
+Resolution is filesystem work: `git rev-parse`, a directory that has to
+exist, an executable resolver in a host's own configuration directory. So
+for a workspace on another machine it runs on that machine, through
+`stormlight _resolve <path>` over SSH — the same chain, that host's
+resolvers, its answer. `--roots` asks the same question about every
+runnable checkout.
+
+Two rules follow from the asymmetry:
+
+- **Paths are not canonicalized here.** `EvalSymlinks` and `Stat` describe
+  the wrong filesystem. A path can exist on both machines and mean
+  different repositories, so a local answer about a remote path looks
+  entirely correct and quietly merges two workspaces into one.
+- **An unreachable host is an error, not a directory.** Local resolution
+  falls back to a plain directory context, which asserts that the directory
+  is there. Nothing on this side can assert that about another machine, so
+  a host that cannot answer resolves to a failure rather than to a
+  workspace that looks perfectly ordinary and describes nothing.
+
+The host is stamped by the side that asked, because a resolver answers
+about its own machine and has no name for it. Stamping also qualifies the
+workspace ID — `devbox:git:/srv/api/.git` — so the same path on two
+machines stays two workspace groups. Paths themselves are never rewritten;
+they belong to the host.

--- a/internal/remote/ssh.go
+++ b/internal/remote/ssh.go
@@ -1,6 +1,7 @@
 package remote
 
 import (
+	"context"
 	"crypto/sha256"
 	"encoding/hex"
 	"encoding/json"
@@ -119,6 +120,13 @@ func (t *Transport) Dial() (net.Conn, error) {
 // left to whatever that host's shell happens to set.
 func (t *Transport) Command(env []string, args ...string) *exec.Cmd {
 	return exec.Command(t.host.sshProgram(), t.sshArgs(false, env, args)...)
+}
+
+// CommandContext is Command bound to a context, for the calls a caller
+// gives up on: workspace resolution runs on the dashboard's refresh path,
+// where an unreachable host must not hold the frame.
+func (t *Transport) CommandContext(ctx context.Context, env []string, args ...string) *exec.Cmd {
+	return exec.CommandContext(ctx, t.host.sshProgram(), t.sshArgs(false, env, args)...)
 }
 
 // TTYCommand is Command for a program that needs a terminal on the far

--- a/internal/workspace/context.go
+++ b/internal/workspace/context.go
@@ -15,6 +15,10 @@ const (
 
 // Context describes the workspace grouping and execution boundary for an agent.
 type Context struct {
+	// Host names the machine this workspace is on; empty means this one.
+	// It belongs to identity rather than decoration: two machines can
+	// hold the same path, and those are two workspaces, not one.
+	Host          string            `json:"host,omitempty"`
 	ID            string            `json:"id"`
 	Kind          string            `json:"kind"`
 	Name          string            `json:"name"`
@@ -27,6 +31,21 @@ type Context struct {
 
 func (c Context) IsZero() bool {
 	return c.ID == ""
+}
+
+// OnHost is a context resolved on another machine, as this dashboard has
+// to record it. The resolver over there answers about its own filesystem
+// and has no idea what this side calls it, so the host is stamped here —
+// and the ID is qualified with it, because /home/me/src/api on two
+// machines is two workspaces and an unqualified ID would merge them into
+// one group holding agents that cannot see each other's files.
+func (c Context) OnHost(host string) Context {
+	if host == "" || c.Host == host {
+		return c
+	}
+	c.Host = host
+	c.ID = host + ":" + c.ID
+	return c
 }
 
 // Tail is the lineage segment that follows the workspace name: a
@@ -91,18 +110,45 @@ func canonicalDirectory(path string) (string, error) {
 	return filepath.Clean(resolved), nil
 }
 
+// normalizeContext is the local form: every path is checked against this
+// machine's filesystem, because on this machine that is knowable.
 func normalizeContext(value Context) (Context, error) {
+	return normalize(value, canonicalDirectory)
+}
+
+// normalizeRemoteContext is the form for a context that was resolved on
+// another machine. The identity rules are the same; the path rules cannot
+// be, because the only filesystem this process can stat is the wrong one.
+// A local check here would be worse than none: it would fail for a path
+// that exists over there, and quietly pass for one that happens to exist
+// here too.
+func normalizeRemoteContext(value Context) (Context, error) {
+	return normalize(value, func(path string) (string, error) {
+		path = strings.TrimSpace(path)
+		if path == "" {
+			return "", fmt.Errorf("a remote path cannot be empty")
+		}
+		if !filepath.IsAbs(path) {
+			return "", fmt.Errorf("remote path %q is not absolute", path)
+		}
+		return filepath.Clean(path), nil
+	})
+}
+
+func normalize(value Context, canonical func(string) (string, error)) (Context, error) {
+	value.Host = strings.TrimSpace(value.Host)
 	value.Kind = strings.TrimSpace(strings.ToLower(value.Kind))
 	value.Name = strings.TrimSpace(value.Name)
 	value.ID = strings.TrimSpace(value.ID)
 	if value.Kind == "" {
 		return Context{}, fmt.Errorf("workspace kind is required")
 	}
-	if hasControl(value.Kind) || hasControl(value.Name) || hasControl(value.ID) {
+	if hasControl(value.Kind) || hasControl(value.Name) || hasControl(value.ID) ||
+		hasControl(value.Host) {
 		return Context{}, fmt.Errorf("workspace identity contains control characters")
 	}
 
-	root, err := canonicalDirectory(value.Root)
+	root, err := canonical(value.Root)
 	if err != nil {
 		return Context{}, fmt.Errorf("workspace root: %w", err)
 	}
@@ -117,14 +163,14 @@ func normalizeContext(value Context) (Context, error) {
 	if strings.TrimSpace(value.ExecutionRoot) == "" {
 		value.ExecutionRoot = root
 	}
-	value.ExecutionRoot, err = canonicalDirectory(value.ExecutionRoot)
+	value.ExecutionRoot, err = canonical(value.ExecutionRoot)
 	if err != nil {
 		return Context{}, fmt.Errorf("execution root: %w", err)
 	}
 
 	value.ComponentName = strings.TrimSpace(value.ComponentName)
 	if strings.TrimSpace(value.ComponentRoot) != "" {
-		value.ComponentRoot, err = canonicalDirectory(value.ComponentRoot)
+		value.ComponentRoot, err = canonical(value.ComponentRoot)
 		if err != nil {
 			return Context{}, fmt.Errorf("component root: %w", err)
 		}

--- a/internal/workspace/context_test.go
+++ b/internal/workspace/context_test.go
@@ -52,3 +52,40 @@ func TestContextTail(t *testing.T) {
 		}
 	}
 }
+
+// TestOnHostQualifiesIdentity: two machines can hold the same path, and
+// an unqualified ID would merge them into one workspace group holding
+// agents that cannot see each other's files.
+func TestOnHostQualifiesIdentity(t *testing.T) {
+	local := Context{
+		ID:            "git:/srv/api/.git",
+		Kind:          KindGit,
+		Name:          "api",
+		Root:          "/srv/api",
+		ExecutionRoot: "/srv/api",
+	}
+	remote := local.OnHost("devbox")
+
+	if remote.Host != "devbox" {
+		t.Fatalf("host not recorded: %+v", remote)
+	}
+	if remote.ID == local.ID {
+		t.Fatalf("the same id on two machines is two workspaces: %q", remote.ID)
+	}
+	if remote.ID != "devbox:git:/srv/api/.git" {
+		t.Fatalf("id = %q", remote.ID)
+	}
+	// Paths belong to the far side and are not rewritten.
+	if remote.Root != local.Root || remote.ExecutionRoot != local.ExecutionRoot {
+		t.Fatalf("paths must stay the host's: %+v", remote)
+	}
+	// Stamping is idempotent: a context that already names its host is
+	// not qualified twice as it passes through the registry again.
+	if again := remote.OnHost("devbox"); again.ID != remote.ID {
+		t.Fatalf("qualification is not idempotent: %q", again.ID)
+	}
+	// And this machine's workspaces are untouched by any of it.
+	if local.OnHost("").ID != local.ID {
+		t.Fatalf("a local context must not be qualified")
+	}
+}

--- a/internal/workspace/registry.go
+++ b/internal/workspace/registry.go
@@ -3,9 +3,11 @@ package workspace
 import (
 	"context"
 	"errors"
+	"fmt"
 	"os"
 	"path/filepath"
 	"slices"
+	"strings"
 	"sync"
 	"time"
 
@@ -22,6 +24,11 @@ type executionRootResolver interface {
 }
 
 type Registry struct {
+	// host is the machine this registry answers about; empty is this one.
+	// Everything below changes shape when it is set: paths are not
+	// canonicalized here, contexts are not checked against this
+	// filesystem, and every ID is qualified with the host.
+	host      string
 	resolvers []Resolver
 	mu        sync.RWMutex
 	cache     map[string]Context
@@ -59,7 +66,7 @@ func NewRegistryWithResolvers(resolvers ...Resolver) *Registry {
 }
 
 func (r *Registry) Resolve(ctx context.Context, path string) (Context, error) {
-	canonical, err := canonicalDirectory(path)
+	canonical, err := r.canonicalize(path)
 	if err != nil {
 		return Context{}, err
 	}
@@ -71,9 +78,13 @@ func (r *Registry) Resolve(ctx context.Context, path string) (Context, error) {
 		return cached, nil
 	}
 
+	// A resolver that fails is logged and passed over — except on a
+	// remote host, where its failure is the only answer available.
+	var failure error
 	for index, resolver := range r.resolvers {
 		value, matched, resolveErr := resolver.Resolve(ctx, canonical)
 		if resolveErr != nil {
+			failure = resolveErr
 			if errors.Is(resolveErr, context.Canceled) ||
 				errors.Is(resolveErr, context.DeadlineExceeded) ||
 				ctx.Err() != nil {
@@ -89,7 +100,7 @@ func (r *Registry) Resolve(ctx context.Context, path string) (Context, error) {
 		if !matched {
 			continue
 		}
-		value, err = normalizeContext(value)
+		value, err = r.normalize(value)
 		if err != nil {
 			diagnostic.Logger().Warn("workspace resolver returned invalid context",
 				"resolver", resolver.Name(),
@@ -102,9 +113,52 @@ func (r *Registry) Resolve(ctx context.Context, path string) (Context, error) {
 		return value, nil
 	}
 
+	// The canonical-directory fallback says "this is a plain directory,
+	// and I know it is there" — which is true here and unknowable about
+	// another machine. Inventing one for an unreachable host would
+	// replace an error with a workspace that looks perfectly ordinary
+	// and describes nothing.
+	if r.host != "" {
+		if failure != nil {
+			return Context{}, failure
+		}
+		return Context{}, fmt.Errorf("%s did not resolve %s", r.host, canonical)
+	}
 	value := DirectoryContext(canonical)
 	r.store(canonical, value, noResolver)
 	return value, nil
+}
+
+// canonicalize resolves a path against the filesystem that owns it. For
+// another machine that is not this one, so the path is taken as given —
+// the resolver over there canonicalizes for real, and a local
+// EvalSymlinks would answer about a path that merely shares a name.
+func (r *Registry) canonicalize(path string) (string, error) {
+	if r.host == "" {
+		return canonicalDirectory(path)
+	}
+	trimmed := strings.TrimSpace(path)
+	if trimmed == "" {
+		return "", fmt.Errorf("a path on %s must be given in full", r.host)
+	}
+	if !filepath.IsAbs(trimmed) {
+		return "", fmt.Errorf("path %q on %s is not absolute", trimmed, r.host)
+	}
+	return filepath.Clean(trimmed), nil
+}
+
+// normalize applies the identity rules, and stamps the host onto whatever
+// a resolver returned: a remote resolver answers about its own machine
+// and has no name for it.
+func (r *Registry) normalize(value Context) (Context, error) {
+	if r.host == "" {
+		return normalizeContext(value)
+	}
+	value, err := normalizeRemoteContext(value)
+	if err != nil {
+		return Context{}, err
+	}
+	return value.OnHost(r.host), nil
 }
 
 // ExecutionRoots returns every runnable checkout currently belonging to a
@@ -156,7 +210,7 @@ func (r *Registry) ExecutionRoots(ctx context.Context, value Context) ([]Context
 	normalized := make([]Context, 0, len(values))
 	seen := make(map[string]bool, len(values))
 	for _, candidate := range values {
-		candidate, err = normalizeContext(candidate)
+		candidate, err = r.normalize(candidate)
 		if err != nil {
 			diagnostic.Logger().Warn("workspace resolver returned invalid execution root",
 				"resolver", resolver.Name(),

--- a/internal/workspace/remote.go
+++ b/internal/workspace/remote.go
@@ -1,0 +1,82 @@
+package workspace
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"strings"
+
+	"github.com/trentkm/stormlight/internal/remote"
+)
+
+// NewRegistryForHost resolves workspaces on another machine.
+//
+// Resolution is filesystem work — `git rev-parse`, a directory that has to
+// exist, an executable resolver in that host's config — so it runs where
+// the filesystem is, through `stormlight _resolve`. Doing it here would be
+// wrong in the quietest possible way: /home/me/src/api may well exist on
+// both machines, and a local answer about a remote path looks entirely
+// correct until two different repositories share one workspace group.
+func NewRegistryForHost(host remote.Host) *Registry {
+	registry := NewRegistryWithResolvers(remoteResolver{
+		transport: remote.NewTransport(host),
+		host:      host.Name,
+	})
+	registry.host = host.Name
+	return registry
+}
+
+type remoteResolver struct {
+	transport *remote.Transport
+	host      string
+}
+
+func (r remoteResolver) Name() string { return "remote:" + r.host }
+
+func (r remoteResolver) Resolve(ctx context.Context, path string) (Context, bool, error) {
+	output, err := r.run(ctx, "_resolve", path)
+	if err != nil {
+		return Context{}, false, err
+	}
+	var value Context
+	if err := json.Unmarshal(output, &value); err != nil {
+		return Context{}, false, fmt.Errorf("%s: %w", r.Name(), err)
+	}
+	return value, true, nil
+}
+
+func (r remoteResolver) ExecutionRoots(
+	ctx context.Context,
+	value Context,
+) ([]Context, bool, error) {
+	output, err := r.run(ctx, "_resolve", "--roots", value.Root)
+	if err != nil {
+		return nil, true, err
+	}
+	var values []Context
+	if err := json.Unmarshal(output, &values); err != nil {
+		return nil, true, fmt.Errorf("%s: %w", r.Name(), err)
+	}
+	return values, true, nil
+}
+
+func (r remoteResolver) run(ctx context.Context, args ...string) ([]byte, error) {
+	command := r.transport.CommandContext(ctx, nil, args...)
+	var stdout, stderr bytes.Buffer
+	command.Stdout = &stdout
+	command.Stderr = &stderr
+	if err := command.Run(); err != nil {
+		if ctx.Err() != nil {
+			return nil, ctx.Err()
+		}
+		// The far side's own complaint says which of the many first-run
+		// problems this is: no stormlight there, no such directory, a
+		// key that is not accepted.
+		if message := strings.TrimSpace(stderr.String()); message != "" {
+			return nil, fmt.Errorf("%s: %s", r.Name(), message)
+		}
+		return nil, fmt.Errorf("%s: %w", r.Name(), err)
+	}
+	return stdout.Bytes(), nil
+}

--- a/internal/workspace/remote_test.go
+++ b/internal/workspace/remote_test.go
@@ -1,0 +1,157 @@
+package workspace
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/trentkm/stormlight/internal/remote"
+)
+
+// fakeHost stands in for a machine reachable over SSH: a script that
+// answers `_resolve` the way that host's own Stormlight would.
+func fakeHost(t *testing.T, name, script string) remote.Host {
+	t.Helper()
+	path := filepath.Join(t.TempDir(), "ssh")
+	if err := os.WriteFile(path, []byte("#!/bin/sh\n"+script+"\n"), 0o755); err != nil {
+		t.Fatalf("write fake ssh: %v", err)
+	}
+	return remote.Host{Name: name, SSHProgram: path}
+}
+
+const remoteAnswer = `{"id":"git:/srv/api/.git","kind":"git","name":"api",` +
+	`"root":"/srv/api","execution_root":"/srv/api"}`
+
+// TestRemoteResolutionAnswersAboutTheOtherMachine: the resolved paths are
+// the far side's, and this process never had to have them.
+func TestRemoteResolutionAnswersAboutTheOtherMachine(t *testing.T) {
+	host := fakeHost(t, "devbox", `printf '%s\n' '`+remoteAnswer+`'`)
+	registry := NewRegistryForHost(host)
+
+	value, err := registry.Resolve(context.Background(), "/srv/api")
+	if err != nil {
+		t.Fatalf("Resolve: %v", err)
+	}
+	if value.Host != "devbox" {
+		t.Fatalf("host not recorded: %+v", value)
+	}
+	// Qualified, because /srv/api on two machines is two workspaces.
+	if value.ID != "devbox:git:/srv/api/.git" {
+		t.Fatalf("id not qualified with the host: %q", value.ID)
+	}
+	if value.Root != "/srv/api" || value.Name != "api" {
+		t.Fatalf("the far side's answer was rewritten: %+v", value)
+	}
+	// /srv/api does not exist here, and nothing about resolving it should
+	// have required that it did.
+	if _, err := os.Stat("/srv/api"); err == nil {
+		t.Skip("/srv/api exists on this machine; the premise does not hold")
+	}
+}
+
+// TestRemoteResolutionIgnoresAPathThatHappensToExistHere is the quiet
+// failure this design exists to prevent. A path can exist on both
+// machines and mean different repositories; resolving it locally would
+// look entirely correct and merge two workspaces into one group whose
+// agents cannot see each other's files.
+func TestRemoteResolutionIgnoresAPathThatHappensToExistHere(t *testing.T) {
+	shared := t.TempDir()
+	// A real git repository here, at the same path the far side answers
+	// about. If anything resolved locally, this is what it would find.
+	answer := `{"id":"git:` + shared + `/.git","kind":"git","name":"the-far-side-copy",` +
+		`"root":"` + shared + `","execution_root":"` + shared + `"}`
+	host := fakeHost(t, "devbox", `printf '%s\n' '`+answer+`'`)
+	registry := NewRegistryForHost(host)
+
+	value, err := registry.Resolve(context.Background(), shared)
+	if err != nil {
+		t.Fatalf("Resolve: %v", err)
+	}
+	if value.Name != "the-far-side-copy" {
+		t.Fatalf("the local filesystem answered instead of the host: %+v", value)
+	}
+	if value.Host != "devbox" || !strings.HasPrefix(value.ID, "devbox:") {
+		t.Fatalf("identity must stay the host's: %+v", value)
+	}
+}
+
+func TestRemoteExecutionRootsAreQualifiedToo(t *testing.T) {
+	answer := `[{"id":"git:/srv/api/.git","kind":"git","name":"api","root":"/srv/api",` +
+		`"execution_root":"/srv/api"},` +
+		`{"id":"git:/srv/api/.git","kind":"git","name":"api","root":"/srv/api",` +
+		`"execution_root":"/srv/api-worktrees/fix"}]`
+	host := fakeHost(t, "devbox", `
+for last; do :; done
+case "$last" in
+  *--roots*) printf '%s\n' '`+answer+`' ;;
+  *) printf '%s\n' '`+remoteAnswer+`' ;;
+esac`)
+	registry := NewRegistryForHost(host)
+
+	value, err := registry.Resolve(context.Background(), "/srv/api")
+	if err != nil {
+		t.Fatalf("Resolve: %v", err)
+	}
+	roots, err := registry.ExecutionRoots(context.Background(), value)
+	if err != nil {
+		t.Fatalf("ExecutionRoots: %v", err)
+	}
+	if len(roots) != 2 {
+		t.Fatalf("want both checkouts, got %+v", roots)
+	}
+	for _, root := range roots {
+		if root.Host != "devbox" || root.ID != value.ID {
+			t.Fatalf("every checkout belongs to the same qualified workspace: %+v", root)
+		}
+	}
+	if roots[1].ExecutionRoot != "/srv/api-worktrees/fix" {
+		t.Fatalf("worktree lost: %+v", roots[1])
+	}
+}
+
+// TestRemoteResolutionReportsTheFarSidesComplaint: the first-run failures
+// are all on the other machine — no stormlight there, no such directory,
+// a key that is not accepted — and only that machine can say which.
+func TestRemoteResolutionReportsTheFarSidesComplaint(t *testing.T) {
+	host := fakeHost(t, "devbox", `echo "sh: stormlight: not found" >&2; exit 127`)
+	registry := NewRegistryForHost(host)
+
+	_, err := registry.Resolve(context.Background(), "/srv/api")
+	if err == nil {
+		t.Fatal("a host that cannot answer must not resolve")
+	}
+	if !strings.Contains(err.Error(), "stormlight: not found") {
+		t.Fatalf("want the far side's own words, got: %v", err)
+	}
+}
+
+// TestRemoteResolutionRefusesARelativePath: a relative path means "here",
+// and here is the wrong machine. There is no working directory this side
+// can offer that would mean anything over there.
+func TestRemoteResolutionRefusesARelativePath(t *testing.T) {
+	host := fakeHost(t, "devbox", `printf '%s\n' '`+remoteAnswer+`'`)
+	registry := NewRegistryForHost(host)
+
+	if _, err := registry.Resolve(context.Background(), "src/api"); err == nil {
+		t.Fatal("a relative remote path must be refused")
+	}
+	if _, err := registry.Resolve(context.Background(), ""); err == nil {
+		t.Fatal("an empty remote path must be refused")
+	}
+}
+
+func TestLocalRegistryIsUnchangedByHosts(t *testing.T) {
+	registry := NewRegistry()
+	value, err := registry.Resolve(context.Background(), t.TempDir())
+	if err != nil {
+		t.Fatalf("Resolve: %v", err)
+	}
+	if value.Host != "" {
+		t.Fatalf("a local workspace has no host: %+v", value)
+	}
+	if strings.Contains(value.ID, ":"+value.Kind+":") {
+		t.Fatalf("a local id is never qualified: %q", value.ID)
+	}
+}

--- a/main.go
+++ b/main.go
@@ -122,6 +122,7 @@ func newRootCommand() *cobra.Command {
 		newWindrunnerDaemonCommand(),
 		newWindrunnerAttachCommand(),
 		newWindrunnerBridgeCommand(),
+		newResolveCommand(),
 		newBenchCommand(),
 	)
 	return root
@@ -187,6 +188,40 @@ func newWindrunnerBridgeCommand() *cobra.Command {
 			}, os.Stdin, os.Stdout)
 		},
 	}
+}
+
+// newResolveCommand answers what a directory belongs to, on this machine.
+// A dashboard on another machine runs it over SSH, because resolution is
+// filesystem work — `git rev-parse`, a directory that has to exist, an
+// executable resolver in this host's own config — and none of that can be
+// answered from somewhere else. The reply is the workspace context as
+// JSON, with --roots for every runnable checkout in the same workspace.
+func newResolveCommand() *cobra.Command {
+	var roots bool
+	command := &cobra.Command{
+		Use:    "_resolve <path>",
+		Hidden: true,
+		Args:   cobra.ExactArgs(1),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			registry := workspace.NewRegistry()
+			value, err := registry.Resolve(cmd.Context(), args[0])
+			if err != nil {
+				return err
+			}
+			encoder := json.NewEncoder(cmd.OutOrStdout())
+			if !roots {
+				return encoder.Encode(value)
+			}
+			values, err := registry.ExecutionRoots(cmd.Context(), value)
+			if err != nil {
+				return err
+			}
+			return encoder.Encode(values)
+		},
+	}
+	command.Flags().BoolVar(&roots, "roots", false,
+		"report every runnable checkout in the workspace")
+	return command
 }
 
 // newWindrunnerAttachCommand is the F key's other half: a full-terminal

--- a/main_test.go
+++ b/main_test.go
@@ -137,3 +137,48 @@ func TestTruncatePlainCollapsesWhitespaceAndCountsRunes(t *testing.T) {
 		})
 	}
 }
+
+// TestResolveCommandAnswersAsJSON: a dashboard on another machine runs
+// this over SSH and parses what comes back, so the contract is the shape
+// of stdout.
+func TestResolveCommandAnswersAsJSON(t *testing.T) {
+	directory := t.TempDir()
+	command := newResolveCommand()
+	var out bytes.Buffer
+	command.SetOut(&out)
+	command.SetArgs([]string{directory})
+	if err := command.Execute(); err != nil {
+		t.Fatalf("Execute: %v", err)
+	}
+
+	var value workspace.Context
+	if err := json.Unmarshal(out.Bytes(), &value); err != nil {
+		t.Fatalf("stdout must be one JSON object: %v (%q)", err, out.String())
+	}
+	if value.Root == "" || value.Kind == "" || value.ID == "" {
+		t.Fatalf("incomplete context: %+v", value)
+	}
+	// The answer describes this machine; naming the host is the asking
+	// side's job, because a host does not know what a remote dashboard
+	// calls it.
+	if value.Host != "" {
+		t.Fatalf("a resolver must not name its own host: %+v", value)
+	}
+}
+
+func TestResolveCommandReportsEveryCheckout(t *testing.T) {
+	command := newResolveCommand()
+	var out bytes.Buffer
+	command.SetOut(&out)
+	command.SetArgs([]string{"--roots", t.TempDir()})
+	if err := command.Execute(); err != nil {
+		t.Fatalf("Execute: %v", err)
+	}
+	var values []workspace.Context
+	if err := json.Unmarshal(out.Bytes(), &values); err != nil {
+		t.Fatalf("--roots must answer with a JSON array: %v (%q)", err, out.String())
+	}
+	if len(values) == 0 {
+		t.Fatal("a workspace always has at least the checkout it was resolved from")
+	}
+}

--- a/site/docs/workspace-resolvers.html
+++ b/site/docs/workspace-resolvers.html
@@ -37,6 +37,7 @@
     <li class="current"><a href="workspace-resolvers.html">Workspace resolvers</a><ul class="sections">
     <li><a href="#resolution-order">Resolution order</a></li>
     <li><a href="#executable-protocol">Executable protocol</a></li>
+    <li><a href="#remote-resolution">Resolution on another machine</a></li>
     </ul></li>
     <li><a href="configuration.html">Configuration</a></li>
   </ul>
@@ -111,6 +112,30 @@
     deadline, and caches successful, unsupported, and failed outcomes for five seconds. A
     failed or timed-out inventory never blocks dashboard refresh; it logs the failure and
     exposes the resolved primary root.</p>
+
+    <h2 id="remote-resolution">Resolution on another machine</h2>
+    <p>Resolution is filesystem work: <code>git rev-parse</code>, a directory that has to
+    exist, an executable resolver in a host's own configuration directory. So for a
+    workspace on another machine it runs on that machine, through
+    <code>stormlight _resolve &lt;path&gt;</code> over SSH — the same chain, that host's
+    resolvers, its answer. <code>--roots</code> asks the same question about every runnable
+    checkout.</p>
+    <p>Two rules follow from the asymmetry:</p>
+    <ul>
+      <li><strong>Paths are not canonicalized here.</strong> <code>EvalSymlinks</code> and
+      <code>Stat</code> describe the wrong filesystem. A path can exist on both machines and
+      mean different repositories, so a local answer about a remote path looks entirely
+      correct and quietly merges two workspaces into one.</li>
+      <li><strong>An unreachable host is an error, not a directory.</strong> Local
+      resolution falls back to a plain directory context, which asserts that the directory
+      is there. Nothing on this side can assert that about another machine, so a host that
+      cannot answer resolves to a failure rather than to a workspace that looks perfectly
+      ordinary and describes nothing.</li>
+    </ul>
+    <p>The host is stamped by the side that asked, because a resolver answers about its own
+    machine and has no name for it. Stamping also qualifies the workspace ID —
+    <code>devbox:git:/srv/api/.git</code> — so the same path on two machines stays two
+    workspace groups. Paths themselves are never rewritten; they belong to the host.</p>
   </article>
 
   <nav class="doc-pager"><a href="architecture.html">← Architecture</a><a href="configuration.html">Configuration →</a></nav>


### PR DESCRIPTION
Phase 3a of #127. Workspace identity and resolution learn about hosts; nothing
consumes it yet beyond `--host`, which the fleet PR will replace.

## Resolution runs where the filesystem is

`stormlight _resolve <path>` answers what a directory belongs to, on the
machine it is on: the same resolver chain, that host's own executable
resolvers, its answer as JSON. `--roots` asks about every runnable checkout,
so remote worktrees group the way local ones do.

Resolving remotely is not a nicety. `/home/me/src/api` exists on plenty of
machines, and a local `EvalSymlinks` against a remote path does not error — it
succeeds, about a *different* repository, and merges two workspaces into one
group whose agents cannot see each other's files. So a host-bound registry
canonicalizes nothing locally and checks no path against this filesystem.
There is a test for exactly that case: the same path present on both sides,
asserting the host's answer wins.

## An unreachable host is an error, not a directory

Local resolution ends at a plain directory context, which asserts the
directory is there. Nothing on this side can assert that about another
machine, so the fallback is now local-only: a host that cannot answer resolves
to its own error.

That one came out of writing the test for an unreachable host — it had been
returning a cheerful directory workspace, which is precisely the "looks fine,
describes nothing" failure this design is supposed to refuse.

## Identity

`workspace.Context` gains `Host`, and `OnHost` stamps it — qualifying the ID
(`devbox:git:/srv/api/.git`) so the same path on two machines stays two
workspace groups, and leaving paths alone because they belong to the host.
Stamping happens on the asking side, since a resolver answers about its own
machine and has no name for it. It is idempotent, so a context passing through
a registry twice is not qualified twice.

`normalizeContext` splits into an identity pass (string hygiene, defaults) and
a path pass, so the remote form can keep the first and skip the second.

## Testing

`go test ./...` green. New coverage:

- A remote path that does not exist here resolves anyway.
- A path that *does* exist here resolves to the host's answer, not this
  machine's — the quiet-failure case above.
- Execution roots come back host-qualified and grouped under one workspace.
- A failing host surfaces its own words (`sh: stormlight: not found`), not a
  JSON parse error.
- Relative and empty remote paths are refused: "here" is the wrong machine.
- A registry with no host takes exactly the path it took before.
- `_resolve` emits one JSON object, an array under `--roots`, and never names
  its own host.

## Not in this PR

The fleet: config-defined hosts, one runtime per host, merged rosters, offline
degradation, the catalog learning hosts, and host badges in the UI.
