### PR TITLE
The catalog remembers which machine a workspace is on

### DIFF
--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -289,7 +289,12 @@ Session metadata in the daemon is the source of truth for the running
 roster, and the daemon's persistence is what makes it durable: agents
 outlive every dashboard because their PTYs and terminals never belonged to
 one. The workspace catalog is an atomic JSON file independent of the
-daemon, as are the dashboard's column preferences.
+daemon, as are the dashboard's column preferences. Its entries carry the
+machine they are on, because a path stopped identifying a workspace once
+one could be on another: the same directory on two hosts is two
+workspaces, named and removed separately. Entries for a host that is
+asleep stay in the catalog and resolve when it comes back; a host that
+cannot answer costs its own rows and not the listing.
 
 The daemon's lifetime bounds the roster's. A reboot or a killed daemon
 takes the processes and their terminals with it — but not the

--- a/internal/app/service.go
+++ b/internal/app/service.go
@@ -50,7 +50,7 @@ type Service struct {
 	// Keyed by catalog path, so added or removed workspaces never consult
 	// a stale entry.
 	resolveMu sync.Mutex
-	resolved  map[string]resolvedWorkspace
+	resolved  map[workspace.Entry]resolvedWorkspace
 }
 
 type resolvedWorkspace struct {
@@ -173,18 +173,12 @@ func (s *Service) Dispatch(ctx context.Context, req DispatchRequest) (agent.Agen
 	if err != nil {
 		return agent.Agent{}, err
 	}
-	// The catalog is a list of paths on this machine, and adding a remote
-	// root to it would file another host's directory as one of ours —
-	// every later load would resolve it here and answer about nothing.
-	// Remote workspaces are visible while they hold agents; teaching the
-	// catalog about hosts is the next step (#127).
-	if workspaceContext.Host == "" {
-		if err := s.catalog.Add(workspaceContext.Root); err != nil {
-			diagnostic.Logger().Warn("workspace catalog update failed",
-				"path", workspaceContext.Root,
-				"error", err,
-			)
-		}
+	if err := s.catalog.Add(workspace.EntryOf(workspaceContext)); err != nil {
+		diagnostic.Logger().Warn("workspace catalog update failed",
+			"host", workspaceContext.Host,
+			"path", workspaceContext.Root,
+			"error", err,
+		)
 	}
 	return managedAgent, nil
 }
@@ -230,17 +224,21 @@ func (s *Service) Resume(
 }
 
 func (s *Service) ListWorkspaces(ctx context.Context) ([]workspace.Context, error) {
-	paths, err := s.catalog.Paths()
+	entries, err := s.catalog.Entries()
 	if err != nil {
 		return nil, err
 	}
-	values := make([]workspace.Context, 0, len(paths))
-	seen := make(map[string]bool, len(paths))
-	for _, path := range paths {
-		value, resolveErr := s.resolveCached(ctx, path)
+	values := make([]workspace.Context, 0, len(entries))
+	seen := make(map[string]bool, len(entries))
+	for _, entry := range entries {
+		value, resolveErr := s.resolveCached(ctx, entry)
 		if resolveErr != nil {
+			// A host that is asleep cannot describe its workspaces, and
+			// that is not a reason to fail the listing — the rest of the
+			// catalog is still answerable.
 			diagnostic.Logger().Warn("catalog workspace resolution failed",
-				"path", path,
+				"host", entry.Host,
+				"path", entry.Path,
 				"error", resolveErr,
 			)
 			continue
@@ -326,23 +324,23 @@ func sortWorkspaceRoots(values []workspace.Context) {
 
 func (s *Service) resolveCached(
 	ctx context.Context,
-	path string,
+	entry workspace.Entry,
 ) (workspace.Context, error) {
 	s.resolveMu.Lock()
-	cached, ok := s.resolved[path]
+	cached, ok := s.resolved[entry]
 	s.resolveMu.Unlock()
 	if ok && time.Since(cached.at) < workspaceResolveTTL {
 		return cached.value, nil
 	}
-	value, err := s.workspaces.Resolve(ctx, path)
+	value, err := s.workspaces.ResolveOn(ctx, entry.Host, entry.Path)
 	if err != nil {
 		return workspace.Context{}, err
 	}
 	s.resolveMu.Lock()
 	if s.resolved == nil {
-		s.resolved = map[string]resolvedWorkspace{}
+		s.resolved = map[workspace.Entry]resolvedWorkspace{}
 	}
-	s.resolved[path] = resolvedWorkspace{value: value, at: time.Now()}
+	s.resolved[entry] = resolvedWorkspace{value: value, at: time.Now()}
 	s.resolveMu.Unlock()
 	return value, nil
 }
@@ -358,25 +356,30 @@ func (s *Service) applyWorkspaceNames(values []workspace.Context) {
 		return
 	}
 	for index := range values {
-		if name, ok := names[values[index].Root]; ok {
+		if name, ok := names[workspace.EntryOf(values[index])]; ok {
 			values[index].Name = name
 		}
 	}
 }
 
-func (s *Service) AddWorkspace(ctx context.Context, path string) (workspace.Context, error) {
-	value, err := s.workspaces.Resolve(ctx, path)
+// AddWorkspace remembers a directory as a workspace. The host names the
+// machine the path is on; empty is this one.
+func (s *Service) AddWorkspace(
+	ctx context.Context,
+	host, path string,
+) (workspace.Context, error) {
+	value, err := s.workspaces.ResolveOn(ctx, host, path)
 	if err != nil {
 		return workspace.Context{}, err
 	}
-	if err := s.catalog.Add(value.Root); err != nil {
+	if err := s.catalog.Add(workspace.EntryOf(value)); err != nil {
 		return workspace.Context{}, err
 	}
 	return value, nil
 }
 
 func (s *Service) RemoveWorkspace(_ context.Context, value workspace.Context) error {
-	return s.catalog.Remove(value.Root)
+	return s.catalog.Remove(workspace.EntryOf(value))
 }
 
 func (s *Service) RenameWorkspace(
@@ -384,7 +387,7 @@ func (s *Service) RenameWorkspace(
 	value workspace.Context,
 	name string,
 ) error {
-	return s.catalog.SetName(value.Root, name)
+	return s.catalog.SetName(workspace.EntryOf(value), name)
 }
 
 func (s *Service) Rename(ctx context.Context, id, name string) error {

--- a/internal/app/service_test.go
+++ b/internal/app/service_test.go
@@ -179,7 +179,7 @@ func TestListWorkspaceRootsExpandsCatalogWorkspaces(t *testing.T) {
 	linked := value
 	linked.ExecutionRoot = worktree
 	catalog := workspace.NewCatalogAt(filepath.Join(t.TempDir(), "workspaces.json"))
-	if err := catalog.Add(root); err != nil {
+	if err := catalog.Add(workspace.Entry{Path: root}); err != nil {
 		t.Fatal(err)
 	}
 	service := NewServiceWithCatalog(
@@ -217,7 +217,7 @@ func TestListWorkspaceRootsDegradesOnResolverFailure(t *testing.T) {
 		ExecutionRoot: root,
 	}
 	catalog := workspace.NewCatalogAt(filepath.Join(t.TempDir(), "workspaces.json"))
-	if err := catalog.Add(root); err != nil {
+	if err := catalog.Add(workspace.Entry{Path: root}); err != nil {
 		t.Fatal(err)
 	}
 	service := NewServiceWithCatalog(

--- a/internal/ui/commands.go
+++ b/internal/ui/commands.go
@@ -115,11 +115,14 @@ func actionCmd(label string, action func(context.Context) error) tea.Cmd {
 	}
 }
 
+// addWorkspaceCmd adds a directory the human picked. The picker runs on
+// this machine, so the path is on this machine; adding one from another
+// host waits on the picker learning to run there (#127).
 func addWorkspaceCmd(backend Backend, path string) tea.Cmd {
 	return func() tea.Msg {
 		ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
 		defer cancel()
-		value, err := backend.AddWorkspace(ctx, path)
+		value, err := backend.AddWorkspace(ctx, "", path)
 		return workspaceAddedMsg{value: value, err: err}
 	}
 }

--- a/internal/ui/input_test.go
+++ b/internal/ui/input_test.go
@@ -2481,8 +2481,11 @@ func (stubBackend) ListWorkspaceRoots(context.Context) ([]workspace.Context, err
 	return nil, nil
 }
 
-func (stubBackend) AddWorkspace(_ context.Context, path string) (workspace.Context, error) {
-	return workspace.DirectoryContext(path), nil
+func (stubBackend) AddWorkspace(
+	_ context.Context,
+	host, path string,
+) (workspace.Context, error) {
+	return workspace.DirectoryContext(path).OnHost(host), nil
 }
 
 func (stubBackend) RemoveWorkspace(context.Context, workspace.Context) error {
@@ -2554,6 +2557,7 @@ type recordingBackend struct {
 	providers      []provider.Info
 	workspaceRoots []workspace.Context
 	request        app.DispatchRequest
+	addedHost      string
 	addedPath      string
 	sentID         string
 	sentMessage    string
@@ -2580,10 +2584,11 @@ func (b *recordingBackend) ListWorkspaceRoots(
 
 func (b *recordingBackend) AddWorkspace(
 	_ context.Context,
-	path string,
+	host, path string,
 ) (workspace.Context, error) {
+	b.addedHost = host
 	b.addedPath = path
-	return workspace.DirectoryContext(path), nil
+	return workspace.DirectoryContext(path).OnHost(host), nil
 }
 
 func (b *recordingBackend) Send(_ context.Context, id, message string) error {

--- a/internal/ui/model.go
+++ b/internal/ui/model.go
@@ -27,7 +27,7 @@ type Backend interface {
 	ListAgents(context.Context) ([]agent.Agent, error)
 	ListWorkspaces(context.Context) ([]workspace.Context, error)
 	ListWorkspaceRoots(context.Context) ([]workspace.Context, error)
-	AddWorkspace(context.Context, string) (workspace.Context, error)
+	AddWorkspace(ctx context.Context, host, path string) (workspace.Context, error)
 	RemoveWorkspace(context.Context, workspace.Context) error
 	Dispatch(context.Context, app.DispatchRequest) (agent.Agent, error)
 	Capture(context.Context, string, int) (string, error)

--- a/internal/workspace/catalog.go
+++ b/internal/workspace/catalog.go
@@ -4,7 +4,6 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
-	"maps"
 	"os"
 	"path/filepath"
 	"slices"
@@ -16,9 +15,24 @@ import (
 )
 
 const (
-	catalogVersion     = 1
+	// catalogVersion 2 keeps entries rather than paths: a path alone
+	// stopped identifying a workspace once one could be on another
+	// machine.
+	catalogVersion     = 2
 	catalogLockTimeout = time.Second
 )
+
+// Entry is one workspace the catalog remembers — a directory, and the
+// machine it is on. An empty Host is this one.
+type Entry struct {
+	Host string `json:"host,omitempty"`
+	Path string `json:"path"`
+}
+
+// EntryOf is the catalog's key for a resolved workspace.
+func EntryOf(value Context) Entry {
+	return Entry{Host: value.Host, Path: value.Root}
+}
 
 type Catalog struct {
 	path string
@@ -26,9 +40,32 @@ type Catalog struct {
 }
 
 type catalogData struct {
-	Version int               `json:"version"`
-	Paths   []string          `json:"paths"`
-	Names   map[string]string `json:"names,omitempty"`
+	Version int            `json:"version"`
+	Entries []catalogEntry `json:"entries"`
+
+	// Paths and Names are version 1: a list of local directories, and a
+	// separate map of display names keyed by them. Read to migrate,
+	// never written.
+	Paths []string          `json:"paths,omitempty"`
+	Names map[string]string `json:"names,omitempty"`
+}
+
+// catalogEntry folds the display name into the entry it names. In version
+// 1 names lived in their own map because a path could key one; an entry
+// cannot key a JSON object, and a name was never anything but a property
+// of the workspace anyway.
+type catalogEntry struct {
+	Host string `json:"host,omitempty"`
+	Path string `json:"path"`
+	Name string `json:"name,omitempty"`
+}
+
+func (e catalogEntry) key() Entry { return Entry{Host: e.Host, Path: e.Path} }
+
+func (d *catalogData) indexOf(entry Entry) int {
+	return slices.IndexFunc(d.Entries, func(candidate catalogEntry) bool {
+		return candidate.key() == entry
+	})
 }
 
 func NewCatalog() *Catalog {
@@ -39,7 +76,8 @@ func NewCatalogAt(path string) *Catalog {
 	return &Catalog{path: path}
 }
 
-func (c *Catalog) Paths() ([]string, error) {
+// Entries reports every remembered workspace, in the order added.
+func (c *Catalog) Entries() ([]Entry, error) {
 	c.mu.Lock()
 	defer c.mu.Unlock()
 
@@ -47,11 +85,37 @@ func (c *Catalog) Paths() ([]string, error) {
 	if err != nil {
 		return nil, err
 	}
-	return slices.Clone(data.Paths), nil
+	entries := make([]Entry, 0, len(data.Entries))
+	for _, stored := range data.Entries {
+		entries = append(entries, stored.key())
+	}
+	return entries, nil
 }
 
-func (c *Catalog) Add(path string) error {
-	canonical, err := canonicalDirectory(path)
+// canonical resolves an entry's path against the filesystem that owns it.
+// For another machine that is not this one — the same rule the resolvers
+// follow, and for the same reason: a path can exist on both machines and
+// mean different repositories.
+func (c *Catalog) canonical(entry Entry) (Entry, error) {
+	entry.Host = strings.TrimSpace(entry.Host)
+	if entry.Host == "" {
+		path, err := canonicalDirectory(entry.Path)
+		if err != nil {
+			return Entry{}, err
+		}
+		entry.Path = path
+		return entry, nil
+	}
+	path := strings.TrimSpace(entry.Path)
+	if !filepath.IsAbs(path) {
+		return Entry{}, fmt.Errorf("path %q on %s is not absolute", path, entry.Host)
+	}
+	entry.Path = filepath.Clean(path)
+	return entry, nil
+}
+
+func (c *Catalog) Add(entry Entry) error {
+	entry, err := c.canonical(entry)
 	if err != nil {
 		return err
 	}
@@ -68,15 +132,15 @@ func (c *Catalog) Add(path string) error {
 	if err != nil {
 		return err
 	}
-	if slices.Contains(data.Paths, canonical) {
+	if data.indexOf(entry) >= 0 {
 		return nil
 	}
-	data.Paths = append(data.Paths, canonical)
+	data.Entries = append(data.Entries, catalogEntry{Host: entry.Host, Path: entry.Path})
 	return c.write(data)
 }
 
-func (c *Catalog) Remove(path string) error {
-	canonical, err := canonicalDirectory(path)
+func (c *Catalog) Remove(entry Entry) error {
+	entry, err := c.canonical(entry)
 	if err != nil {
 		return err
 	}
@@ -93,18 +157,17 @@ func (c *Catalog) Remove(path string) error {
 	if err != nil {
 		return err
 	}
-	data.Paths = slices.DeleteFunc(data.Paths, func(candidate string) bool {
-		return candidate == canonical
+	data.Entries = slices.DeleteFunc(data.Entries, func(candidate catalogEntry) bool {
+		return candidate.key() == entry
 	})
-	delete(data.Names, canonical)
 	return c.write(data)
 }
 
 // SetName stores a display-name override for a workspace root. An empty
 // name removes the override. The path is added to the catalog if missing so
 // the name survives even for workspaces discovered through their agents.
-func (c *Catalog) SetName(path, name string) error {
-	canonical, err := canonicalDirectory(path)
+func (c *Catalog) SetName(entry Entry, name string) error {
+	entry, err := c.canonical(entry)
 	if err != nil {
 		return err
 	}
@@ -121,23 +184,18 @@ func (c *Catalog) SetName(path, name string) error {
 	if err != nil {
 		return err
 	}
-	if !slices.Contains(data.Paths, canonical) {
-		data.Paths = append(data.Paths, canonical)
+	index := data.indexOf(entry)
+	if index < 0 {
+		data.Entries = append(data.Entries,
+			catalogEntry{Host: entry.Host, Path: entry.Path})
+		index = len(data.Entries) - 1
 	}
-	name = strings.TrimSpace(name)
-	if name == "" {
-		delete(data.Names, canonical)
-	} else {
-		if data.Names == nil {
-			data.Names = map[string]string{}
-		}
-		data.Names[canonical] = name
-	}
+	data.Entries[index].Name = strings.TrimSpace(name)
 	return c.write(data)
 }
 
-// Names returns the display-name overrides keyed by canonical root path.
-func (c *Catalog) Names() (map[string]string, error) {
+// Names returns the display-name overrides, keyed by workspace.
+func (c *Catalog) Names() (map[Entry]string, error) {
 	c.mu.Lock()
 	defer c.mu.Unlock()
 
@@ -145,7 +203,13 @@ func (c *Catalog) Names() (map[string]string, error) {
 	if err != nil {
 		return nil, err
 	}
-	return maps.Clone(data.Names), nil
+	names := make(map[Entry]string)
+	for _, stored := range data.Entries {
+		if stored.Name != "" {
+			names[stored.key()] = stored.Name
+		}
+	}
+	return names, nil
 }
 
 func (c *Catalog) read() (catalogData, error) {
@@ -163,7 +227,11 @@ func (c *Catalog) read() (catalogData, error) {
 	if err := json.Unmarshal(content, &data); err != nil {
 		return catalogData{}, fmt.Errorf("decode workspace catalog: %w", err)
 	}
-	if data.Version != catalogVersion {
+	switch data.Version {
+	case catalogVersion:
+	case 1:
+		data = migrateFromV1(data)
+	default:
 		return catalogData{}, fmt.Errorf(
 			"unsupported workspace catalog version %d",
 			data.Version,
@@ -172,11 +240,31 @@ func (c *Catalog) read() (catalogData, error) {
 	return data, nil
 }
 
+// migrateFromV1 folds a path list and its separate name map into entries.
+// Everything version 1 held was on this machine, so every entry migrates
+// with no host — which is exactly what an empty host means.
+//
+// The file is rewritten as version 2 on the next write rather than on
+// read: a dashboard that only ever lists workspaces has no business
+// rewriting state, and the migration is cheap enough to redo until
+// something does.
+func migrateFromV1(data catalogData) catalogData {
+	entries := make([]catalogEntry, 0, len(data.Paths))
+	for _, path := range data.Paths {
+		entries = append(entries, catalogEntry{Path: path, Name: data.Names[path]})
+	}
+	return catalogData{Version: catalogVersion, Entries: entries}
+}
+
 func (c *Catalog) write(data catalogData) error {
 	if strings.TrimSpace(c.path) == "" {
 		return nil
 	}
 	data.Version = catalogVersion
+	// Version 1's fields are read for migration and never written back,
+	// or a v2 file would keep a stale copy of everything it replaced.
+	data.Paths = nil
+	data.Names = nil
 	if err := os.MkdirAll(filepath.Dir(c.path), 0o700); err != nil {
 		return fmt.Errorf("create workspace catalog directory: %w", err)
 	}

--- a/internal/workspace/catalog_test.go
+++ b/internal/workspace/catalog_test.go
@@ -2,6 +2,8 @@ package workspace
 
 import (
 	"bytes"
+	"encoding/json"
+	"fmt"
 	"os"
 	"os/exec"
 	"path/filepath"
@@ -17,14 +19,14 @@ func TestCatalogPersistsCanonicalUniquePaths(t *testing.T) {
 	catalogPath := filepath.Join(t.TempDir(), "state", "workspaces.json")
 	catalog := NewCatalogAt(catalogPath)
 
-	if err := catalog.Add(root); err != nil {
+	if err := catalog.Add(Entry{Path: root}); err != nil {
 		t.Fatal(err)
 	}
-	if err := catalog.Add(filepath.Join(root, ".")); err != nil {
+	if err := catalog.Add(Entry{Path: filepath.Join(root, ".")}); err != nil {
 		t.Fatal(err)
 	}
 
-	paths, err := NewCatalogAt(catalogPath).Paths()
+	paths, err := NewCatalogAt(catalogPath).Entries()
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -32,7 +34,7 @@ func TestCatalogPersistsCanonicalUniquePaths(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	if len(paths) != 1 || paths[0] != canonicalRoot {
+	if len(paths) != 1 || paths[0] != (Entry{Path: canonicalRoot}) {
 		t.Fatalf("paths = %#v", paths)
 	}
 	info, err := os.Stat(catalogPath)
@@ -47,13 +49,13 @@ func TestCatalogPersistsCanonicalUniquePaths(t *testing.T) {
 func TestCatalogRemovesPath(t *testing.T) {
 	root := t.TempDir()
 	catalog := NewCatalogAt(filepath.Join(t.TempDir(), "workspaces.json"))
-	if err := catalog.Add(root); err != nil {
+	if err := catalog.Add(Entry{Path: root}); err != nil {
 		t.Fatal(err)
 	}
-	if err := catalog.Remove(root); err != nil {
+	if err := catalog.Remove(Entry{Path: root}); err != nil {
 		t.Fatal(err)
 	}
-	paths, err := catalog.Paths()
+	paths, err := catalog.Entries()
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -72,23 +74,23 @@ func TestSetNamePersistsTrimmedOverrideAndAddsMissingPath(t *testing.T) {
 
 	// The path is not in the catalog yet; SetName must add it so the name
 	// survives for workspaces discovered through their agents.
-	if err := NewCatalogAt(catalogPath).SetName(root, "  Stormlight  "); err != nil {
+	if err := NewCatalogAt(catalogPath).SetName(Entry{Path: root}, "  Stormlight  "); err != nil {
 		t.Fatal(err)
 	}
 
 	reopened := NewCatalogAt(catalogPath)
-	paths, err := reopened.Paths()
+	paths, err := reopened.Entries()
 	if err != nil {
 		t.Fatal(err)
 	}
-	if len(paths) != 1 || paths[0] != canonicalRoot {
+	if len(paths) != 1 || paths[0] != (Entry{Path: canonicalRoot}) {
 		t.Fatalf("paths = %#v", paths)
 	}
 	names, err := reopened.Names()
 	if err != nil {
 		t.Fatal(err)
 	}
-	if names[canonicalRoot] != "Stormlight" {
+	if names[Entry{Path: canonicalRoot}] != "Stormlight" {
 		t.Fatalf("names = %#v", names)
 	}
 }
@@ -101,33 +103,33 @@ func TestSetNameOverwritesAndEmptyNameClearsOverride(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	if err := catalog.SetName(root, "first"); err != nil {
+	if err := catalog.SetName(Entry{Path: root}, "first"); err != nil {
 		t.Fatal(err)
 	}
-	if err := catalog.SetName(root, "second"); err != nil {
+	if err := catalog.SetName(Entry{Path: root}, "second"); err != nil {
 		t.Fatal(err)
 	}
 	names, err := catalog.Names()
 	if err != nil {
 		t.Fatal(err)
 	}
-	if names[canonicalRoot] != "second" {
+	if names[Entry{Path: canonicalRoot}] != "second" {
 		t.Fatalf("names = %#v", names)
 	}
 
 	// Whitespace-only is treated as empty and removes the override without
 	// dropping the path itself.
-	if err := catalog.SetName(root, "   "); err != nil {
+	if err := catalog.SetName(Entry{Path: root}, "   "); err != nil {
 		t.Fatal(err)
 	}
 	names, err = catalog.Names()
 	if err != nil {
 		t.Fatal(err)
 	}
-	if _, ok := names[canonicalRoot]; ok {
+	if _, ok := names[Entry{Path: canonicalRoot}]; ok {
 		t.Fatalf("override survived clearing: %#v", names)
 	}
-	paths, err := catalog.Paths()
+	paths, err := catalog.Entries()
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -145,22 +147,22 @@ func TestRemoveDiscardsTheNameOverride(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	if err := catalog.SetName(root, "Stormlight"); err != nil {
+	if err := catalog.SetName(Entry{Path: root}, "Stormlight"); err != nil {
 		t.Fatal(err)
 	}
-	if err := catalog.Remove(root); err != nil {
+	if err := catalog.Remove(Entry{Path: root}); err != nil {
 		t.Fatal(err)
 	}
 
 	// A stale name would resurface if the same path were added back later.
-	if err := catalog.Add(root); err != nil {
+	if err := catalog.Add(Entry{Path: root}); err != nil {
 		t.Fatal(err)
 	}
 	names, err := NewCatalogAt(catalogPath).Names()
 	if err != nil {
 		t.Fatal(err)
 	}
-	if _, ok := names[canonicalRoot]; ok {
+	if _, ok := names[Entry{Path: canonicalRoot}]; ok {
 		t.Fatalf("removed name came back: %#v", names)
 	}
 }
@@ -172,7 +174,7 @@ func TestNamesReturnsACopyCallersCannotMutate(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	if err := catalog.SetName(root, "Stormlight"); err != nil {
+	if err := catalog.SetName(Entry{Path: root}, "Stormlight"); err != nil {
 		t.Fatal(err)
 	}
 
@@ -180,14 +182,14 @@ func TestNamesReturnsACopyCallersCannotMutate(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	names[canonicalRoot] = "mutated"
-	delete(names, canonicalRoot)
+	names[Entry{Path: canonicalRoot}] = "mutated"
+	delete(names, Entry{Path: canonicalRoot})
 
 	fresh, err := catalog.Names()
 	if err != nil {
 		t.Fatal(err)
 	}
-	if fresh[canonicalRoot] != "Stormlight" {
+	if fresh[Entry{Path: canonicalRoot}] != "Stormlight" {
 		t.Fatalf("caller mutation leaked into the catalog: %#v", fresh)
 	}
 }
@@ -202,7 +204,7 @@ func TestCatalogRejectsCorruptAndFutureVersionFiles(t *testing.T) {
 			if err := os.WriteFile(path, []byte(testCase.content), 0o600); err != nil {
 				t.Fatal(err)
 			}
-			if _, err := NewCatalogAt(path).Paths(); err == nil {
+			if _, err := NewCatalogAt(path).Entries(); err == nil {
 				t.Fatal("corrupt catalog was accepted")
 			}
 		})
@@ -210,7 +212,7 @@ func TestCatalogRejectsCorruptAndFutureVersionFiles(t *testing.T) {
 }
 
 func TestMissingCatalogFileReadsAsEmpty(t *testing.T) {
-	paths, err := NewCatalogAt(filepath.Join(t.TempDir(), "absent.json")).Paths()
+	paths, err := NewCatalogAt(filepath.Join(t.TempDir(), "absent.json")).Entries()
 	if err != nil {
 		t.Fatalf("missing catalog was an error: %v", err)
 	}
@@ -286,7 +288,7 @@ func TestCatalogSerializesConcurrentProcesses(t *testing.T) {
 			t.Fatalf("writer %d: %v\n%s", index, err, outputs[index].String())
 		}
 	}
-	paths, err := NewCatalogAt(catalogPath).Paths()
+	paths, err := NewCatalogAt(catalogPath).Entries()
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -310,7 +312,7 @@ func TestCatalogLockWaitIsBounded(t *testing.T) {
 	defer unlock()
 
 	started := time.Now()
-	err = NewCatalogAt(catalogPath).Add(root)
+	err = NewCatalogAt(catalogPath).Add(Entry{Path: root})
 	elapsed := time.Since(started)
 	if err == nil || !strings.Contains(err.Error(), "timed out") {
 		t.Fatalf("Add error = %v", err)
@@ -335,7 +337,141 @@ func TestCatalogProcessWriter(t *testing.T) {
 		time.Sleep(5 * time.Millisecond)
 	}
 	if err := NewCatalogAt(os.Getenv("STORMLIGHT_CATALOG_PATH")).
-		Add(os.Getenv("STORMLIGHT_CATALOG_ROOT")); err != nil {
+		Add(Entry{Path: os.Getenv("STORMLIGHT_CATALOG_ROOT")}); err != nil {
 		t.Fatal(err)
+	}
+}
+
+// TestVersionOneCatalogMigrates: everything version 1 held was on this
+// machine, and it has to keep working. A user upgrading does not
+// re-add their workspaces, and does not re-type the names they chose.
+func TestVersionOneCatalogMigrates(t *testing.T) {
+	root, err := canonicalDirectory(t.TempDir())
+	if err != nil {
+		t.Fatal(err)
+	}
+	other, err := canonicalDirectory(t.TempDir())
+	if err != nil {
+		t.Fatal(err)
+	}
+	path := filepath.Join(t.TempDir(), "workspaces.json")
+	legacy := fmt.Sprintf(
+		`{"version":1,"paths":[%q,%q],"names":{%q:"Stormlight"}}`, root, other, root)
+	if err := os.WriteFile(path, []byte(legacy), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	catalog := NewCatalogAt(path)
+	entries, err := catalog.Entries()
+	if err != nil {
+		t.Fatalf("a version 1 catalog must still load: %v", err)
+	}
+	if len(entries) != 2 || entries[0] != (Entry{Path: root}) || entries[1] != (Entry{Path: other}) {
+		t.Fatalf("entries = %#v", entries)
+	}
+	// Order matters: it is the order of the workspace pane.
+	names, err := catalog.Names()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if names[Entry{Path: root}] != "Stormlight" {
+		t.Fatalf("a chosen name was lost in migration: %#v", names)
+	}
+
+	// The next write puts it in the new shape, and leaves no copy of the
+	// old one behind to be read again.
+	if err := catalog.Add(Entry{Host: "devbox", Path: "/srv/api"}); err != nil {
+		t.Fatal(err)
+	}
+	content, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	var raw map[string]any
+	if err := json.Unmarshal(content, &raw); err != nil {
+		t.Fatal(err)
+	}
+	if raw["version"] != float64(catalogVersion) {
+		t.Fatalf("version = %v", raw["version"])
+	}
+	if _, stale := raw["paths"]; stale {
+		t.Fatalf("version 1 fields must not survive a write: %s", content)
+	}
+	if _, stale := raw["names"]; stale {
+		t.Fatalf("version 1 fields must not survive a write: %s", content)
+	}
+}
+
+// TestRemoteEntriesAreNotResolvedHere: a catalogued path on another
+// machine must not be canonicalized against this filesystem, and must not
+// have to exist here at all.
+func TestRemoteEntriesAreNotResolvedHere(t *testing.T) {
+	catalog := NewCatalogAt(filepath.Join(t.TempDir(), "workspaces.json"))
+	remote := Entry{Host: "devbox", Path: "/srv/api"}
+	if err := catalog.Add(remote); err != nil {
+		t.Fatalf("a remote entry should not need to exist here: %v", err)
+	}
+	entries, err := catalog.Entries()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(entries) != 1 || entries[0] != remote {
+		t.Fatalf("entries = %#v", entries)
+	}
+	if err := catalog.Add(Entry{Host: "devbox", Path: "/srv/api/"}); err != nil {
+		t.Fatal(err)
+	}
+	if entries, _ := catalog.Entries(); len(entries) != 1 {
+		t.Fatalf("the same path twice is one workspace: %#v", entries)
+	}
+	// A relative path means "here", and here is the wrong machine.
+	if err := catalog.Add(Entry{Host: "devbox", Path: "srv/api"}); err == nil {
+		t.Fatal("a relative remote path must be refused")
+	}
+}
+
+// TestTheSamePathOnTwoMachinesIsTwoWorkspaces: the whole reason the
+// catalog stopped being a list of paths.
+func TestTheSamePathOnTwoMachinesIsTwoWorkspaces(t *testing.T) {
+	local, err := canonicalDirectory(t.TempDir())
+	if err != nil {
+		t.Fatal(err)
+	}
+	catalog := NewCatalogAt(filepath.Join(t.TempDir(), "workspaces.json"))
+	if err := catalog.Add(Entry{Path: local}); err != nil {
+		t.Fatal(err)
+	}
+	if err := catalog.Add(Entry{Host: "devbox", Path: local}); err != nil {
+		t.Fatal(err)
+	}
+	entries, err := catalog.Entries()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(entries) != 2 {
+		t.Fatalf("one path on two machines is two workspaces: %#v", entries)
+	}
+
+	// And naming one does not name the other.
+	if err := catalog.SetName(Entry{Host: "devbox", Path: local}, "There"); err != nil {
+		t.Fatal(err)
+	}
+	names, err := catalog.Names()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if names[Entry{Host: "devbox", Path: local}] != "There" {
+		t.Fatalf("names = %#v", names)
+	}
+	if _, named := names[Entry{Path: local}]; named {
+		t.Fatalf("naming one machine's workspace named the other's: %#v", names)
+	}
+
+	// Removing one leaves the other.
+	if err := catalog.Remove(Entry{Host: "devbox", Path: local}); err != nil {
+		t.Fatal(err)
+	}
+	if entries, _ := catalog.Entries(); len(entries) != 1 || entries[0].Host != "" {
+		t.Fatalf("entries = %#v", entries)
 	}
 }

--- a/main.go
+++ b/main.go
@@ -114,7 +114,7 @@ func newRootCommand() *cobra.Command {
 		newStopCommand(cfg),
 		newDeleteCommand(cfg),
 		newMarkCommand(cfg),
-		newWorkspaceCommand(),
+		newWorkspaceCommand(cfg),
 		newEventCommand(cfg),
 		newProviderEventCommand(cfg),
 		newLogsCommand(&logFile),
@@ -366,7 +366,7 @@ func runDashboard(command *cobra.Command, cfg config.Config, openPath string) er
 		Columns:         ui.LoadColumnPrefs(),
 	}
 	if openPath != "" {
-		value, err := service.AddWorkspace(context.Background(), openPath)
+		value, err := service.AddWorkspace(context.Background(), "", openPath)
 		if err != nil {
 			return fmt.Errorf("open workspace %s: %w", openPath, err)
 		}
@@ -450,13 +450,9 @@ func newService(cfg config.Config) (*app.Service, error) {
 		return nil, err
 	}
 	registry := provider.NewRegistryWithSpecs(providerSpecs(cfg))
-	workspaces := workspace.NewRegistry()
 	// Resolution follows a path to the machine that has it, so the
 	// registry needs the same host list the runtime has.
-	for _, name := range slices.Sorted(maps.Keys(cfg.Hosts)) {
-		workspaces.AddHost(remoteHostFrom(name, cfg.Hosts[name]))
-	}
-	return app.NewService(runtime, registry, workspaces), nil
+	return app.NewService(runtime, registry, workspacesWithHosts(cfg)), nil
 }
 
 // newRuntime builds the fleet: this machine's daemon, and one per
@@ -492,12 +488,24 @@ func remoteHostFrom(name string, host config.Host) remote.Host {
 	}
 }
 
-func newWorkspaceService() *app.Service {
+// newWorkspaceService is the runtime-free service the workspace commands
+// use: they read and edit the catalog and never touch an agent. It still
+// needs the host list, because a catalog entry can name another machine
+// and only that machine can resolve it.
+func newWorkspaceService(cfg config.Config) *app.Service {
 	return app.NewService(
 		nil,
 		provider.NewRegistry(),
-		workspace.NewRegistry(),
+		workspacesWithHosts(cfg),
 	)
+}
+
+func workspacesWithHosts(cfg config.Config) *workspace.Registry {
+	workspaces := workspace.NewRegistry()
+	for _, name := range slices.Sorted(maps.Keys(cfg.Hosts)) {
+		workspaces.AddHost(remoteHostFrom(name, cfg.Hosts[name]))
+	}
+	return workspaces
 }
 
 func newDispatchCommand(cfg config.Config) *cobra.Command {
@@ -619,30 +627,31 @@ func newListCommand(cfg config.Config) *cobra.Command {
 	return command
 }
 
-func newWorkspaceCommand() *cobra.Command {
+func newWorkspaceCommand(cfg config.Config) *cobra.Command {
 	command := &cobra.Command{
 		Use:   "workspace",
 		Short: "Inspect and manage workspaces",
 	}
 	command.AddCommand(
-		newWorkspaceAddCommand(),
-		newWorkspaceListCommand(),
-		newWorkspaceRootsCommand(),
+		newWorkspaceAddCommand(cfg),
+		newWorkspaceListCommand(cfg),
+		newWorkspaceRootsCommand(cfg),
 	)
 	return command
 }
 
-func newWorkspaceAddCommand() *cobra.Command {
+func newWorkspaceAddCommand(cfg config.Config) *cobra.Command {
 	var asJSON bool
+	var host string
 	command := &cobra.Command{
 		Use:   "add <path>",
 		Short: "Add a workspace to the dashboard",
 		Args:  cobra.ExactArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
-			service := newWorkspaceService()
+			service := newWorkspaceService(cfg)
 			ctx, cancel := context.WithTimeout(cmd.Context(), 10*time.Second)
 			defer cancel()
-			value, err := service.AddWorkspace(ctx, args[0])
+			value, err := service.AddWorkspace(ctx, host, args[0])
 			if err != nil {
 				return err
 			}
@@ -654,17 +663,19 @@ func newWorkspaceAddCommand() *cobra.Command {
 		},
 	}
 	command.Flags().BoolVar(&asJSON, "json", false, "emit JSON")
+	command.Flags().StringVar(&host, "host", "",
+		"the configured host the path is on; omit for this machine")
 	return command
 }
 
-func newWorkspaceListCommand() *cobra.Command {
+func newWorkspaceListCommand(cfg config.Config) *cobra.Command {
 	var asJSON bool
 	command := &cobra.Command{
 		Use:   "list",
 		Short: "List catalog workspaces",
 		Args:  cobra.NoArgs,
 		RunE: func(cmd *cobra.Command, args []string) error {
-			service := newWorkspaceService()
+			service := newWorkspaceService(cfg)
 			ctx, cancel := context.WithTimeout(cmd.Context(), 10*time.Second)
 			defer cancel()
 			values, err := service.ListWorkspaces(ctx)
@@ -678,14 +689,14 @@ func newWorkspaceListCommand() *cobra.Command {
 	return command
 }
 
-func newWorkspaceRootsCommand() *cobra.Command {
+func newWorkspaceRootsCommand(cfg config.Config) *cobra.Command {
 	var asJSON bool
 	command := &cobra.Command{
 		Use:   "roots [path]",
 		Short: "List runnable roots in a workspace",
 		Args:  cobra.MaximumNArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
-			service := newWorkspaceService()
+			service := newWorkspaceService(cfg)
 			ctx, cancel := context.WithTimeout(cmd.Context(), 10*time.Second)
 			defer cancel()
 			var values []workspace.Context

--- a/site/docs/architecture.html
+++ b/site/docs/architecture.html
@@ -304,7 +304,12 @@
     <p>Session metadata in the daemon is the source of truth for the running roster, and the
     daemon's persistence is what makes it durable: agents outlive every dashboard because
     their PTYs and terminals never belonged to one. The workspace catalog is an atomic JSON
-    file independent of the daemon, as are the dashboard's column preferences.</p>
+    file independent of the daemon, as are the dashboard's column preferences. Its entries
+    carry the machine they are on, because a path stopped identifying a workspace once one
+    could be on another: the same directory on two hosts is two workspaces, named and
+    removed separately. Entries for a host that is asleep stay in the catalog and resolve
+    when it comes back; a host that cannot answer costs its own rows and not the
+    listing.</p>
     <p>The daemon's lifetime bounds the roster's. A reboot or a killed daemon takes the
     processes and their terminals with it — but not the conversations.
     <code>internal/history</code> keeps an append-only session log


### PR DESCRIPTION
Phase 4a of #127.

A path stopped identifying a workspace the moment one could be on another
machine. `/srv/api` here and `/srv/api` on `devbox` are two repositories —
named separately, removed separately, grouped separately — so the catalog now
keeps entries (`{host, path}`) rather than a path list.

With this, a remote dispatch catalogues its workspace like any other, so remote
workspaces persist instead of vanishing with their last agent. #130 had to skip
them for exactly this reason.

## Names move into the entry

In version 1 names lived in their own map because a path could key one. An
entry cannot key a JSON object, and a name was never anything but a property of
the workspace anyway:

```json
{"version": 2, "entries": [
  {"path": "/Volumes/repos/stormlight", "name": "Renamed By Hand"},
  {"host": "devbox", "path": "/srv/api"}
]}
```

## Migration

Version 1 files migrate on read; everything they held was on this machine,
which is exactly what an empty host means. The rewrite happens on the next
*write* rather than on read — a dashboard that only lists workspaces has no
business rewriting state — and a write drops the v1 fields rather than leaving
a stale copy of what it replaced.

Remote entries are not canonicalized here, for the reason the resolvers already
refuse to (#129): this is the wrong filesystem, and a path that happens to
exist on both would resolve to the wrong repository while looking correct. A
relative remote path is refused outright.

## API

`AddWorkspace` takes a host, and `workspace add --host` names one. The
dashboard's own add still passes none: the picker runs here, so the path it
returns is here. Running the picker on the remote is the next piece — the
plumbing (`OverlayRequest.Host`) is already in place from #130.

The runtime-free workspace service now gets the config, because a catalogue
entry can name another machine and only that machine can resolve it. A host
that is asleep costs its own rows and not the listing.

## Testing

`go test ./...` and `go vet ./...` green. New coverage: v1 migration keeps
order and chosen names and leaves no v1 fields after a write; remote entries
need not exist here and reject relative paths; the same path on two machines is
two workspaces that name and remove independently.

**Against a real v1 file**, written in the shipped format: the dashboard lists
it, the hand-chosen name survives, reading leaves the file untouched, and
`workspace add` rewrites it as version 2 with the name carried into its entry.
