### PR TITLE
The transcript view reads from the machine the agent is on

### DIFF
--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -145,6 +145,15 @@ nothing else. Closing the laptop stops nothing.
 - `F` runs `ssh -t <host> stormlight _wrattach`, carrying the socket
   directory explicitly: a tty session runs a login shell where a bridge
   does not, and the two can disagree about where XDG state lives.
+- An agent's transcript is written by its provider, beside its repository,
+  on its own host — so `session.FileReader` is a runtime capability for
+  reading a file where the agent is (`stormlight _read` over the same
+  SSH, size-capped on the far side so a cap never pays for the bytes it
+  discards). Deliberately not a channel in the wire protocol, which is
+  about terminals and knows nothing of files. Remote renders are cached
+  for a beat, because this runs on the refresh path; the live screen
+  below the divider comes from the terminal snapshot and is never cached,
+  so output in flight still arrives every frame.
 
 The trust boundary comes along unchanged. The wire protocol has no
 authentication of its own and needs none: reaching the socket means being

--- a/internal/app/service.go
+++ b/internal/app/service.go
@@ -51,7 +51,24 @@ type Service struct {
 	// a stale entry.
 	resolveMu sync.Mutex
 	resolved  map[workspace.Entry]resolvedWorkspace
+
+	// transcripts caches renders of transcripts that had to cross a
+	// tunnel to get here.
+	transcriptMu sync.Mutex
+	transcripts  map[string]renderedTranscript
 }
+
+type renderedTranscript struct {
+	rendered string
+	ok       bool
+	at       time.Time
+}
+
+// remoteTranscriptTTL bounds how stale the settled part of a remote
+// conversation can be. Short enough that a finished turn appears without
+// anyone waiting for it; long enough that a refresh loop is not a file
+// transfer.
+const remoteTranscriptTTL = 2 * time.Second
 
 type resolvedWorkspace struct {
 	value workspace.Context
@@ -418,7 +435,7 @@ func (s *Service) transcriptCapture(ctx context.Context, id string, lines int) (
 		if managedAgent.TranscriptPath == "" {
 			return "", false
 		}
-		rendered, ok := provider.RenderClaudeTranscript(managedAgent.TranscriptPath)
+		rendered, ok := s.renderTranscript(ctx, managedAgent)
 		if !ok {
 			return "", false
 		}
@@ -432,6 +449,62 @@ func (s *Service) transcriptCapture(ctx context.Context, id string, lines int) (
 		return rendered, true
 	}
 	return "", false
+}
+
+// renderTranscript reads and renders an agent's transcript from the
+// machine it is on.
+//
+// A remote transcript is cached for a beat. This runs on the dashboard's
+// refresh path, and a conversation that has run all afternoon is not a
+// file to pull across a tunnel several times a second. What the cache
+// costs is nothing the eye can see: the live screen is appended below the
+// divider from the terminal snapshot, which is cheap and never cached, so
+// output in flight still arrives every frame — only the settled part of
+// the conversation waits.
+func (s *Service) renderTranscript(
+	ctx context.Context,
+	managedAgent agent.Agent,
+) (string, bool) {
+	reader, ok := s.runtime.(session.FileReader)
+	if !ok {
+		return provider.RenderClaudeTranscript(managedAgent.TranscriptPath)
+	}
+	if managedAgent.Host == "" {
+		// Reading a local file is cheap enough that a cache would only
+		// add staleness.
+		return provider.RenderClaudeTranscript(managedAgent.TranscriptPath)
+	}
+
+	key := managedAgent.Host + "\x00" + managedAgent.TranscriptPath
+	s.transcriptMu.Lock()
+	cached, hit := s.transcripts[key]
+	s.transcriptMu.Unlock()
+	if hit && time.Since(cached.at) < remoteTranscriptTTL {
+		return cached.rendered, cached.ok
+	}
+
+	rendered, ok := func() (string, bool) {
+		source, err := reader.ReadAgentFile(ctx, managedAgent.ID, managedAgent.TranscriptPath)
+		if err != nil {
+			diagnostic.Logger().Warn("transcript unavailable",
+				"agent_id", managedAgent.ID,
+				"host", managedAgent.Host,
+				"path", managedAgent.TranscriptPath,
+				"error", err,
+			)
+			return "", false
+		}
+		defer source.Close()
+		return provider.RenderClaudeTranscriptFrom(source)
+	}()
+
+	s.transcriptMu.Lock()
+	if s.transcripts == nil {
+		s.transcripts = map[string]renderedTranscript{}
+	}
+	s.transcripts[key] = renderedTranscript{rendered: rendered, ok: ok, at: time.Now()}
+	s.transcriptMu.Unlock()
+	return rendered, ok
 }
 
 func (s *Service) Attach(ctx context.Context, id string) (AttachResult, error) {

--- a/internal/app/transcript_test.go
+++ b/internal/app/transcript_test.go
@@ -1,0 +1,177 @@
+package app
+
+import (
+	"context"
+	"fmt"
+	"io"
+	"os"
+	"path/filepath"
+	"regexp"
+	"strings"
+	"sync"
+	"testing"
+
+	"github.com/trentkm/stormlight/internal/agent"
+	"github.com/trentkm/stormlight/internal/history"
+	"github.com/trentkm/stormlight/internal/provider"
+	"github.com/trentkm/stormlight/internal/session"
+	"github.com/trentkm/stormlight/internal/workspace"
+)
+
+// readingRuntime is a runtime whose agents live somewhere this process
+// cannot reach, and which can fetch a file from there.
+type readingRuntime struct {
+	recordingRuntime
+	mu      sync.Mutex
+	files   map[string]string
+	capture string
+	reads   int
+	readErr error
+}
+
+func (r *readingRuntime) Capture(context.Context, string, int) (string, error) {
+	return r.capture, nil
+}
+
+func (r *readingRuntime) ReadAgentFile(
+	_ context.Context,
+	_ string,
+	path string,
+) (io.ReadCloser, error) {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	r.reads++
+	if r.readErr != nil {
+		return nil, r.readErr
+	}
+	content, ok := r.files[path]
+	if !ok {
+		return nil, fmt.Errorf("no such file")
+	}
+	return io.NopCloser(strings.NewReader(content)), nil
+}
+
+func (r *readingRuntime) readCount() int {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	return r.reads
+}
+
+// The renderer styles as it goes, so a phrase can carry escape sequences
+// through its middle. Assertions are about the words.
+var ansiPattern = regexp.MustCompile(`\x1b\[[0-9;]*m`)
+
+func plain(text string) string { return ansiPattern.ReplaceAllString(text, "") }
+
+const transcriptJSONL = `{"type":"user","message":{"content":"why is the build red"}}
+{"type":"assistant","message":{"content":[{"type":"text","text":"A missing import."}]}}
+`
+
+func serviceWithRuntime(t *testing.T, runtime session.Runtime) *Service {
+	t.Helper()
+	return NewServiceWithCatalog(
+		runtime,
+		provider.NewRegistry(),
+		workspace.NewRegistry(),
+		workspace.NewCatalogAt(filepath.Join(t.TempDir(), "workspaces.json")),
+		history.NewLogAt(filepath.Join(t.TempDir(), "sessions.jsonl")),
+	)
+}
+
+// TestRemoteTranscriptIsReadFromItsOwnMachine: the path in an agent's
+// record names a file on the agent's host. Reading it here would find
+// nothing — or, worse, find something.
+func TestRemoteTranscriptIsReadFromItsOwnMachine(t *testing.T) {
+	runtime := &readingRuntime{files: map[string]string{
+		"/home/trent/.claude/projects/api/session.jsonl": transcriptJSONL,
+	}}
+	runtime.agents = []agent.Agent{{
+		ID:             "aaa",
+		Host:           "devbox",
+		TranscriptPath: "/home/trent/.claude/projects/api/session.jsonl",
+		Activity:       agent.ActivityIdle,
+	}}
+	service := serviceWithRuntime(t, runtime)
+
+	rendered, err := service.Capture(context.Background(), "aaa", 100)
+	if err != nil {
+		t.Fatalf("Capture: %v", err)
+	}
+	for _, want := range []string{"why is the build red", "A missing import."} {
+		if !strings.Contains(plain(rendered), want) {
+			t.Fatalf("transcript did not cross: %q", rendered)
+		}
+	}
+}
+
+// TestRemoteTranscriptIsNotRefetchedEveryFrame: this runs on the
+// dashboard's refresh path, and a conversation that has run all afternoon
+// is not a file to pull across a tunnel several times a second.
+func TestRemoteTranscriptIsNotRefetchedEveryFrame(t *testing.T) {
+	runtime := &readingRuntime{files: map[string]string{"/t.jsonl": transcriptJSONL}}
+	runtime.agents = []agent.Agent{{
+		ID: "aaa", Host: "devbox", TranscriptPath: "/t.jsonl",
+		Activity: agent.ActivityIdle,
+	}}
+	service := serviceWithRuntime(t, runtime)
+
+	for range 5 {
+		if _, err := service.Capture(context.Background(), "aaa", 100); err != nil {
+			t.Fatalf("Capture: %v", err)
+		}
+	}
+	if got := runtime.readCount(); got != 1 {
+		t.Fatalf("fetched %d times across five refreshes, want 1", got)
+	}
+}
+
+// TestALocalTranscriptIsNotCached: reading a local file is cheap enough
+// that a cache would only add staleness to a conversation being watched.
+func TestALocalTranscriptIsNotCached(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "session.jsonl")
+	if err := os.WriteFile(path, []byte(transcriptJSONL), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	runtime := &readingRuntime{files: map[string]string{}}
+	runtime.agents = []agent.Agent{{
+		ID: "aaa", TranscriptPath: path, Activity: agent.ActivityIdle,
+	}}
+	service := serviceWithRuntime(t, runtime)
+
+	first, err := service.Capture(context.Background(), "aaa", 100)
+	if err != nil || !strings.Contains(plain(first), "A missing import.") {
+		t.Fatalf("Capture: %v, %q", err, first)
+	}
+	appended := transcriptJSONL +
+		`{"type":"assistant","message":{"content":[{"type":"text","text":"Fixed now."}]}}` + "\n"
+	if err := os.WriteFile(path, []byte(appended), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	second, err := service.Capture(context.Background(), "aaa", 100)
+	if err != nil {
+		t.Fatalf("Capture: %v", err)
+	}
+	if !strings.Contains(plain(second), "Fixed now.") {
+		t.Fatalf("a local transcript should be read fresh: %q", second)
+	}
+}
+
+// TestAnUnreadableTranscriptFallsBackToTheScreen: a host that went away
+// mid-conversation should cost the reading view, not the pane.
+func TestAnUnreadableTranscriptFallsBackToTheScreen(t *testing.T) {
+	runtime := &readingRuntime{readErr: fmt.Errorf("ssh: connection closed")}
+	runtime.agents = []agent.Agent{{
+		ID: "aaa", Host: "devbox", TranscriptPath: "/t.jsonl",
+		Activity: agent.ActivityIdle,
+	}}
+	runtime.capture = "what the terminal last showed"
+	service := serviceWithRuntime(t, runtime)
+
+	rendered, err := service.Capture(context.Background(), "aaa", 100)
+	if err != nil {
+		t.Fatalf("Capture: %v", err)
+	}
+	if !strings.Contains(plain(rendered), "what the terminal last showed") {
+		t.Fatalf("want the terminal snapshot, got %q", rendered)
+	}
+}

--- a/internal/fleet/fleet.go
+++ b/internal/fleet/fleet.go
@@ -17,6 +17,7 @@ package fleet
 import (
 	"context"
 	"fmt"
+	"io"
 	"sync"
 	"time"
 
@@ -345,6 +346,24 @@ func (f *Runtime) AttachTerminal(
 		return nil, fmt.Errorf("runtime does not stream terminals")
 	}
 	return streamer.AttachTerminal(ctx, id, cols, rows)
+}
+
+// ReadAgentFile forwards the file-reading capability to the daemon that
+// holds the agent, which is the one standing on the filesystem the path
+// belongs to.
+func (f *Runtime) ReadAgentFile(
+	ctx context.Context,
+	id, path string,
+) (io.ReadCloser, error) {
+	runtime, err := f.memberFor(ctx, id)
+	if err != nil {
+		return nil, err
+	}
+	reader, ok := runtime.(session.FileReader)
+	if !ok {
+		return nil, fmt.Errorf("runtime cannot read files")
+	}
+	return reader.ReadAgentFile(ctx, id, path)
 }
 
 // StartOverlay runs the picker or the editor on the machine whose

--- a/internal/fleet/fleet_test.go
+++ b/internal/fleet/fleet_test.go
@@ -3,6 +3,7 @@ package fleet
 import (
 	"context"
 	"errors"
+	"io"
 	"strings"
 	"sync"
 	"testing"
@@ -15,13 +16,14 @@ import (
 // stub is one daemon's worth of runtime: a roster it will report and a
 // record of what was asked of it.
 type stub struct {
-	mu       sync.Mutex
-	agents   []agent.Agent
-	listErr  error
-	sent     []string
-	deleted  []string
-	launched []session.DispatchRequest
-	lists    int
+	mu        sync.Mutex
+	agents    []agent.Agent
+	listErr   error
+	sent      []string
+	deleted   []string
+	launched  []session.DispatchRequest
+	lists     int
+	readPaths []string
 }
 
 func (s *stub) ListAgents(context.Context) ([]agent.Agent, error) {
@@ -59,6 +61,17 @@ func (s *stub) Delete(_ context.Context, id string) error {
 }
 
 func (s *stub) Capture(context.Context, string, int) (string, error) { return "", nil }
+
+func (s *stub) ReadAgentFile(
+	_ context.Context,
+	_ string,
+	path string,
+) (io.ReadCloser, error) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.readPaths = append(s.readPaths, path)
+	return io.NopCloser(strings.NewReader("contents of " + path)), nil
+}
 func (s *stub) Attach(context.Context, string) (session.AttachResult, error) {
 	return session.AttachResult{}, nil
 }
@@ -303,5 +316,31 @@ func TestAFleetOfOneIsJustTheRuntime(t *testing.T) {
 	}
 	if len(local.sent) != 1 {
 		t.Fatalf("the message never arrived: %v", local.sent)
+	}
+}
+
+// TestFileReadsFollowTheAgentToItsHost: a transcript path names a file on
+// the agent's own machine, and reading it here would find nothing — or,
+// worse, find something that happens to share the path.
+func TestFileReadsFollowTheAgentToItsHost(t *testing.T) {
+	local := &stub{agents: []agent.Agent{{ID: "aaa"}}}
+	devbox := &stub{agents: []agent.Agent{{ID: "bbb"}}}
+	f := New(reachable("", local), reachable("devbox", devbox))
+
+	source, err := f.ReadAgentFile(context.Background(), "bbb", "/home/trent/t.jsonl")
+	if err != nil {
+		t.Fatalf("ReadAgentFile: %v", err)
+	}
+	defer source.Close()
+	content, err := io.ReadAll(source)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if string(content) != "contents of /home/trent/t.jsonl" {
+		t.Fatalf("content = %q", content)
+	}
+	if len(devbox.readPaths) != 1 || len(local.readPaths) != 0 {
+		t.Fatalf("read went to the wrong machine: local=%v devbox=%v",
+			local.readPaths, devbox.readPaths)
 	}
 }

--- a/internal/provider/transcript.go
+++ b/internal/provider/transcript.go
@@ -4,6 +4,7 @@ import (
 	"bufio"
 	"encoding/json"
 	"fmt"
+	"io"
 	"os"
 	"strings"
 
@@ -106,10 +107,15 @@ func RenderClaudeTranscript(path string) (rendered string, ok bool) {
 		return "", false
 	}
 	defer file.Close()
+	return RenderClaudeTranscriptFrom(file)
+}
 
+// RenderClaudeTranscriptFrom is RenderClaudeTranscript over an already-open
+// transcript, for the ones that are not on this machine.
+func RenderClaudeTranscriptFrom(source io.Reader) (rendered string, ok bool) {
 	var out strings.Builder
 	turns := 0
-	scanner := bufio.NewScanner(file)
+	scanner := bufio.NewScanner(source)
 	scanner.Buffer(make([]byte, 0, 64*1024), transcriptScanBuffer)
 	for scanner.Scan() {
 		var line transcriptLine

--- a/internal/session/runtime.go
+++ b/internal/session/runtime.go
@@ -2,6 +2,7 @@ package session
 
 import (
 	"context"
+	"io"
 	"os/exec"
 
 	"github.com/trentkm/stormlight/internal/agent"
@@ -37,6 +38,17 @@ type TerminalStream interface {
 	Write(p []byte) error
 	Resize(ctx context.Context, cols, rows int) error
 	Close()
+}
+
+// FileReader is an optional runtime capability: read a file on the
+// machine an agent is running on.
+//
+// An agent's transcript is written by its provider, beside its
+// repository, on its own host — so the path in an agent's record names a
+// file this process may have no way to open. The runtime knows which
+// daemon holds the agent, which makes it the only layer that can answer.
+type FileReader interface {
+	ReadAgentFile(ctx context.Context, id, path string) (io.ReadCloser, error)
 }
 
 // OverlayRequest describes a short-lived interactive program the

--- a/internal/windrun/files.go
+++ b/internal/windrun/files.go
@@ -1,0 +1,63 @@
+package windrun
+
+import (
+	"bytes"
+	"context"
+	"fmt"
+	"io"
+	"os"
+	"strings"
+)
+
+// MaxAgentFile bounds what a single read will pull across a tunnel. A
+// transcript grows with the conversation and nothing prunes it, so the
+// cap is what stops one very long-lived agent from turning a keystroke
+// into a minute of transfer. A truncated transcript loses its tail; the
+// renderer skips the partial line and shows the rest, which is a better
+// answer than a dashboard that stops responding.
+const MaxAgentFile = 64 << 20
+
+// ReadAgentFile opens a file on the machine the agent is running on.
+//
+// Locally that is os.Open. On another host it is `cat` over the same SSH
+// the daemon is reached through — deliberately not a new channel in the
+// wire protocol, which is about terminals and knows nothing of files.
+func (r *Runtime) ReadAgentFile(
+	ctx context.Context,
+	_ string,
+	path string,
+) (io.ReadCloser, error) {
+	if strings.TrimSpace(path) == "" {
+		return nil, fmt.Errorf("no file to read")
+	}
+	if r.transport == nil {
+		file, err := os.Open(path)
+		if err != nil {
+			return nil, err
+		}
+		return cappedFile{Reader: io.LimitReader(file, MaxAgentFile), closer: file}, nil
+	}
+
+	command := r.transport.CommandContext(ctx, nil, "_read", path)
+	var stdout, stderr bytes.Buffer
+	command.Stdout = &stdout
+	command.Stderr = &stderr
+	if err := command.Run(); err != nil {
+		if ctx.Err() != nil {
+			return nil, ctx.Err()
+		}
+		if message := strings.TrimSpace(stderr.String()); message != "" {
+			return nil, fmt.Errorf("%s: %s", r.transport.Host().Name, message)
+		}
+		return nil, fmt.Errorf("%s: %w", r.transport.Host().Name, err)
+	}
+	return io.NopCloser(bytes.NewReader(stdout.Bytes())), nil
+}
+
+// cappedFile is a bounded reader that still closes the file underneath.
+type cappedFile struct {
+	io.Reader
+	closer io.Closer
+}
+
+func (c cappedFile) Close() error { return c.closer.Close() }

--- a/main.go
+++ b/main.go
@@ -123,6 +123,7 @@ func newRootCommand() *cobra.Command {
 		newWindrunnerAttachCommand(),
 		newWindrunnerBridgeCommand(),
 		newResolveCommand(),
+		newReadCommand(),
 		newBenchCommand(),
 	)
 	return root
@@ -222,6 +223,31 @@ func newResolveCommand() *cobra.Command {
 	command.Flags().BoolVar(&roots, "roots", false,
 		"report every runnable checkout in the workspace")
 	return command
+}
+
+// newReadCommand copies a file to stdout, for a dashboard on another
+// machine. An agent's transcript is written by its provider beside its
+// repository, so the path in an agent's record names a file only that
+// host can open.
+//
+// The size cap is applied here rather than by the reader, because a cap
+// on the far side of a tunnel is one that has already paid for every byte
+// it discards.
+func newReadCommand() *cobra.Command {
+	return &cobra.Command{
+		Use:    "_read <path>",
+		Hidden: true,
+		Args:   cobra.ExactArgs(1),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			file, err := os.Open(args[0])
+			if err != nil {
+				return err
+			}
+			defer file.Close()
+			_, err = io.Copy(cmd.OutOrStdout(), io.LimitReader(file, windrun.MaxAgentFile))
+			return err
+		},
+	}
 }
 
 // newWindrunnerAttachCommand is the F key's other half: a full-terminal

--- a/site/docs/architecture.html
+++ b/site/docs/architecture.html
@@ -178,6 +178,14 @@
       <li><code>F</code> runs <code>ssh -t &lt;host&gt; stormlight _wrattach</code>,
       carrying the socket directory explicitly: a tty session runs a login shell where a
       bridge does not, and the two can disagree about where XDG state lives.</li>
+      <li>An agent's transcript is written by its provider, beside its repository, on its
+      own host — so <code>session.FileReader</code> is a runtime capability for reading a
+      file where the agent is (<code>stormlight _read</code> over the same SSH, size-capped
+      on the far side so a cap never pays for the bytes it discards). Deliberately not a
+      channel in the wire protocol, which is about terminals and knows nothing of files.
+      Remote renders are cached for a beat, because this runs on the refresh path; the live
+      screen below the divider comes from the terminal snapshot and is never cached, so
+      output in flight still arrives every frame.</li>
     </ul>
     <p>The trust boundary comes along unchanged. The wire protocol has no authentication of
     its own and needs none: reaching the socket means being the user who owns it, enforced


### PR DESCRIPTION
Phase 4b of #127.

An agent's transcript is written by its provider, beside its repository, on its
own host — so the path in an agent's record names a file this process may have
no way to open. The failure was the quiet kind: a remote agent fell back to its
terminal snapshot, which for an alternate-screen provider is one screen of a
conversation that has been running all afternoon.

## The capability

`session.FileReader` — read a file on the machine an agent is on. The runtime
is the layer that knows which daemon holds an agent, which makes it the only
one that can answer. Locally that is `os.Open`; remotely it is `stormlight
_read` over the same SSH the daemon is reached through.

Deliberately *not* a new channel in the wire protocol: windrunner is about
terminals and knows nothing of files, and this is Stormlight's concern. The
size cap lives on the far side, because a cap applied here is one that has
already paid for every byte it discards.

`RenderClaudeTranscript` splits into a path form and a reader form; nothing
about the rendering changes.

## Caching, and what it deliberately does not cover

Remote renders are cached for two seconds. This runs on the dashboard's refresh
path, and a long conversation is not a file to pull across a tunnel several
times a second.

The cache costs nothing visible: the live screen under the divider comes from
the terminal snapshot, which is cheap and never cached, so output in flight
still arrives every frame — only the settled part of the conversation waits.
Local transcripts are not cached at all; reading a file here is cheap enough
that a cache would only add staleness to a conversation being watched.

A host that goes away mid-conversation costs the reading view and not the pane:
an unreadable transcript falls back to the terminal snapshot, the way an agent
that never reported one always has.

## Testing

`go test ./...` green, including under `-race`. New coverage: a remote
transcript is read from its own machine; it is fetched once across five
refreshes; a local one is re-read every time (asserted by appending to the file
between calls); an unreadable one falls back to the screen; the fleet routes
reads to the daemon holding the agent.

**End to end**: a transcript written only on the far side, reported through the
provider hook path exactly as a real one would be, rendered in the Spanreed
transcript view of an agent running on that machine.

## What is left in #127

Per-host history and resume, the remote directory picker (the plumbing is in
place — `OverlayRequest.Host`), and a `remote add` command.
