### PR TITLE
One dashboard, several machines

### DIFF
--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -154,9 +154,19 @@ binds a port. This is also why the transport is SSH rather than a
 tailnet-native listener — Tailscale is a network the transport runs over,
 and `stormlight remote add` works on one without a line of code about it.
 
-Today `--host` swaps which daemon the whole dashboard talks to. Making the
-host a dimension of workspace identity, so local and remote agents share
-one roster, is the next step ([#127](https://github.com/trentkm/stormlight/issues/127)).
+One dashboard holds several daemons at once. `internal/fleet` is a
+`session.Runtime` over the local daemon and one per configured host: it
+merges rosters, stamps each agent with the daemon that answered for it,
+and routes every later call back to that one. Two rules shape it. A host
+that cannot be reached costs its own absence and nothing else — never a
+failed refresh, never a frame spent waiting on SSH, and a failed member is
+left alone for a retry window rather than dialled on every tick. And an
+agent's host is discovered by asking rather than remembered, so ownership
+is rebuilt from every listing and never persisted anywhere.
+
+Dispatch follows the workspace it resolved: the context already names the
+machine, because resolution happened there. Hosts are configured under
+`[hosts.<name>]`, and the name is what qualifies workspace IDs.
 
 #### The terminal seam
 

--- a/docs/config-design.md
+++ b/docs/config-design.md
@@ -103,6 +103,19 @@ provider = "claude"
 # args   = ["--message", "{task}"]
 # [providers.aider.mode_args]
 # auto = ["--yes-always"]
+
+# Other machines this dashboard works. Each runs its own daemon and its
+# own agents, reached over SSH; the key is the name Stormlight calls it,
+# and what qualifies the workspace IDs of everything running there.
+[hosts.devbox]
+# destination  = "trent@10.0.0.4"  # defaults to the key; an ssh_config
+#                                  # alias or a tailnet name works too
+# bin          = "/opt/bin/stormlight"  # when it is not on PATH — a
+#                                       # non-interactive SSH shell often
+#                                       # has no ~/.local/bin
+# options      = ["-p", "2222"]    # extra ssh flags, before the destination
+# no_multiplex = false             # sharing is on: a dashboard opens
+#                                  # several connections per host
 ```
 
 ## Wiring

--- a/internal/agent/agent.go
+++ b/internal/agent/agent.go
@@ -151,6 +151,11 @@ func ParseMode(value string) (PermissionMode, error) {
 }
 
 type Agent struct {
+	// Host names the machine this agent is running on; empty is this one.
+	// It is never stored in the agent's document: the daemon that
+	// answered for it is the fact, and a name recorded on one dashboard
+	// would be a claim about the world made from the wrong place.
+	Host      string    `json:"-"`
 	ID        string    `json:"id"`
 	Provider  Provider  `json:"provider"`
 	Name      string    `json:"name"`

--- a/internal/app/service.go
+++ b/internal/app/service.go
@@ -24,6 +24,9 @@ type DispatchRequest struct {
 	Task     string
 	Cwd      string
 	Mode     agent.PermissionMode
+	// Host is the machine to run on; empty is this one. Cwd is a path on
+	// that machine, so the two travel together.
+	Host string
 }
 
 type AttachResult = session.AttachResult
@@ -107,7 +110,10 @@ func (s *Service) ListAgents(ctx context.Context) ([]agent.Agent, error) {
 		if agents[index].Workspace.IsComplete() {
 			continue
 		}
-		value, resolveErr := s.workspaces.Resolve(ctx, agents[index].Cwd)
+		// An agent's cwd is a path on its own machine, and the fleet has
+		// already said which that is.
+		value, resolveErr := s.workspaces.ResolveOn(
+			ctx, agents[index].Host, agents[index].Cwd)
 		if resolveErr != nil {
 			diagnostic.Logger().Warn("legacy agent workspace resolution failed",
 				"agent_id", agents[index].ID,
@@ -148,7 +154,10 @@ func (s *Service) Dispatch(ctx context.Context, req DispatchRequest) (agent.Agen
 	if err != nil {
 		return agent.Agent{}, err
 	}
-	workspaceContext, err := s.workspaces.Resolve(ctx, req.Cwd)
+	// Resolution happens on the machine the path is on, and the context
+	// it returns is what tells the runtime which daemon this dispatch
+	// belongs to.
+	workspaceContext, err := s.workspaces.ResolveOn(ctx, req.Host, req.Cwd)
 	if err != nil {
 		return agent.Agent{}, fmt.Errorf("resolve workspace: %w", err)
 	}
@@ -164,11 +173,18 @@ func (s *Service) Dispatch(ctx context.Context, req DispatchRequest) (agent.Agen
 	if err != nil {
 		return agent.Agent{}, err
 	}
-	if err := s.catalog.Add(workspaceContext.Root); err != nil {
-		diagnostic.Logger().Warn("workspace catalog update failed",
-			"path", workspaceContext.Root,
-			"error", err,
-		)
+	// The catalog is a list of paths on this machine, and adding a remote
+	// root to it would file another host's directory as one of ours —
+	// every later load would resolve it here and answer about nothing.
+	// Remote workspaces are visible while they hold agents; teaching the
+	// catalog about hosts is the next step (#127).
+	if workspaceContext.Host == "" {
+		if err := s.catalog.Add(workspaceContext.Root); err != nil {
+			diagnostic.Logger().Warn("workspace catalog update failed",
+				"path", workspaceContext.Root,
+				"error", err,
+			)
+		}
 	}
 	return managedAgent, nil
 }
@@ -194,7 +210,11 @@ func (s *Service) Resume(
 	if task == "" {
 		task = "Resume session " + record.SessionID
 	}
-	workspaceContext, err := s.workspaces.Resolve(ctx, record.Cwd)
+	// A conversation reopens on the machine it happened on: its
+	// transcript, its repository, and its provider's own session state
+	// are all over there.
+	workspaceContext, err := s.workspaces.ResolveOn(
+		ctx, record.Workspace.Host, record.Cwd)
 	if err != nil {
 		return agent.Agent{}, fmt.Errorf("resolve workspace: %w", err)
 	}

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -26,6 +26,26 @@ type Config struct {
 	Tools      Tools                        `toml:"tools"`
 	Workspaces map[string]WorkspaceOverride `toml:"workspaces"`
 	Providers  map[string]Provider          `toml:"providers"`
+	// Hosts are other machines this dashboard works, keyed by the name it
+	// calls them. Each runs its own daemon and its own agents; Stormlight
+	// reaches them over SSH.
+	Hosts map[string]Host `toml:"hosts"`
+}
+
+// Host is one machine reachable over SSH.
+type Host struct {
+	// Destination is what ssh is given — user@host, an ssh_config alias,
+	// a tailnet name. Empty means the key names it.
+	Destination string `toml:"destination"`
+	// Bin is the remote stormlight when it is not simply on PATH. A
+	// non-interactive SSH shell often has no ~/.local/bin, which is the
+	// usual reason to need this.
+	Bin string `toml:"bin"`
+	// Options are extra ssh flags, placed ahead of the destination.
+	Options []string `toml:"options"`
+	// NoMultiplex turns off SSH connection sharing, which is on by
+	// default because a dashboard opens several connections per host.
+	NoMultiplex bool `toml:"no_multiplex"`
 }
 
 type Defaults struct {
@@ -149,6 +169,26 @@ func (c Config) normalize(path string) (Config, []string, error) {
 		if info, err := os.Stat(*tool.path); err != nil || info.IsDir() {
 			warn("%s: %q is not an executable file", tool.name, *tool.path)
 			*tool.path = ""
+		}
+	}
+	for name, host := range c.Hosts {
+		if strings.TrimSpace(name) == "" {
+			warn("hosts: a host needs a name")
+			delete(c.Hosts, name)
+			continue
+		}
+		// The name qualifies workspace IDs and is spliced into an ssh
+		// command line, so it stays a plain word.
+		if strings.ContainsAny(name, " \t:'\"") {
+			warn("hosts.%s: a host name cannot contain spaces, colons, or quotes", name)
+			delete(c.Hosts, name)
+			continue
+		}
+		if strings.TrimSpace(host.Destination) == "" && strings.Contains(name, "@") {
+			// A key like trent@devbox is already a destination; taking it
+			// as one saves saying it twice.
+			host.Destination = name
+			c.Hosts[name] = host
 		}
 	}
 	for root, override := range c.Workspaces {

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -193,3 +193,53 @@ func TestWriteTemplateRefusesToOverwrite(t *testing.T) {
 		t.Fatalf("force overwrite failed: %v", err)
 	}
 }
+
+func TestHostsAreRead(t *testing.T) {
+	path := writeConfig(t, `
+[hosts.devbox]
+destination = "trent@10.0.0.4"
+bin = "/opt/stormlight/bin/stormlight"
+options = ["-p", "2222"]
+
+[hosts."trent@laptop"]
+
+[hosts.plain]
+`)
+	cfg, warnings, err := loadFrom(path)
+	if err != nil {
+		t.Fatalf("loadFrom: %v", err)
+	}
+	if len(warnings) != 0 {
+		t.Fatalf("unexpected warnings: %v", warnings)
+	}
+	if got := cfg.Hosts["devbox"]; got.Destination != "trent@10.0.0.4" ||
+		got.Bin != "/opt/stormlight/bin/stormlight" ||
+		len(got.Options) != 2 {
+		t.Fatalf("host not read: %+v", got)
+	}
+	// A key that is already a destination is taken as one, so nobody has
+	// to write trent@laptop twice.
+	if got := cfg.Hosts["trent@laptop"]; got.Destination != "trent@laptop" {
+		t.Fatalf("a user@host key should double as the destination: %+v", got)
+	}
+	// A plain name is left alone: ssh_config may well define it.
+	if got := cfg.Hosts["plain"]; got.Destination != "" {
+		t.Fatalf("a plain name is resolved by ssh, not by us: %+v", got)
+	}
+}
+
+// TestAnUnusableHostNameIsRefused: the name qualifies workspace IDs and is
+// spliced into an ssh command line, so it has to stay a plain word.
+func TestAnUnusableHostNameIsRefused(t *testing.T) {
+	path := writeConfig(t, "[hosts.\"dev box\"]\n")
+	cfg, warnings, err := loadFrom(path)
+	if err != nil {
+		t.Fatalf("loadFrom: %v", err)
+	}
+	if len(warnings) == 0 {
+		t.Fatal("a host name with a space should warn")
+	}
+	if _, kept := cfg.Hosts["dev box"]; kept {
+		t.Fatalf("an unusable host must not be configured: %+v", cfg.Hosts)
+	}
+}

--- a/internal/fleet/fleet.go
+++ b/internal/fleet/fleet.go
@@ -1,0 +1,365 @@
+// Package fleet is several daemons behind one runtime.
+//
+// A dashboard that works two machines is still one dashboard: one roster,
+// one selection, one set of keys. Nothing above this package should have
+// to ask which daemon an agent is in, so the fan-out lives here, as a
+// session.Runtime like any other. Members are the local daemon and one
+// per configured host.
+//
+// Two rules shape everything below. A host that cannot be reached must
+// cost nothing but its own absence — never a failed refresh, never a
+// frame the dashboard spends waiting. And an agent's host is discovered
+// by asking, never remembered: whichever daemon answers for an agent owns
+// it, so ownership is rebuilt from every listing rather than persisted
+// anywhere.
+package fleet
+
+import (
+	"context"
+	"fmt"
+	"sync"
+	"time"
+
+	"github.com/trentkm/stormlight/internal/agent"
+	"github.com/trentkm/stormlight/internal/diagnostic"
+	"github.com/trentkm/stormlight/internal/session"
+	"github.com/trentkm/stormlight/internal/workspace"
+)
+
+// retryAfter is how long a member that failed to connect is left alone.
+// The dashboard refreshes on a timer, and an unreachable host would
+// otherwise pay for an SSH attempt on every one of them.
+const retryAfter = 30 * time.Second
+
+// Member is one daemon in the fleet.
+type Member struct {
+	// Host is what the dashboard calls this machine; empty is this one.
+	Host string
+	// Connect builds the runtime. It is called lazily and again after a
+	// failure, so a host that comes up later joins without a restart.
+	Connect func() (session.Runtime, error)
+}
+
+type member struct {
+	host    string
+	connect func() (session.Runtime, error)
+
+	mu       sync.Mutex
+	runtime  session.Runtime
+	failure  error
+	failedAt time.Time
+}
+
+// Runtime fans one session.Runtime out over several daemons.
+type Runtime struct {
+	members []*member
+
+	// owner maps an agent to the member that last answered for it. It is
+	// a cache of the last listing, not a record: an agent that has moved
+	// or vanished is corrected by the next one.
+	mu    sync.RWMutex
+	owner map[string]*member
+}
+
+func New(members ...Member) *Runtime {
+	fleet := &Runtime{owner: make(map[string]*member)}
+	for _, m := range members {
+		fleet.members = append(fleet.members, &member{host: m.Host, connect: m.Connect})
+	}
+	return fleet
+}
+
+// Status is one member's reachability, for a dashboard that wants to say
+// so rather than silently listing fewer agents.
+type Status struct {
+	Host  string
+	Error error
+}
+
+func (f *Runtime) Status() []Status {
+	statuses := make([]Status, 0, len(f.members))
+	for _, m := range f.members {
+		m.mu.Lock()
+		statuses = append(statuses, Status{Host: m.host, Error: m.failure})
+		m.mu.Unlock()
+	}
+	return statuses
+}
+
+// resolve connects the member if it is not connected, honouring the retry
+// window so an unreachable host is not dialled on every refresh.
+func (m *member) resolve() (session.Runtime, error) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	if m.runtime != nil {
+		return m.runtime, nil
+	}
+	if m.failure != nil && time.Since(m.failedAt) < retryAfter {
+		return nil, m.failure
+	}
+	runtime, err := m.connect()
+	if err != nil {
+		m.failure = err
+		m.failedAt = time.Now()
+		return nil, err
+	}
+	m.runtime = runtime
+	m.failure = nil
+	return runtime, nil
+}
+
+// drop forgets a connection so the next call rebuilds it. A tunnel dies
+// with the network it ran over, and every later call through it would
+// fail the same way until something notices.
+func (m *member) drop(err error) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	m.runtime = nil
+	m.failure = err
+	m.failedAt = time.Now()
+}
+
+func (f *Runtime) ListAgents(ctx context.Context) ([]agent.Agent, error) {
+	type result struct {
+		member *member
+		agents []agent.Agent
+		err    error
+	}
+	results := make([]result, len(f.members))
+	var wait sync.WaitGroup
+	for index, m := range f.members {
+		wait.Add(1)
+		go func() {
+			defer wait.Done()
+			results[index] = result{member: m}
+			runtime, err := m.resolve()
+			if err != nil {
+				results[index].err = err
+				return
+			}
+			agents, err := runtime.ListAgents(ctx)
+			if err != nil {
+				m.drop(err)
+				results[index].err = err
+				return
+			}
+			results[index].agents = agents
+		}()
+	}
+	wait.Wait()
+
+	owner := make(map[string]*member)
+	var agents []agent.Agent
+	var failures []error
+	for _, item := range results {
+		if item.err != nil {
+			failures = append(failures, fmt.Errorf("%s: %w", hostName(item.member.host), item.err))
+			diagnostic.Logger().Warn("host unavailable",
+				"host", hostName(item.member.host),
+				"error", item.err,
+			)
+			continue
+		}
+		for _, listed := range item.agents {
+			listed.Host = item.member.host
+			owner[listed.ID] = item.member
+			agents = append(agents, listed)
+		}
+	}
+
+	f.mu.Lock()
+	f.owner = owner
+	f.mu.Unlock()
+
+	// A host being down is its own absence, not the dashboard's failure —
+	// unless every host is, in which case there is nothing to show and
+	// saying so beats an empty roster that looks like an idle morning.
+	if len(failures) == len(f.members) && len(failures) > 0 {
+		return nil, failures[0]
+	}
+	return agents, nil
+}
+
+// memberFor finds the daemon that owns an agent. A miss is not an error:
+// an agent dispatched a moment ago has not been listed yet, so the roster
+// is refreshed once before giving up.
+func (f *Runtime) memberFor(ctx context.Context, id string) (session.Runtime, error) {
+	if len(f.members) == 1 {
+		return f.members[0].resolve()
+	}
+	if runtime, ok := f.lookup(id); ok {
+		return runtime, nil
+	}
+	if _, err := f.ListAgents(ctx); err != nil {
+		return nil, err
+	}
+	if runtime, ok := f.lookup(id); ok {
+		return runtime, nil
+	}
+	return nil, fmt.Errorf("agent %q not found on any host", id)
+}
+
+func (f *Runtime) lookup(id string) (session.Runtime, bool) {
+	f.mu.RLock()
+	owner, ok := f.owner[id]
+	f.mu.RUnlock()
+	if !ok {
+		// Prefixes are how a human names an agent on the command line,
+		// and the dashboard passes them straight through.
+		f.mu.RLock()
+		for known, candidate := range f.owner {
+			if len(id) > 0 && len(known) >= len(id) && known[:len(id)] == id {
+				if owner != nil && owner != candidate {
+					f.mu.RUnlock()
+					return nil, false
+				}
+				owner = candidate
+			}
+		}
+		f.mu.RUnlock()
+		if owner == nil {
+			return nil, false
+		}
+	}
+	runtime, err := owner.resolve()
+	if err != nil {
+		return nil, false
+	}
+	return runtime, true
+}
+
+// hostFor is memberFor by host name rather than by agent: dispatch names
+// the machine it means through the workspace it resolved.
+func (f *Runtime) hostFor(host string) (session.Runtime, error) {
+	for _, m := range f.members {
+		if m.host == host {
+			return m.resolve()
+		}
+	}
+	return nil, fmt.Errorf("no host named %q", hostName(host))
+}
+
+func hostName(host string) string {
+	if host == "" {
+		return "this machine"
+	}
+	return host
+}
+
+func (f *Runtime) Dispatch(
+	ctx context.Context,
+	request session.DispatchRequest,
+) (agent.Agent, error) {
+	// The workspace has already been resolved on the machine that owns
+	// it, so it is the request's own statement of where it belongs.
+	runtime, err := f.hostFor(request.Workspace.Host)
+	if err != nil {
+		return agent.Agent{}, err
+	}
+	dispatched, err := runtime.Dispatch(ctx, request)
+	if err != nil {
+		return agent.Agent{}, err
+	}
+	dispatched.Host = request.Workspace.Host
+	return dispatched, nil
+}
+
+func (f *Runtime) Capture(ctx context.Context, id string, lines int) (string, error) {
+	runtime, err := f.memberFor(ctx, id)
+	if err != nil {
+		return "", err
+	}
+	return runtime.Capture(ctx, id, lines)
+}
+
+func (f *Runtime) Attach(ctx context.Context, id string) (session.AttachResult, error) {
+	runtime, err := f.memberFor(ctx, id)
+	if err != nil {
+		return session.AttachResult{}, err
+	}
+	return runtime.Attach(ctx, id)
+}
+
+func (f *Runtime) Send(ctx context.Context, id, message string) error {
+	runtime, err := f.memberFor(ctx, id)
+	if err != nil {
+		return err
+	}
+	return runtime.Send(ctx, id, message)
+}
+
+func (f *Runtime) Interrupt(ctx context.Context, id string) error {
+	runtime, err := f.memberFor(ctx, id)
+	if err != nil {
+		return err
+	}
+	return runtime.Interrupt(ctx, id)
+}
+
+func (f *Runtime) Delete(ctx context.Context, id string) error {
+	runtime, err := f.memberFor(ctx, id)
+	if err != nil {
+		return err
+	}
+	return runtime.Delete(ctx, id)
+}
+
+func (f *Runtime) Rename(ctx context.Context, id, name string) error {
+	runtime, err := f.memberFor(ctx, id)
+	if err != nil {
+		return err
+	}
+	return runtime.Rename(ctx, id, name)
+}
+
+func (f *Runtime) Update(ctx context.Context, id string, update session.Update) error {
+	runtime, err := f.memberFor(ctx, id)
+	if err != nil {
+		return err
+	}
+	return runtime.Update(ctx, id, update)
+}
+
+func (f *Runtime) SetWorkspace(ctx context.Context, id string, value workspace.Context) error {
+	runtime, err := f.memberFor(ctx, id)
+	if err != nil {
+		return err
+	}
+	return runtime.SetWorkspace(ctx, id, value)
+}
+
+// AttachTerminal forwards the streaming capability. A fleet declares it
+// unconditionally — Go decides capability by type, not by membership — so
+// a member that cannot stream says so here rather than at the seam.
+func (f *Runtime) AttachTerminal(
+	ctx context.Context,
+	id string,
+	cols, rows int,
+) (session.TerminalStream, error) {
+	runtime, err := f.memberFor(ctx, id)
+	if err != nil {
+		return nil, err
+	}
+	streamer, ok := runtime.(session.TerminalStreamer)
+	if !ok {
+		return nil, fmt.Errorf("runtime does not stream terminals")
+	}
+	return streamer.AttachTerminal(ctx, id, cols, rows)
+}
+
+// StartOverlay runs the picker or the editor on the machine whose
+// filesystem it is about to browse.
+func (f *Runtime) StartOverlay(
+	ctx context.Context,
+	request session.OverlayRequest,
+) (session.Overlay, error) {
+	runtime, err := f.hostFor(request.Host)
+	if err != nil {
+		return nil, err
+	}
+	host, ok := runtime.(session.OverlayHost)
+	if !ok {
+		return nil, fmt.Errorf("runtime cannot host overlays")
+	}
+	return host.StartOverlay(ctx, request)
+}

--- a/internal/fleet/fleet_test.go
+++ b/internal/fleet/fleet_test.go
@@ -1,0 +1,307 @@
+package fleet
+
+import (
+	"context"
+	"errors"
+	"strings"
+	"sync"
+	"testing"
+
+	"github.com/trentkm/stormlight/internal/agent"
+	"github.com/trentkm/stormlight/internal/session"
+	"github.com/trentkm/stormlight/internal/workspace"
+)
+
+// stub is one daemon's worth of runtime: a roster it will report and a
+// record of what was asked of it.
+type stub struct {
+	mu       sync.Mutex
+	agents   []agent.Agent
+	listErr  error
+	sent     []string
+	deleted  []string
+	launched []session.DispatchRequest
+	lists    int
+}
+
+func (s *stub) ListAgents(context.Context) ([]agent.Agent, error) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.lists++
+	if s.listErr != nil {
+		return nil, s.listErr
+	}
+	return append([]agent.Agent(nil), s.agents...), nil
+}
+
+func (s *stub) Dispatch(
+	_ context.Context,
+	request session.DispatchRequest,
+) (agent.Agent, error) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.launched = append(s.launched, request)
+	return agent.Agent{ID: "new", Workspace: request.Workspace}, nil
+}
+
+func (s *stub) Send(_ context.Context, id, message string) error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.sent = append(s.sent, id+":"+message)
+	return nil
+}
+
+func (s *stub) Delete(_ context.Context, id string) error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.deleted = append(s.deleted, id)
+	return nil
+}
+
+func (s *stub) Capture(context.Context, string, int) (string, error) { return "", nil }
+func (s *stub) Attach(context.Context, string) (session.AttachResult, error) {
+	return session.AttachResult{}, nil
+}
+func (s *stub) Interrupt(context.Context, string) error              { return nil }
+func (s *stub) Rename(context.Context, string, string) error         { return nil }
+func (s *stub) Update(context.Context, string, session.Update) error { return nil }
+func (s *stub) SetWorkspace(context.Context, string, workspace.Context) error {
+	return nil
+}
+
+func reachable(host string, runtime session.Runtime) Member {
+	return Member{Host: host, Connect: func() (session.Runtime, error) { return runtime, nil }}
+}
+
+func unreachable(host string, err error) Member {
+	return Member{Host: host, Connect: func() (session.Runtime, error) { return nil, err }}
+}
+
+// TestRosterMergesAndStampsTheHost: one dashboard, one roster, and every
+// agent knowing which machine answered for it.
+func TestRosterMergesAndStampsTheHost(t *testing.T) {
+	local := &stub{agents: []agent.Agent{{ID: "aaa"}}}
+	devbox := &stub{agents: []agent.Agent{{ID: "bbb"}, {ID: "ccc"}}}
+	f := New(reachable("", local), reachable("devbox", devbox))
+
+	agents, err := f.ListAgents(context.Background())
+	if err != nil {
+		t.Fatalf("ListAgents: %v", err)
+	}
+	if len(agents) != 3 {
+		t.Fatalf("want every host's agents, got %+v", agents)
+	}
+	hosts := map[string]string{}
+	for _, listed := range agents {
+		hosts[listed.ID] = listed.Host
+	}
+	if hosts["aaa"] != "" || hosts["bbb"] != "devbox" || hosts["ccc"] != "devbox" {
+		t.Fatalf("host not stamped from the daemon that answered: %v", hosts)
+	}
+}
+
+// TestAnUnreachableHostIsItsOwnAbsence: a laptop that closed, a VPN that
+// dropped, a box that is asleep. None of them are the dashboard's
+// failure, and none of them may hide the agents that are still there.
+func TestAnUnreachableHostIsItsOwnAbsence(t *testing.T) {
+	local := &stub{agents: []agent.Agent{{ID: "aaa"}}}
+	f := New(reachable("", local), unreachable("devbox", errors.New("ssh: no route to host")))
+
+	agents, err := f.ListAgents(context.Background())
+	if err != nil {
+		t.Fatalf("one host down must not fail the refresh: %v", err)
+	}
+	if len(agents) != 1 || agents[0].ID != "aaa" {
+		t.Fatalf("the reachable host's agents must still be listed: %+v", agents)
+	}
+
+	// It is reported, though — silently listing fewer agents is how a
+	// dashboard tells a comfortable lie.
+	var reported bool
+	for _, status := range f.Status() {
+		if status.Host == "devbox" && status.Error != nil {
+			reported = true
+		}
+	}
+	if !reported {
+		t.Fatalf("an unreachable host must be visible as unreachable: %+v", f.Status())
+	}
+}
+
+// TestEveryHostDownIsAnError: an empty roster reads as a quiet morning.
+// When nothing could be reached, say so.
+func TestEveryHostDownIsAnError(t *testing.T) {
+	f := New(
+		unreachable("", errors.New("no daemon")),
+		unreachable("devbox", errors.New("ssh: no route to host")),
+	)
+	if _, err := f.ListAgents(context.Background()); err == nil {
+		t.Fatal("no reachable host must not look like no agents")
+	}
+}
+
+// TestOperationsFollowTheAgentToItsHost: every id-addressed call has to
+// land on the daemon that holds the agent, or a message meant for one
+// machine is typed into another.
+func TestOperationsFollowTheAgentToItsHost(t *testing.T) {
+	local := &stub{agents: []agent.Agent{{ID: "aaa"}}}
+	devbox := &stub{agents: []agent.Agent{{ID: "bbb"}}}
+	f := New(reachable("", local), reachable("devbox", devbox))
+
+	if err := f.Send(context.Background(), "bbb", "hello"); err != nil {
+		t.Fatalf("Send: %v", err)
+	}
+	if len(devbox.sent) != 1 || len(local.sent) != 0 {
+		t.Fatalf("message went to the wrong machine: local=%v devbox=%v", local.sent, devbox.sent)
+	}
+	if err := f.Delete(context.Background(), "aaa"); err != nil {
+		t.Fatalf("Delete: %v", err)
+	}
+	if len(local.deleted) != 1 || len(devbox.deleted) != 0 {
+		t.Fatalf("deletion went to the wrong machine: local=%v devbox=%v",
+			local.deleted, devbox.deleted)
+	}
+}
+
+// TestAnAgentNobodyHasListedIsStillFound: dispatch returns an id before
+// any refresh has run, and the very next keystroke may address it.
+func TestAnAgentNobodyHasListedIsStillFound(t *testing.T) {
+	local := &stub{}
+	devbox := &stub{agents: []agent.Agent{{ID: "bbb"}}}
+	f := New(reachable("", local), reachable("devbox", devbox))
+
+	// No ListAgents has been called, so ownership is unknown.
+	if err := f.Send(context.Background(), "bbb", "hello"); err != nil {
+		t.Fatalf("Send: %v", err)
+	}
+	if len(devbox.sent) != 1 {
+		t.Fatalf("the fleet should have gone looking: %v", devbox.sent)
+	}
+	if _, err := f.Capture(context.Background(), "nobody", 10); err == nil {
+		t.Fatal("an id no host holds must be an error, not a silent no-op")
+	}
+}
+
+// TestAPrefixNamesAnAgentAcrossHosts: a human types the first few
+// characters of an id, and the dashboard passes that straight through.
+func TestAPrefixNamesAnAgentAcrossHosts(t *testing.T) {
+	local := &stub{agents: []agent.Agent{{ID: "aaa11111"}}}
+	devbox := &stub{agents: []agent.Agent{{ID: "bbb22222"}}}
+	f := New(reachable("", local), reachable("devbox", devbox))
+	if _, err := f.ListAgents(context.Background()); err != nil {
+		t.Fatalf("ListAgents: %v", err)
+	}
+
+	if err := f.Send(context.Background(), "bbb2", "hello"); err != nil {
+		t.Fatalf("Send by prefix: %v", err)
+	}
+	if len(devbox.sent) != 1 {
+		t.Fatalf("prefix did not reach the right host: %v", devbox.sent)
+	}
+}
+
+// TestDispatchFollowsTheWorkspace: the workspace was resolved on the
+// machine that owns it, so it already says where the agent belongs.
+func TestDispatchFollowsTheWorkspace(t *testing.T) {
+	local := &stub{}
+	devbox := &stub{}
+	f := New(reachable("", local), reachable("devbox", devbox))
+
+	dispatched, err := f.Dispatch(context.Background(), session.DispatchRequest{
+		Cwd:       "/srv/api",
+		Workspace: workspace.Context{Host: "devbox", ID: "devbox:git:/srv/api/.git"},
+	})
+	if err != nil {
+		t.Fatalf("Dispatch: %v", err)
+	}
+	if len(devbox.launched) != 1 || len(local.launched) != 0 {
+		t.Fatalf("dispatch landed on the wrong machine")
+	}
+	if dispatched.Host != "devbox" {
+		t.Fatalf("a dispatched agent knows its host: %+v", dispatched)
+	}
+
+	_, err = f.Dispatch(context.Background(), session.DispatchRequest{
+		Workspace: workspace.Context{Host: "nowhere"},
+	})
+	if err == nil || !strings.Contains(err.Error(), "nowhere") {
+		t.Fatalf("an unknown host must be named in the error: %v", err)
+	}
+}
+
+// TestAFailedHostIsNotDialledEveryRefresh: the dashboard refreshes on a
+// timer, and an SSH attempt per refresh against a sleeping laptop is a
+// stall the user feels on every frame.
+func TestAFailedHostIsNotDialledEveryRefresh(t *testing.T) {
+	attempts := 0
+	f := New(
+		reachable("", &stub{}),
+		Member{Host: "devbox", Connect: func() (session.Runtime, error) {
+			attempts++
+			return nil, errors.New("ssh: connection timed out")
+		}},
+	)
+	for range 5 {
+		if _, err := f.ListAgents(context.Background()); err != nil {
+			t.Fatalf("ListAgents: %v", err)
+		}
+	}
+	if attempts != 1 {
+		t.Fatalf("dialled %d times in a row; the retry window should hold it to 1", attempts)
+	}
+}
+
+// TestALostConnectionIsRebuilt: a tunnel dies with the network it ran
+// over, and every later call through it fails the same way until
+// something drops it.
+func TestALostConnectionIsRebuilt(t *testing.T) {
+	broken := &stub{listErr: errors.New("broken pipe")}
+	healthy := &stub{agents: []agent.Agent{{ID: "bbb"}}}
+	connects := 0
+	f := New(
+		reachable("", &stub{}),
+		Member{Host: "devbox", Connect: func() (session.Runtime, error) {
+			connects++
+			if connects == 1 {
+				return broken, nil
+			}
+			return healthy, nil
+		}},
+	)
+
+	if _, err := f.ListAgents(context.Background()); err != nil {
+		t.Fatalf("ListAgents: %v", err)
+	}
+	// The retry window applies to the dropped connection too, so reach
+	// past it the way the next refresh eventually does.
+	f.members[1].failedAt = f.members[1].failedAt.Add(-2 * retryAfter)
+
+	agents, err := f.ListAgents(context.Background())
+	if err != nil {
+		t.Fatalf("ListAgents: %v", err)
+	}
+	if connects != 2 {
+		t.Fatalf("a dead connection must be rebuilt, not reused: %d connects", connects)
+	}
+	if len(agents) != 1 || agents[0].ID != "bbb" {
+		t.Fatalf("the recovered host's agents should be back: %+v", agents)
+	}
+}
+
+// TestAFleetOfOneIsJustTheRuntime: everyone who has configured no hosts
+// pays for this package on every call, so the single-member path routes
+// straight through without a listing.
+func TestAFleetOfOneIsJustTheRuntime(t *testing.T) {
+	local := &stub{}
+	f := New(reachable("", local))
+
+	if err := f.Send(context.Background(), "aaa", "hello"); err != nil {
+		t.Fatalf("Send: %v", err)
+	}
+	if local.lists != 0 {
+		t.Fatalf("a fleet of one should not have to look anything up: %d listings", local.lists)
+	}
+	if len(local.sent) != 1 {
+		t.Fatalf("the message never arrived: %v", local.sent)
+	}
+}

--- a/internal/session/runtime.go
+++ b/internal/session/runtime.go
@@ -43,6 +43,9 @@ type TerminalStream interface {
 // dashboard wants floated over itself rather than handed the whole
 // screen: the Yazi picker, the Neovim task editor.
 type OverlayRequest struct {
+	// Host is the machine to run it on; empty is this one. An overlay
+	// browses a filesystem, so it belongs on the machine that has it.
+	Host string
 	Path string
 	Args []string
 	Dir  string

--- a/internal/ui/band.go
+++ b/internal/ui/band.go
@@ -97,10 +97,16 @@ func (m Model) rosterLit() bool {
 }
 
 // renderWorkspacesBar is the band's first segment: the pane's name and
-// how many workspaces the catalog holds.
+// how many workspaces are listed under it.
+//
+// The count is of the rows, not of the catalog. The pane has always shown
+// both — catalogued workspaces and any that merely hold an agent — and
+// counting only the catalogue was a number that happened to agree.
+// Workspaces on another machine are not in this machine's catalogue, so
+// it stopped agreeing.
 func (m Model) renderWorkspacesBar(meta string, width int) string {
 	if meta == "" {
-		meta = fmt.Sprintf("%d", len(m.catalogWorkspaces))
+		meta = fmt.Sprintf("%d", len(m.groups))
 	}
 	return rosterSegment("Workspaces", meta,
 		m.activePane == paneWorkspaces, m.rosterLit(), width)

--- a/internal/ui/bandwidth_test.go
+++ b/internal/ui/bandwidth_test.go
@@ -1,9 +1,13 @@
 package ui
 
 import (
+	"strings"
 	"testing"
 
 	"charm.land/lipgloss/v2"
+
+	"github.com/trentkm/stormlight/internal/agent"
+	"github.com/trentkm/stormlight/internal/workspace"
 )
 
 // The strip is the one row that reaches the terminal's true right edge:
@@ -17,5 +21,35 @@ func TestTitleBandReachesTheTerminalEdge(t *testing.T) {
 	band := model.renderTitleBand(workspaceWidth, agentWidth, interactionWidth)
 	if got := lipgloss.Width(band); got != model.width {
 		t.Fatalf("band width = %d, want %d", got, model.width)
+	}
+}
+
+// TestWorkspaceCountMatchesTheRows: the pane lists catalogued workspaces
+// and any that merely hold an agent, and a workspace on another machine
+// is never in this machine's catalogue. A count taken from the catalogue
+// would then disagree with what is on screen.
+func TestWorkspaceCountMatchesTheRows(t *testing.T) {
+	local := workspace.Context{
+		ID: "git:/here/.git", Kind: "git", Name: "here",
+		Root: "/here", ExecutionRoot: "/here",
+	}
+	remote := workspace.Context{
+		Host: "devbox", ID: "devbox:git:/there/.git", Kind: "git", Name: "there",
+		Root: "/there", ExecutionRoot: "/there",
+	}
+	model := Model{
+		catalogWorkspaces: []workspace.Context{local},
+		agents: []agent.Agent{
+			{ID: "aaa", Workspace: local},
+			{ID: "bbb", Host: "devbox", Workspace: remote},
+		},
+	}
+	model.rebuildGroups("", "")
+
+	if len(model.groups) != 2 {
+		t.Fatalf("both workspaces should be listed: %+v", model.groups)
+	}
+	if got := model.renderWorkspacesBar("", 40); !strings.Contains(got, "2") {
+		t.Fatalf("the count should be of the rows, got %q", got)
 	}
 }

--- a/internal/workspace/registry.go
+++ b/internal/workspace/registry.go
@@ -30,10 +30,14 @@ type Registry struct {
 	// filesystem, and every ID is qualified with the host.
 	host      string
 	resolvers []Resolver
-	mu        sync.RWMutex
-	cache     map[string]Context
-	routes    map[string]int
-	roots     map[string]cachedExecutionRoots
+	// hosts holds one registry per remote machine, for a local registry
+	// serving a dashboard that works several. A hosted registry never
+	// has its own.
+	hosts  map[string]*Registry
+	mu     sync.RWMutex
+	cache  map[string]Context
+	routes map[string]int
+	roots  map[string]cachedExecutionRoots
 }
 
 type cachedExecutionRoots struct {
@@ -165,6 +169,16 @@ func (r *Registry) normalize(value Context) (Context, error) {
 // workspace. Enumeration is best-effort: unsupported, invalid, failed, and
 // timed-out discovery all cache and return the resolved path.
 func (r *Registry) ExecutionRoots(ctx context.Context, value Context) ([]Context, error) {
+	// A workspace says which machine it is on, so enumeration follows it
+	// there rather than asking this filesystem about someone else's
+	// worktrees.
+	if value.Host != "" && r.host == "" {
+		hosted, err := r.forHost(value.Host)
+		if err != nil {
+			return nil, err
+		}
+		return hosted.ExecutionRoots(ctx, value)
+	}
 	r.mu.RLock()
 	cached, ok := r.roots[value.ID]
 	resolverIndex, routed := r.routes[value.ID]

--- a/internal/workspace/remote.go
+++ b/internal/workspace/remote.go
@@ -27,6 +27,50 @@ func NewRegistryForHost(host remote.Host) *Registry {
 	return registry
 }
 
+// AddHost teaches a local registry to answer about another machine as
+// well, so one registry can serve a dashboard that works several. The
+// host's own registry is kept whole rather than folded in: its resolvers,
+// its caches, and its rules about paths are all different from this
+// machine's.
+func (r *Registry) AddHost(host remote.Host) {
+	if host.Name == "" {
+		return
+	}
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	if r.hosts == nil {
+		r.hosts = make(map[string]*Registry)
+	}
+	if _, known := r.hosts[host.Name]; known {
+		return
+	}
+	r.hosts[host.Name] = NewRegistryForHost(host)
+}
+
+// ResolveOn resolves a path on a named machine. An empty host is this
+// one, which is the only case that can take a relative path — "here"
+// means nothing said from somewhere else.
+func (r *Registry) ResolveOn(ctx context.Context, host, path string) (Context, error) {
+	if host == "" {
+		return r.Resolve(ctx, path)
+	}
+	hosted, err := r.forHost(host)
+	if err != nil {
+		return Context{}, err
+	}
+	return hosted.Resolve(ctx, path)
+}
+
+func (r *Registry) forHost(host string) (*Registry, error) {
+	r.mu.RLock()
+	hosted, ok := r.hosts[host]
+	r.mu.RUnlock()
+	if !ok {
+		return nil, fmt.Errorf("no host named %q is configured", host)
+	}
+	return hosted, nil
+}
+
 type remoteResolver struct {
 	transport *remote.Transport
 	host      string

--- a/main.go
+++ b/main.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
+	"maps"
 	"net"
 	"os"
 	"path/filepath"
@@ -18,6 +19,7 @@ import (
 	"github.com/trentkm/stormlight/internal/app"
 	"github.com/trentkm/stormlight/internal/config"
 	"github.com/trentkm/stormlight/internal/diagnostic"
+	"github.com/trentkm/stormlight/internal/fleet"
 	"github.com/trentkm/stormlight/internal/provider"
 	"github.com/trentkm/stormlight/internal/remote"
 	"github.com/trentkm/stormlight/internal/selfpath"
@@ -94,8 +96,6 @@ func newRootCommand() *cobra.Command {
 			return runDashboard(cmd, cfg, openPath)
 		},
 	}
-	root.PersistentFlags().StringVar(&remoteHost, "host", "",
-		"work on a remote machine over SSH: its daemon, its agents, its repositories (experimental)")
 	root.PersistentFlags().StringVar(&logFile, "log-file",
 		envFirstOr(cfg.Log.File, "STORMLIGHT_LOG_FILE"),
 		"diagnostic log file",
@@ -445,25 +445,51 @@ func newLogsCommand(logFile *string) *cobra.Command {
 // authoritative state rather than sampled panes — so they outlive every
 // dashboard and every terminal the dashboard ran in.
 func newService(cfg config.Config) (*app.Service, error) {
-	runtime, err := newRuntime()
+	runtime, err := newRuntime(cfg)
 	if err != nil {
 		return nil, err
 	}
 	registry := provider.NewRegistryWithSpecs(providerSpecs(cfg))
-	return app.NewService(runtime, registry, workspace.NewRegistry()), nil
+	workspaces := workspace.NewRegistry()
+	// Resolution follows a path to the machine that has it, so the
+	// registry needs the same host list the runtime has.
+	for _, name := range slices.Sorted(maps.Keys(cfg.Hosts)) {
+		workspaces.AddHost(remoteHostFrom(name, cfg.Hosts[name]))
+	}
+	return app.NewService(runtime, registry, workspaces), nil
 }
 
-// remoteHost names a machine to work on instead of this one. Experimental
-// and deliberately whole-dashboard for now: the service holds one runtime,
-// so --host swaps which daemon it is, rather than showing local and remote
-// agents together. Per-workspace hosts are the next step (#127).
-var remoteHost string
-
-func newRuntime() (session.Runtime, error) {
-	if remoteHost == "" {
-		return windrun.NewRuntime()
+// newRuntime builds the fleet: this machine's daemon, and one per
+// configured host. It is always a fleet, even with no hosts configured,
+// so there is one shape of runtime to reason about and one set of paths
+// to test; a fleet of one routes straight through to its only member.
+//
+// Members connect lazily and on their own schedule. A host that is asleep
+// or unreachable costs the dashboard its absence and nothing else — never
+// a failed refresh, and never a frame spent waiting on SSH.
+func newRuntime(cfg config.Config) (session.Runtime, error) {
+	members := []fleet.Member{{
+		Host:    "",
+		Connect: func() (session.Runtime, error) { return windrun.NewRuntime() },
+	}}
+	for _, name := range slices.Sorted(maps.Keys(cfg.Hosts)) {
+		host := remoteHostFrom(name, cfg.Hosts[name])
+		members = append(members, fleet.Member{
+			Host:    name,
+			Connect: func() (session.Runtime, error) { return windrun.NewRemoteRuntime(host) },
+		})
 	}
-	return windrun.NewRemoteRuntime(remote.Host{Name: remoteHost})
+	return fleet.New(members...), nil
+}
+
+func remoteHostFrom(name string, host config.Host) remote.Host {
+	return remote.Host{
+		Name:        name,
+		Destination: host.Destination,
+		Bin:         host.Bin,
+		Options:     host.Options,
+		NoMultiplex: host.NoMultiplex,
+	}
 }
 
 func newWorkspaceService() *app.Service {
@@ -479,6 +505,7 @@ func newDispatchCommand(cfg config.Config) *cobra.Command {
 	var cwd string
 	var name string
 	var modeName string
+	var host string
 
 	command := &cobra.Command{
 		Use:   "dispatch [task]",
@@ -493,7 +520,9 @@ func newDispatchCommand(cfg config.Config) *cobra.Command {
 			if err != nil {
 				return err
 			}
-			if overrideDir, dirErr := dispatchDirectory(cwd); dirErr == nil {
+			// The per-directory overrides read this machine's filesystem,
+			// so they only apply to a dispatch that lands on it.
+			if overrideDir, dirErr := dispatchDirectory(cwd); dirErr == nil && host == "" {
 				if !cmd.Flags().Changed("mode") {
 					if override, ok := cfg.ModeForDir(overrideDir); ok {
 						mode = override
@@ -517,6 +546,7 @@ func newDispatchCommand(cfg config.Config) *cobra.Command {
 				Task:     task,
 				Cwd:      cwd,
 				Mode:     mode,
+				Host:     host,
 			})
 			if err != nil {
 				return err
@@ -529,6 +559,8 @@ func newDispatchCommand(cfg config.Config) *cobra.Command {
 		configValueOr(cfg.Defaults.Provider, string(agent.ProviderCodex)),
 		"provider: codex, claude, or a configured provider")
 	command.Flags().StringVarP(&cwd, "cwd", "C", "", "working directory")
+	command.Flags().StringVar(&host, "host", "",
+		"run on a configured host instead of this machine; --cwd is a path there")
 	command.Flags().StringVarP(&name, "name", "n", "", "agent name")
 	command.Flags().StringVarP(&modeName, "mode", "m",
 		configValueOr(cfg.Defaults.Mode, string(agent.DefaultMode)),

--- a/site/docs/architecture.html
+++ b/site/docs/architecture.html
@@ -185,9 +185,17 @@
     running as that user. Nothing binds a port. This is also why the transport is SSH rather
     than a tailnet-native listener — Tailscale is a network the transport runs over, and
     <code>stormlight remote add</code> works on one without a line of code about it.</p>
-    <p>Today <code>--host</code> swaps which daemon the whole dashboard talks to. Making the
-    host a dimension of workspace identity, so local and remote agents share one roster, is
-    the next step (<a href="https://github.com/trentkm/stormlight/issues/127">#127</a>).</p>
+    <p>One dashboard holds several daemons at once. <code>internal/fleet</code> is a
+    <code>session.Runtime</code> over the local daemon and one per configured host: it merges
+    rosters, stamps each agent with the daemon that answered for it, and routes every later
+    call back to that one. Two rules shape it. A host that cannot be reached costs its own
+    absence and nothing else — never a failed refresh, never a frame spent waiting on SSH,
+    and a failed member is left alone for a retry window rather than dialled on every tick.
+    And an agent's host is discovered by asking rather than remembered, so ownership is
+    rebuilt from every listing and never persisted anywhere.</p>
+    <p>Dispatch follows the workspace it resolved: the context already names the machine,
+    because resolution happened there. Hosts are configured under
+    <code>[hosts.&lt;name&gt;]</code>, and the name is what qualifies workspace IDs.</p>
 
     <h4 id="terminal-seam">The terminal seam</h4>
     <p>Live terminals reach the dashboard through one narrow seam, declared as an optional

--- a/site/docs/configuration.html
+++ b/site/docs/configuration.html
@@ -132,7 +132,22 @@ provider = <span class="s">"claude"</span>
 <span class="c"># binary = "aider"</span>
 <span class="c"># args   = ["--message", "{task}"]</span>
 <span class="c"># [providers.aider.mode_args]</span>
-<span class="c"># auto = ["--yes-always"]</span></code></pre>
+<span class="c"># auto = ["--yes-always"]</span>
+
+<span class="c"># Other machines this dashboard works. Each runs its own daemon and</span>
+<span class="c"># its own agents, reached over SSH; the key is the name Stormlight</span>
+<span class="c"># calls it, and what qualifies the workspace IDs of everything there.</span>
+<span class="k">[hosts.devbox]</span>
+<span class="c"># destination  = "trent@10.0.0.4"   # defaults to the key</span>
+<span class="c"># bin          = "/opt/bin/stormlight"  # when it is not on PATH</span>
+<span class="c"># options      = ["-p", "2222"]     # extra ssh flags</span>
+<span class="c"># no_multiplex = false              # sharing is on by default</span></code></pre>
+    <p>A configured host joins the dashboard as another daemon: its agents appear in the
+    same roster, its workspaces in the same pane, and <code>dispatch --host</code> starts
+    agents there. Hosts connect lazily and are retried on their own schedule, so one that is
+    asleep costs the dashboard its absence and nothing else. <code>destination</code>
+    defaults to the key, which may be a plain <code>ssh_config</code> alias or a tailnet
+    name — anything <code>ssh</code> already understands.</p>
     <p>Custom providers appear in the New Agent picker and dispatch like any other.
     Lifecycle integration is the public contract: managed processes receive
     <code>STORMLIGHT_ID</code> and can report state with <code>stormlight event</code> from


### PR DESCRIPTION
Phase 3b of #127, and the milestone the earlier phases were for: a dashboard
that works two machines is still one dashboard — one roster, one selection,
one set of keys.

## The fleet

`internal/fleet` is a `session.Runtime` over this machine's daemon and one per
configured host. It merges rosters and routes every later call back to the
daemon that answered. Nothing above it changed shape: `app.Service` still holds
one runtime.

Two rules shape it.

**An unreachable host costs its own absence and nothing else.** A closed
laptop, a dropped VPN, a box asleep — none are the dashboard's failure, and
none may hide the agents that are still there. Members connect lazily; a
failure is left alone for a retry window rather than dialled on every refresh
(an SSH attempt per frame against a sleeping laptop is a stall the user feels);
a connection that dies is dropped so the next attempt rebuilds it instead of
failing the same way forever. Only when *nothing* can be reached is that an
error — an empty roster otherwise reads as a quiet morning.

**An agent's host is discovered by asking, never remembered.** Whichever daemon
answers for an agent owns it, so ownership is rebuilt from every listing and
persisted nowhere. `Agent.Host` is `json:"-"` for the same reason: a name
recorded in an agent's own document would be a claim about the world made from
the wrong place.

## Routing

Dispatch follows the workspace it resolved — the context already names the
machine, because resolution happened there (#129). Resume does the same: a
conversation reopens where its transcript, its repository, and its provider's
session state are. Id-addressed calls follow the agent, prefixes included.

`--host` stops being a global that swaps the whole dashboard and becomes a flag
on `dispatch`, naming where one agent goes. Per-directory config overrides no
longer apply to a remote dispatch: they read this machine's filesystem, which
is not the one the path is on.

The runtime is always a fleet, even with no hosts configured, so there is one
shape to reason about and one set of paths to test. A fleet of one routes
straight through without a lookup — asserted, since everyone with no hosts pays
for this package on every call.

## Configuration

```toml
[hosts.devbox]
# destination  = "trent@10.0.0.4"      # defaults to the key
# bin          = "/opt/bin/stormlight" # when it is not on PATH
# options      = ["-p", "2222"]
# no_multiplex = false
```

The name is validated as a plain word: it is spliced into an ssh command line
and qualifies every workspace ID from that machine. A key that already looks
like `user@host` doubles as the destination.

## One UI change

The workspace count in the band counts the rows now, not the catalogue. The
pane has always shown both catalogued workspaces and any that merely hold an
agent; counting only the catalogue was a number that happened to agree, and a
workspace on another machine — which this machine's catalogue does not hold —
is what stopped it agreeing.

## Deliberately not here

Remote workspaces are not written to the catalogue. Every load resolves
catalogue paths locally, so a remote root filed among them would resolve here
and answer about nothing. They are visible while they hold agents; teaching the
catalogue about hosts is the next step.

## Testing

`go test ./...` and `go vet ./...` green; the fleet's own tests also pass under
`-race`. Covered: merged rosters with hosts stamped, one host down not failing
the refresh (and being visible as down), every host down being an error,
operations following an agent to its machine, an agent nobody has listed yet
still being found, prefixes, dispatch routing by workspace, the retry window
holding a failed host to one dial across five refreshes, a dead connection
being rebuilt, and a fleet of one not looking anything up.

**End to end.** With one configured host, an agent dispatched to it and one
dispatched here appear in a single roster, in two workspaces, each terminal
streaming from its own daemon — confirmed against both daemons' own session
lists.

**Non-regression.** The runtime construction changed for everyone, so per the
#125 guardrail: branch and `main` built and driven through the tmux harness
with isolated `XDG_*`/`WINDRUNNER_DIR`, and their `capture-pane` dumps are
byte-identical — checked again after the count change.
