### PR TITLE
An HTTP API: the same service, a second client

### DIFF
--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -46,9 +46,9 @@ SDK can similarly replace its CLI hook bridge. The runtime exposes
 ### Application service
 
 The application service validates requests, resolves a provider and workspace,
-and delegates terminal operations to the runtime. The TUI and CLI use the same
-service. A persistent workspace catalog supplies workspaces that
-do not currently contain an agent.
+and delegates terminal operations to the runtime. The TUI, the CLI, and the
+HTTP API all use the same service. A persistent workspace catalog supplies
+workspaces that do not currently contain an agent.
 
 Workspace resolvers return a stable group ID, a group root, an execution root,
 and optional component metadata. External executable resolvers run before the
@@ -59,6 +59,33 @@ Enumeration is routed back to the resolver that claimed the workspace and is
 bounded, cached, and best-effort, so a failed external integration cannot block
 dashboard refresh. This keeps environment-specific workspace semantics outside
 the public runtime.
+
+### HTTP API
+
+`stormlight serve` exposes the application service to clients that are not a
+terminal — a browser front end first among them. It is a peer of the TUI, not
+a layer above or below it: both drive the same service, so a rule about what a
+dispatch means or when an agent needs attention is written once.
+
+Two planes share the listener and never mix. The control plane is JSON over
+HTTP — roster, workspaces, dispatch, history — where latency is irrelevant.
+The data plane is one WebSocket per attached terminal carrying raw bytes in
+both directions: the daemon's exact snapshot arrives first as state, then live
+output, and keystrokes travel back unwrapped. Terminal input is never queued
+behind a control request and never encoded as JSON, because everything about
+how typing feels lives on that path. Sizes and resync notices ride the same
+socket as text messages, which are rare and never in the typing path.
+
+A second client attaching changes nothing for the first: the daemon owns the
+terminal, so the dashboard and a browser can hold the same agent at once, each
+seeded with its own exact snapshot.
+
+The server binds loopback only and requires a per-run token on every request
+and upgrade — these routes dispatch agents and stream terminals in every
+workspace the catalog knows. Reaching them from another machine is a tunnel
+the operator opens deliberately, never a default. WebSocket upgrades also
+check `Origin`, so a page the user merely visited cannot reach the API just
+because it is on localhost.
 
 ### windrunner runtime
 

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -76,9 +76,13 @@ behind a control request and never encoded as JSON, because everything about
 how typing feels lives on that path. Sizes and resync notices ride the same
 socket as text messages, which are rare and never in the typing path.
 
-A second client attaching changes nothing for the first: the daemon owns the
-terminal, so the dashboard and a browser can hold the same agent at once, each
-seeded with its own exact snapshot.
+The dashboard and a browser can hold the same agent at once, each seeded with
+its own exact snapshot, because the daemon owns the terminal rather than any
+client. What they cannot have is their own geometry: an agent has one terminal,
+so the newest viewer's size becomes everyone's, and the others are told over
+their own streams and repaint. Sharing the size is what keeps the replicas
+identical — the alternative is each client rendering a different reflow of the
+same program's output.
 
 The server binds loopback only and requires a per-run token on every request
 and upgrade — these routes dispatch agents and stream terminals in every

--- a/go.mod
+++ b/go.mod
@@ -27,6 +27,7 @@ require (
 	github.com/charmbracelet/x/windows v0.2.2 // indirect
 	github.com/clipperhouse/displaywidth v0.11.0 // indirect
 	github.com/clipperhouse/uax29/v2 v2.7.0 // indirect
+	github.com/coder/websocket v1.8.15 // indirect
 	github.com/creack/pty v1.1.24 // indirect
 	github.com/dlclark/regexp2 v1.11.5 // indirect
 	github.com/gorilla/css v1.0.1 // indirect

--- a/go.mod
+++ b/go.mod
@@ -9,6 +9,7 @@ require (
 	charm.land/lipgloss/v2 v2.0.5
 	github.com/charmbracelet/x/ansi v0.11.8
 	github.com/charmbracelet/x/vt v0.0.0-20260811151704-00c6608f106b
+	github.com/coder/websocket v1.8.15
 	github.com/pelletier/go-toml/v2 v2.4.3
 	github.com/spf13/cobra v1.10.2
 	github.com/trentkm/windrunner v0.0.0-20260818040409-06cca0f222eb
@@ -27,7 +28,6 @@ require (
 	github.com/charmbracelet/x/windows v0.2.2 // indirect
 	github.com/clipperhouse/displaywidth v0.11.0 // indirect
 	github.com/clipperhouse/uax29/v2 v2.7.0 // indirect
-	github.com/coder/websocket v1.8.15 // indirect
 	github.com/creack/pty v1.1.24 // indirect
 	github.com/dlclark/regexp2 v1.11.5 // indirect
 	github.com/gorilla/css v1.0.1 // indirect

--- a/go.sum
+++ b/go.sum
@@ -44,6 +44,8 @@ github.com/clipperhouse/displaywidth v0.11.0 h1:lBc6kY44VFw+TDx4I8opi/EtL9m20WSE
 github.com/clipperhouse/displaywidth v0.11.0/go.mod h1:bkrFNkf81G8HyVqmKGxsPufD3JhNl3dSqnGhOoSD/o0=
 github.com/clipperhouse/uax29/v2 v2.7.0 h1:+gs4oBZ2gPfVrKPthwbMzWZDaAFPGYK72F0NJv2v7Vk=
 github.com/clipperhouse/uax29/v2 v2.7.0/go.mod h1:EFJ2TJMRUaplDxHKj1qAEhCtQPW2tJSwu5BF98AuoVM=
+github.com/coder/websocket v1.8.15 h1:6B2JPeOGlpff2Uz6vOEH1Vzpi0iUz20A+lPVhPHtNUA=
+github.com/coder/websocket v1.8.15/go.mod h1:NX3SzP+inril6yawo5CQXx8+fk145lPDC6pumgx0mVg=
 github.com/cpuguy83/go-md2man/v2 v2.0.6/go.mod h1:oOW0eioCTA6cOiMLiUPZOpcVxMig6NIQQ7OS05n1F4g=
 github.com/creack/pty v1.1.24 h1:bJrF4RRfyJnbTJqzRLHzcGaZK1NeM5kTC9jGgovnR1s=
 github.com/creack/pty v1.1.24/go.mod h1:08sCNb52WyoAwi2QDyzUCTgcvVFhUzewun7wtTfvcwE=

--- a/internal/api/agents.go
+++ b/internal/api/agents.go
@@ -17,6 +17,28 @@ func call(r *http.Request) (context.Context, context.CancelFunc) {
 	return context.WithTimeout(r.Context(), callTimeout)
 }
 
+// agentView is an agent as this API reports it: the domain record plus
+// the host it answered from.
+//
+// agent.Agent deliberately does not serialize Host — the field is the
+// answering daemon's fact, and writing it into the agent's own document
+// would be one dashboard's claim about the world. Over the wire it is
+// exactly what a client needs, though: on a fleet, "which machine is this
+// on" is not decoration. The outer field shadows the embedded one, which
+// is why this reads as a plain agent with a host.
+type agentView struct {
+	agent.Agent
+	Host string `json:"host,omitempty"`
+}
+
+func viewOf(agents []agent.Agent) []agentView {
+	views := make([]agentView, 0, len(agents))
+	for _, managedAgent := range agents {
+		views = append(views, agentView{Agent: managedAgent, Host: managedAgent.Host})
+	}
+	return views
+}
+
 func (s *Server) listAgents(w http.ResponseWriter, r *http.Request) {
 	ctx, cancel := call(r)
 	defer cancel()
@@ -25,7 +47,7 @@ func (s *Server) listAgents(w http.ResponseWriter, r *http.Request) {
 		writeError(w, http.StatusBadGateway, err.Error())
 		return
 	}
-	writeJSON(w, http.StatusOK, orEmpty(agents))
+	writeJSON(w, http.StatusOK, viewOf(agents))
 }
 
 type dispatchBody struct {
@@ -39,7 +61,17 @@ type dispatchBody struct {
 
 func (s *Server) dispatchAgent(w http.ResponseWriter, r *http.Request) {
 	var body dispatchBody
-	if err := decode(r, &body); err != nil {
+	if err := decode(w, r, &body); err != nil {
+		writeError(w, http.StatusBadRequest, err.Error())
+		return
+	}
+	// The same parser every other entry point uses. Casting the string
+	// straight to a PermissionMode would accept "Auto" and then quietly
+	// launch the agent in the provider's default mode instead of the one
+	// asked for — a misspelled value silently ignored, which is exactly
+	// what DisallowUnknownFields exists to prevent for keys.
+	mode, err := agent.ParseMode(body.Mode)
+	if err != nil {
 		writeError(w, http.StatusBadRequest, err.Error())
 		return
 	}
@@ -53,13 +85,13 @@ func (s *Server) dispatchAgent(w http.ResponseWriter, r *http.Request) {
 		Task:     body.Task,
 		Cwd:      body.Cwd,
 		Host:     body.Host,
-		Mode:     agent.PermissionMode(body.Mode),
+		Mode:     mode,
 	})
 	if err != nil {
 		writeError(w, http.StatusBadRequest, err.Error())
 		return
 	}
-	writeJSON(w, http.StatusCreated, dispatched)
+	writeJSON(w, http.StatusCreated, agentView{Agent: dispatched, Host: dispatched.Host})
 }
 
 type renameBody struct {
@@ -68,7 +100,7 @@ type renameBody struct {
 
 func (s *Server) renameAgent(w http.ResponseWriter, r *http.Request) {
 	var body renameBody
-	if err := decode(r, &body); err != nil {
+	if err := decode(w, r, &body); err != nil {
 		writeError(w, http.StatusBadRequest, err.Error())
 		return
 	}
@@ -99,7 +131,7 @@ type messageBody struct {
 
 func (s *Server) sendMessage(w http.ResponseWriter, r *http.Request) {
 	var body messageBody
-	if err := decode(r, &body); err != nil {
+	if err := decode(w, r, &body); err != nil {
 		writeError(w, http.StatusBadRequest, err.Error())
 		return
 	}
@@ -128,13 +160,18 @@ type markBody struct {
 
 func (s *Server) markAgent(w http.ResponseWriter, r *http.Request) {
 	var body markBody
-	if err := decode(r, &body); err != nil {
+	if err := decode(w, r, &body); err != nil {
+		writeError(w, http.StatusBadRequest, err.Error())
+		return
+	}
+	mark, err := agent.ParseMark(body.Mark)
+	if err != nil {
 		writeError(w, http.StatusBadRequest, err.Error())
 		return
 	}
 	ctx, cancel := call(r)
 	defer cancel()
-	if err := s.service.SetMark(ctx, r.PathValue("id"), agent.Mark(body.Mark)); err != nil {
+	if err := s.service.SetMark(ctx, r.PathValue("id"), mark); err != nil {
 		writeError(w, http.StatusBadRequest, err.Error())
 		return
 	}

--- a/internal/api/agents.go
+++ b/internal/api/agents.go
@@ -1,0 +1,156 @@
+package api
+
+import (
+	"context"
+	"net/http"
+	"time"
+
+	"github.com/trentkm/stormlight/internal/agent"
+	"github.com/trentkm/stormlight/internal/app"
+)
+
+// call gives a control-plane handler its bounded context. Every handler
+// below is the same three steps — decode, one Service call, encode — and
+// anything that wants to be cleverer than that belongs in internal/app,
+// where the dashboard gets it too.
+func call(r *http.Request) (context.Context, context.CancelFunc) {
+	return context.WithTimeout(r.Context(), callTimeout)
+}
+
+func (s *Server) listAgents(w http.ResponseWriter, r *http.Request) {
+	ctx, cancel := call(r)
+	defer cancel()
+	agents, err := s.service.ListAgents(ctx)
+	if err != nil {
+		writeError(w, http.StatusBadGateway, err.Error())
+		return
+	}
+	writeJSON(w, http.StatusOK, orEmpty(agents))
+}
+
+type dispatchBody struct {
+	Provider string `json:"provider"`
+	Name     string `json:"name,omitempty"`
+	Task     string `json:"task"`
+	Cwd      string `json:"cwd"`
+	Host     string `json:"host,omitempty"`
+	Mode     string `json:"mode,omitempty"`
+}
+
+func (s *Server) dispatchAgent(w http.ResponseWriter, r *http.Request) {
+	var body dispatchBody
+	if err := decode(r, &body); err != nil {
+		writeError(w, http.StatusBadRequest, err.Error())
+		return
+	}
+	// Dispatch spawns a process and waits for the provider to answer for
+	// it; the control plane's ordinary bound is too tight for that.
+	ctx, cancel := context.WithTimeout(r.Context(), 60*time.Second)
+	defer cancel()
+	dispatched, err := s.service.Dispatch(ctx, app.DispatchRequest{
+		Provider: agent.Provider(body.Provider),
+		Name:     body.Name,
+		Task:     body.Task,
+		Cwd:      body.Cwd,
+		Host:     body.Host,
+		Mode:     agent.PermissionMode(body.Mode),
+	})
+	if err != nil {
+		writeError(w, http.StatusBadRequest, err.Error())
+		return
+	}
+	writeJSON(w, http.StatusCreated, dispatched)
+}
+
+type renameBody struct {
+	Name string `json:"name"`
+}
+
+func (s *Server) renameAgent(w http.ResponseWriter, r *http.Request) {
+	var body renameBody
+	if err := decode(r, &body); err != nil {
+		writeError(w, http.StatusBadRequest, err.Error())
+		return
+	}
+	ctx, cancel := call(r)
+	defer cancel()
+	if err := s.service.Rename(ctx, r.PathValue("id"), body.Name); err != nil {
+		writeError(w, http.StatusBadRequest, err.Error())
+		return
+	}
+	writeJSON(w, http.StatusNoContent, nil)
+}
+
+func (s *Server) deleteAgent(w http.ResponseWriter, r *http.Request) {
+	ctx, cancel := call(r)
+	defer cancel()
+	// Delete hands the conversation to the history log on its way out —
+	// the Service's own doing, so this route inherits it.
+	if err := s.service.Delete(ctx, r.PathValue("id")); err != nil {
+		writeError(w, http.StatusBadRequest, err.Error())
+		return
+	}
+	writeJSON(w, http.StatusNoContent, nil)
+}
+
+type messageBody struct {
+	Message string `json:"message"`
+}
+
+func (s *Server) sendMessage(w http.ResponseWriter, r *http.Request) {
+	var body messageBody
+	if err := decode(r, &body); err != nil {
+		writeError(w, http.StatusBadRequest, err.Error())
+		return
+	}
+	ctx, cancel := call(r)
+	defer cancel()
+	if err := s.service.Send(ctx, r.PathValue("id"), body.Message); err != nil {
+		writeError(w, http.StatusBadRequest, err.Error())
+		return
+	}
+	writeJSON(w, http.StatusNoContent, nil)
+}
+
+func (s *Server) interruptAgent(w http.ResponseWriter, r *http.Request) {
+	ctx, cancel := call(r)
+	defer cancel()
+	if err := s.service.Interrupt(ctx, r.PathValue("id")); err != nil {
+		writeError(w, http.StatusBadRequest, err.Error())
+		return
+	}
+	writeJSON(w, http.StatusNoContent, nil)
+}
+
+type markBody struct {
+	Mark string `json:"mark"`
+}
+
+func (s *Server) markAgent(w http.ResponseWriter, r *http.Request) {
+	var body markBody
+	if err := decode(r, &body); err != nil {
+		writeError(w, http.StatusBadRequest, err.Error())
+		return
+	}
+	ctx, cancel := call(r)
+	defer cancel()
+	if err := s.service.SetMark(ctx, r.PathValue("id"), agent.Mark(body.Mark)); err != nil {
+		writeError(w, http.StatusBadRequest, err.Error())
+		return
+	}
+	writeJSON(w, http.StatusNoContent, nil)
+}
+
+func (s *Server) clearAttention(w http.ResponseWriter, r *http.Request) {
+	ctx, cancel := call(r)
+	defer cancel()
+	if err := s.service.ClearAttention(ctx, r.PathValue("id")); err != nil {
+		writeError(w, http.StatusBadRequest, err.Error())
+		return
+	}
+	writeJSON(w, http.StatusNoContent, nil)
+}
+
+func (s *Server) listProviders(w http.ResponseWriter, r *http.Request) {
+	writeJSON(w, http.StatusOK, orEmpty(s.service.Providers()))
+}

--- a/internal/api/events.go
+++ b/internal/api/events.go
@@ -1,0 +1,181 @@
+package api
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"sync"
+	"time"
+
+	"github.com/coder/websocket"
+
+	"github.com/trentkm/stormlight/internal/agent"
+	"github.com/trentkm/stormlight/internal/app"
+)
+
+// pollInterval is how often the hub asks the runtime for the roster. It
+// matches the dashboard's own refresh: the daemon is the source of truth
+// for liveness and answers cheaply, and a second client polling at the
+// same cadence adds one caller, not one per viewer.
+const pollInterval = 700 * time.Millisecond
+
+// hub turns the roster into an event stream. One poller serves every
+// connected client, and only a roster that actually changed is broadcast,
+// so an idle fleet is an idle socket.
+//
+// Polling is the v1 shape, not the destination: the daemon already
+// publishes its own lifecycle and idle/busy feed, and moving to it later
+// changes nothing a client can see — which is why the client contract is
+// "here is the roster", never "here is what happened".
+type hub struct {
+	service *app.Service
+
+	mu      sync.Mutex
+	clients map[chan []byte]struct{}
+	// latest is the last roster broadcast, kept so a client that connects
+	// between polls is answered immediately instead of waiting.
+	latest []byte
+}
+
+func newHub(service *app.Service) *hub {
+	return &hub{service: service, clients: make(map[chan []byte]struct{})}
+}
+
+// run starts polling and returns the stop function.
+func (h *hub) run() func() {
+	ctx, cancel := context.WithCancel(context.Background())
+	go h.poll(ctx)
+	return cancel
+}
+
+func (h *hub) poll(ctx context.Context) {
+	ticker := time.NewTicker(pollInterval)
+	defer ticker.Stop()
+	var previous string
+	for {
+		select {
+		case <-ctx.Done():
+			return
+		case <-ticker.C:
+		}
+		if !h.hasClients() {
+			// Nobody is listening; do not spend a daemon round trip.
+			continue
+		}
+		listCtx, cancel := context.WithTimeout(ctx, callTimeout)
+		agents, err := h.service.ListAgents(listCtx)
+		cancel()
+		if err != nil {
+			continue
+		}
+		payload, err := json.Marshal(rosterEvent{Type: "agents", Agents: agents})
+		if err != nil {
+			continue
+		}
+		if string(payload) == previous {
+			continue
+		}
+		previous = string(payload)
+		h.broadcast(payload)
+	}
+}
+
+type rosterEvent struct {
+	Type   string        `json:"type"`
+	Agents []agent.Agent `json:"agents"`
+}
+
+func (h *hub) hasClients() bool {
+	h.mu.Lock()
+	defer h.mu.Unlock()
+	return len(h.clients) > 0
+}
+
+func (h *hub) broadcast(payload []byte) {
+	h.mu.Lock()
+	defer h.mu.Unlock()
+	h.latest = payload
+	for client := range h.clients {
+		select {
+		case client <- payload:
+		default:
+			// A client that cannot keep up with the roster is not worth
+			// buffering for: the next broadcast carries the whole state
+			// anyway, so dropping this one loses nothing.
+		}
+	}
+}
+
+func (h *hub) subscribe() (<-chan []byte, func()) {
+	client := make(chan []byte, 1)
+	h.mu.Lock()
+	h.clients[client] = struct{}{}
+	latest := h.latest
+	h.mu.Unlock()
+	if latest != nil {
+		client <- latest
+	}
+	return client, func() {
+		h.mu.Lock()
+		delete(h.clients, client)
+		h.mu.Unlock()
+	}
+}
+
+// eventStream pushes the roster to one client for as long as it listens.
+func (s *Server) eventStream(w http.ResponseWriter, r *http.Request) {
+	conn, err := websocket.Accept(w, r, &websocket.AcceptOptions{
+		InsecureSkipVerify: true, // Origin is checked in the middleware.
+	})
+	if err != nil {
+		return
+	}
+	ctx, cancel := context.WithCancel(context.WithoutCancel(r.Context()))
+	defer cancel()
+	defer conn.CloseNow()
+
+	updates, unsubscribe := s.events.subscribe()
+	defer unsubscribe()
+
+	// The client speaks only by hanging up; notice when it does.
+	go func() {
+		defer cancel()
+		for {
+			if _, _, err := conn.Read(ctx); err != nil {
+				return
+			}
+		}
+	}()
+
+	// An immediate roster, so a fresh client paints without waiting for
+	// something to change.
+	if err := s.sendRoster(ctx, conn); err != nil {
+		return
+	}
+	for {
+		select {
+		case <-ctx.Done():
+			return
+		case payload := <-updates:
+			if err := conn.Write(ctx, websocket.MessageText, payload); err != nil {
+				return
+			}
+		}
+	}
+}
+
+func (s *Server) sendRoster(ctx context.Context, conn *websocket.Conn) error {
+	listCtx, cancel := context.WithTimeout(ctx, callTimeout)
+	defer cancel()
+	agents, err := s.service.ListAgents(listCtx)
+	if err != nil {
+		// A roster that cannot be read right now is not a reason to
+		// refuse the stream; the next poll will carry one.
+		return nil
+	}
+	payload, err := json.Marshal(rosterEvent{Type: "agents", Agents: agents})
+	if err != nil {
+		return err
+	}
+	return conn.Write(ctx, websocket.MessageText, payload)
+}

--- a/internal/api/events.go
+++ b/internal/api/events.go
@@ -31,10 +31,20 @@ type hub struct {
 
 	mu      sync.Mutex
 	clients map[chan []byte]struct{}
+	// latest is the last roster broadcast, handed to a client the moment
+	// it subscribes so a fresh viewer paints without waiting for a tick.
+	latest []byte
+
+	// wake asks the poller for a roster now rather than at the next tick.
+	wake chan struct{}
 }
 
 func newHub(service *app.Service) *hub {
-	return &hub{service: service, clients: make(map[chan []byte]struct{})}
+	return &hub{
+		service: service,
+		clients: make(map[chan []byte]struct{}),
+		wake:    make(chan struct{}, 1),
+	}
 }
 
 // run starts polling and returns the stop function.
@@ -52,6 +62,10 @@ func (h *hub) poll(ctx context.Context) {
 		select {
 		case <-ctx.Done():
 			return
+		case <-h.wake:
+			// A client just arrived and has nothing to paint; answer it
+			// now rather than at the next tick.
+			previous = ""
 		case <-ticker.C:
 		}
 		if !h.hasClients() {
@@ -87,30 +101,52 @@ func (h *hub) hasClients() bool {
 	return len(h.clients) > 0
 }
 
+// broadcast replaces what each client is holding rather than skipping the
+// ones that are busy. Every message is the whole roster, so the newest is
+// the only one worth having — but dropping it is not the same thing:
+// polling suppresses an unchanged roster, so a message skipped here is
+// one nobody resends, and a viewer whose socket stalled for a single tick
+// would show a stale agent until the next real change. Which, for an
+// agent that just went quiet, may be never.
 func (h *hub) broadcast(payload []byte) {
 	h.mu.Lock()
 	defer h.mu.Unlock()
+	h.latest = payload
 	for client := range h.clients {
-		select {
-		case client <- payload:
-		default:
-			// A client that cannot keep up with the roster is not worth
-			// buffering for: the next broadcast carries the whole state
-			// anyway, so dropping this one loses nothing.
-		}
+		send(client, payload)
 	}
+}
+
+// send hands a client the latest roster, discarding whatever older one it
+// had not read. The caller holds the hub lock, which is what makes this
+// safe to do without blocking: every send happens under that lock, so
+// nothing can refill the slot between the discard and the send.
+func send(client chan []byte, payload []byte) {
+	select {
+	case <-client:
+	default:
+	}
+	client <- payload
 }
 
 func (h *hub) subscribe() (<-chan []byte, func()) {
 	client := make(chan []byte, 1)
 	h.mu.Lock()
 	h.clients[client] = struct{}{}
+	if h.latest != nil {
+		// Under the lock, so it cannot block; see send. Doing this after
+		// unlocking is what would deadlock — a broadcast could fill the
+		// one slot first, and the reader that would drain it is what this
+		// function has not returned yet.
+		send(client, h.latest)
+	}
 	h.mu.Unlock()
-	// Nothing is sent here. A broadcast landing between the registration
-	// above and the reader starting would fill the one slot, and a send
-	// from here would then block forever — with no reader, because the
-	// reader is what this function returns to. The stream sends its own
-	// opening roster instead, which is fresher than a cached one anyway.
+	// Ask for a fresh roster either way: the poll skips itself while
+	// nobody is listening, so what was cached may be old.
+	select {
+	case h.wake <- struct{}{}:
+	default:
+	}
 	return client, func() {
 		h.mu.Lock()
 		delete(h.clients, client)
@@ -130,8 +166,9 @@ func (s *Server) eventStream(w http.ResponseWriter, r *http.Request) {
 	defer cancel()
 	defer conn.CloseNow()
 
-	// Subscribe before sending the opening roster, so a change landing
-	// between the two is queued rather than missed.
+	// The hub answers a new subscriber itself — with what it has, and by
+	// asking the poller for something fresher. Fetching an opening roster
+	// here instead is how the stale one ended up arriving after it.
 	updates, unsubscribe := s.events.subscribe()
 	defer unsubscribe()
 
@@ -146,11 +183,6 @@ func (s *Server) eventStream(w http.ResponseWriter, r *http.Request) {
 	}()
 	go keepalive(ctx, cancel, conn)
 
-	// An immediate roster, so a fresh client paints without waiting for
-	// something to change.
-	if err := s.sendRoster(ctx, conn); err != nil {
-		return
-	}
 	for {
 		select {
 		case <-ctx.Done():
@@ -161,20 +193,4 @@ func (s *Server) eventStream(w http.ResponseWriter, r *http.Request) {
 			}
 		}
 	}
-}
-
-func (s *Server) sendRoster(ctx context.Context, conn *websocket.Conn) error {
-	listCtx, cancel := context.WithTimeout(ctx, callTimeout)
-	defer cancel()
-	agents, err := s.service.ListAgents(listCtx)
-	if err != nil {
-		// A roster that cannot be read right now is not a reason to
-		// refuse the stream; the next poll will carry one.
-		return nil
-	}
-	payload, err := json.Marshal(rosterEvent{Type: "agents", Agents: viewOf(agents)})
-	if err != nil {
-		return err
-	}
-	return conn.Write(ctx, websocket.MessageText, payload)
 }

--- a/internal/api/events.go
+++ b/internal/api/events.go
@@ -9,7 +9,6 @@ import (
 
 	"github.com/coder/websocket"
 
-	"github.com/trentkm/stormlight/internal/agent"
 	"github.com/trentkm/stormlight/internal/app"
 )
 
@@ -32,9 +31,6 @@ type hub struct {
 
 	mu      sync.Mutex
 	clients map[chan []byte]struct{}
-	// latest is the last roster broadcast, kept so a client that connects
-	// between polls is answered immediately instead of waiting.
-	latest []byte
 }
 
 func newHub(service *app.Service) *hub {
@@ -68,7 +64,7 @@ func (h *hub) poll(ctx context.Context) {
 		if err != nil {
 			continue
 		}
-		payload, err := json.Marshal(rosterEvent{Type: "agents", Agents: agents})
+		payload, err := json.Marshal(rosterEvent{Type: "agents", Agents: viewOf(agents)})
 		if err != nil {
 			continue
 		}
@@ -81,8 +77,8 @@ func (h *hub) poll(ctx context.Context) {
 }
 
 type rosterEvent struct {
-	Type   string        `json:"type"`
-	Agents []agent.Agent `json:"agents"`
+	Type   string      `json:"type"`
+	Agents []agentView `json:"agents"`
 }
 
 func (h *hub) hasClients() bool {
@@ -94,7 +90,6 @@ func (h *hub) hasClients() bool {
 func (h *hub) broadcast(payload []byte) {
 	h.mu.Lock()
 	defer h.mu.Unlock()
-	h.latest = payload
 	for client := range h.clients {
 		select {
 		case client <- payload:
@@ -110,11 +105,12 @@ func (h *hub) subscribe() (<-chan []byte, func()) {
 	client := make(chan []byte, 1)
 	h.mu.Lock()
 	h.clients[client] = struct{}{}
-	latest := h.latest
 	h.mu.Unlock()
-	if latest != nil {
-		client <- latest
-	}
+	// Nothing is sent here. A broadcast landing between the registration
+	// above and the reader starting would fill the one slot, and a send
+	// from here would then block forever — with no reader, because the
+	// reader is what this function returns to. The stream sends its own
+	// opening roster instead, which is fresher than a cached one anyway.
 	return client, func() {
 		h.mu.Lock()
 		delete(h.clients, client)
@@ -134,6 +130,8 @@ func (s *Server) eventStream(w http.ResponseWriter, r *http.Request) {
 	defer cancel()
 	defer conn.CloseNow()
 
+	// Subscribe before sending the opening roster, so a change landing
+	// between the two is queued rather than missed.
 	updates, unsubscribe := s.events.subscribe()
 	defer unsubscribe()
 
@@ -146,6 +144,7 @@ func (s *Server) eventStream(w http.ResponseWriter, r *http.Request) {
 			}
 		}
 	}()
+	go keepalive(ctx, cancel, conn)
 
 	// An immediate roster, so a fresh client paints without waiting for
 	// something to change.
@@ -173,7 +172,7 @@ func (s *Server) sendRoster(ctx context.Context, conn *websocket.Conn) error {
 		// refuse the stream; the next poll will carry one.
 		return nil
 	}
-	payload, err := json.Marshal(rosterEvent{Type: "agents", Agents: agents})
+	payload, err := json.Marshal(rosterEvent{Type: "agents", Agents: viewOf(agents)})
 	if err != nil {
 		return err
 	}

--- a/internal/api/history.go
+++ b/internal/api/history.go
@@ -1,0 +1,51 @@
+package api
+
+import (
+	"context"
+	"net/http"
+	"time"
+
+	"github.com/trentkm/stormlight/internal/history"
+)
+
+func (s *Server) listHistory(w http.ResponseWriter, r *http.Request) {
+	ctx, cancel := call(r)
+	defer cancel()
+	records, err := s.service.SessionHistory(ctx)
+	if err != nil {
+		writeError(w, http.StatusBadGateway, err.Error())
+		return
+	}
+	writeJSON(w, http.StatusOK, orEmpty(records))
+}
+
+func (s *Server) resumeHistory(w http.ResponseWriter, r *http.Request) {
+	sessionID := r.PathValue("id")
+	listCtx, cancel := call(r)
+	defer cancel()
+	records, err := s.service.SessionHistory(listCtx)
+	if err != nil {
+		writeError(w, http.StatusBadGateway, err.Error())
+		return
+	}
+	var record history.Record
+	for _, candidate := range records {
+		if candidate.SessionID == sessionID {
+			record = candidate
+			break
+		}
+	}
+	if record.SessionID == "" {
+		writeError(w, http.StatusNotFound, "no such conversation: "+sessionID)
+		return
+	}
+	// Resuming starts a provider process, the same wait dispatching has.
+	resumeCtx, cancelResume := context.WithTimeout(r.Context(), 60*time.Second)
+	defer cancelResume()
+	resumed, err := s.service.Resume(resumeCtx, record)
+	if err != nil {
+		writeError(w, http.StatusBadRequest, err.Error())
+		return
+	}
+	writeJSON(w, http.StatusCreated, resumed)
+}

--- a/internal/api/history.go
+++ b/internal/api/history.go
@@ -47,5 +47,5 @@ func (s *Server) resumeHistory(w http.ResponseWriter, r *http.Request) {
 		writeError(w, http.StatusBadRequest, err.Error())
 		return
 	}
-	writeJSON(w, http.StatusCreated, resumed)
+	writeJSON(w, http.StatusCreated, agentView{Agent: resumed, Host: resumed.Host})
 }

--- a/internal/api/server.go
+++ b/internal/api/server.go
@@ -17,7 +17,9 @@ import (
 	"encoding/hex"
 	"encoding/json"
 	"fmt"
+	"net"
 	"net/http"
+	"net/url"
 	"strings"
 	"time"
 
@@ -114,15 +116,25 @@ func (s *Server) routes() {
 // terminal socket is the whole point of this server.
 func (s *Server) authenticated(next http.Handler) http.Handler {
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		// A Host this server does not answer to means the name resolved
+		// here from somewhere else — the rebinding trick that turns a
+		// page the user is visiting into a client of their own machine.
+		if !loopbackHost(r.Host) {
+			writeError(w, http.StatusForbidden, "unrecognized host")
+			return
+		}
 		if !s.tokenMatches(r) {
 			// No detail: a wrong token learns nothing about the right one.
 			writeError(w, http.StatusUnauthorized, "unauthorized")
 			return
 		}
-		if isUpgrade(r) && !sameOrigin(r) {
-			// A page the user is merely visiting must not be able to
-			// reach this server just because it is on loopback.
-			writeError(w, http.StatusForbidden, "cross-origin upgrade refused")
+		// Every request that acts, not only the upgrades. A cross-origin
+		// form post or a no-cors fetch is a *simple* request — it reaches
+		// the handler with no preflight, and the side effect lands even
+		// though the attacker cannot read the reply. Dispatching an agent
+		// is exactly such a side effect.
+		if !allowedOrigin(r) {
+			writeError(w, http.StatusForbidden, "cross-origin request refused")
 			return
 		}
 		next.ServeHTTP(w, r)
@@ -131,38 +143,75 @@ func (s *Server) authenticated(next http.Handler) http.Handler {
 
 func (s *Server) tokenMatches(r *http.Request) bool {
 	presented := r.URL.Query().Get("token")
-	if header := r.Header.Get("Authorization"); header != "" {
-		presented = strings.TrimSpace(strings.TrimPrefix(header, "Bearer"))
+	// A bearer header wins only when it actually carries one. Overwriting
+	// a good query token with an unrelated Authorization header — a proxy
+	// injecting Basic, a browser replaying cached credentials for
+	// 127.0.0.1 — would reject a request that was perfectly authorized.
+	if bearer, ok := bearerToken(r.Header.Get("Authorization")); ok {
+		presented = bearer
 	}
 	return subtle.ConstantTimeCompare([]byte(presented), []byte(s.token)) == 1
+}
+
+// bearerToken pulls the credential out of an Authorization header. The
+// scheme is case-insensitive per RFC 7235, and the space after it is not
+// optional.
+func bearerToken(header string) (string, bool) {
+	scheme, credential, found := strings.Cut(header, " ")
+	if !found || !strings.EqualFold(scheme, "Bearer") {
+		return "", false
+	}
+	credential = strings.TrimSpace(credential)
+	return credential, credential != ""
 }
 
 func isUpgrade(r *http.Request) bool {
 	return strings.EqualFold(r.Header.Get("Upgrade"), "websocket")
 }
 
-// sameOrigin accepts a request with no Origin at all — that is a program,
-// not a page, and programs are the other half of this API's audience —
-// and otherwise requires the origin's host to be the one being served.
-func sameOrigin(r *http.Request) bool {
+// loopbackHost reports whether a Host header names this machine. The
+// server binds loopback, so anything else arrived by a name that resolved
+// to it from outside — and matching an Origin against such a Host would
+// be checking the attacker's claim against itself.
+func loopbackHost(host string) bool {
+	name, _, err := net.SplitHostPort(host)
+	if err != nil {
+		name = host
+	}
+	name = strings.Trim(name, "[]")
+	if strings.EqualFold(name, "localhost") {
+		return true
+	}
+	address := net.ParseIP(name)
+	return address != nil && address.IsLoopback()
+}
+
+// allowedOrigin accepts a request with no Origin at all — that is a
+// program, not a page, and programs are the other half of this API's
+// audience — and otherwise requires an origin whose host is loopback and
+// matches the one being served.
+func allowedOrigin(r *http.Request) bool {
 	origin := r.Header.Get("Origin")
 	if origin == "" {
 		return true
 	}
-	trimmed := origin
-	for _, scheme := range []string{"http://", "https://"} {
-		trimmed = strings.TrimPrefix(trimmed, scheme)
+	parsed, err := url.Parse(origin)
+	if err != nil || parsed.Host == "" {
+		return false
 	}
-	return trimmed == r.Host
+	return loopbackHost(parsed.Host) && parsed.Host == r.Host
 }
 
 // writeJSON encodes a successful response.
 func writeJSON(w http.ResponseWriter, status int, payload any) {
-	w.Header().Set("Content-Type", "application/json")
-	w.WriteHeader(status)
 	if payload == nil {
+		// Nothing to describe; a content type would be a claim about a
+		// body that is not there.
+		w.WriteHeader(status)
 		return
 	}
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(status)
 	if err := json.NewEncoder(w).Encode(payload); err != nil {
 		// The status line is already out; all that is left is a record.
 		diagnostic.Logger().Warn("api response truncated", "error", err)
@@ -189,10 +238,15 @@ func writeError(w http.ResponseWriter, status int, message string) {
 	writeJSON(w, status, errorBody{Error: message})
 }
 
+// maxRequestBody bounds a control-plane request. The largest legitimate
+// one is a task description; anything approaching this is a mistake or an
+// attempt to make the server hold memory on request.
+const maxRequestBody = 1 << 20
+
 // decode reads a JSON request body, refusing unknown fields so a
 // misspelled key is an error rather than a silently ignored intention.
-func decode(r *http.Request, target any) error {
-	decoder := json.NewDecoder(r.Body)
+func decode(w http.ResponseWriter, r *http.Request, target any) error {
+	decoder := json.NewDecoder(http.MaxBytesReader(w, r.Body, maxRequestBody))
 	decoder.DisallowUnknownFields()
 	if err := decoder.Decode(target); err != nil {
 		return fmt.Errorf("malformed request body: %w", err)

--- a/internal/api/server.go
+++ b/internal/api/server.go
@@ -116,16 +116,17 @@ func (s *Server) routes() {
 // terminal socket is the whole point of this server.
 func (s *Server) authenticated(next http.Handler) http.Handler {
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if !s.tokenMatches(r) {
+			// First, and with no detail: a wrong token learns nothing
+			// about the right one, nor about what else would be accepted.
+			writeError(w, http.StatusUnauthorized, "unauthorized")
+			return
+		}
 		// A Host this server does not answer to means the name resolved
 		// here from somewhere else — the rebinding trick that turns a
 		// page the user is visiting into a client of their own machine.
 		if !loopbackHost(r.Host) {
 			writeError(w, http.StatusForbidden, "unrecognized host")
-			return
-		}
-		if !s.tokenMatches(r) {
-			// No detail: a wrong token learns nothing about the right one.
-			writeError(w, http.StatusUnauthorized, "unauthorized")
 			return
 		}
 		// Every request that acts, not only the upgrades. A cross-origin
@@ -163,10 +164,6 @@ func bearerToken(header string) (string, bool) {
 	}
 	credential = strings.TrimSpace(credential)
 	return credential, credential != ""
-}
-
-func isUpgrade(r *http.Request) bool {
-	return strings.EqualFold(r.Header.Get("Upgrade"), "websocket")
 }
 
 // loopbackHost reports whether a Host header names this machine. The
@@ -211,6 +208,7 @@ func writeJSON(w http.ResponseWriter, status int, payload any) {
 		return
 	}
 	w.Header().Set("Content-Type", "application/json")
+	w.Header().Set("X-Content-Type-Options", "nosniff")
 	w.WriteHeader(status)
 	if err := json.NewEncoder(w).Encode(payload); err != nil {
 		// The status line is already out; all that is left is a record.

--- a/internal/api/server.go
+++ b/internal/api/server.go
@@ -1,0 +1,201 @@
+// Package api serves Stormlight's domain over HTTP and WebSockets: a
+// second head on the same internal/app.Service the dashboard drives, so a
+// browser client and the TUI are peers over one set of rules rather than
+// two implementations of them.
+//
+// Two planes share the listener and never mix. The control plane is JSON
+// over HTTP — roster, workspaces, dispatch, history — where a millisecond
+// costs nothing. The data plane is one WebSocket per attached terminal,
+// carrying raw bytes in both directions: keystrokes are never wrapped in
+// JSON and never queued behind a request. That split is what keeps typing
+// in a browser terminal feel like typing in a terminal.
+package api
+
+import (
+	"crypto/rand"
+	"crypto/subtle"
+	"encoding/hex"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"strings"
+	"time"
+
+	"github.com/trentkm/stormlight/internal/app"
+	"github.com/trentkm/stormlight/internal/diagnostic"
+)
+
+// callTimeout bounds a control-plane call. The data plane sets no
+// deadline of its own: a terminal attachment is meant to outlive any
+// request.
+const callTimeout = 10 * time.Second
+
+// Server is the HTTP surface. It owns no state the dashboard does not
+// already own — every route is a decode, one Service call, and an encode.
+type Server struct {
+	service *app.Service
+	token   string
+	events  *hub
+	mux     *http.ServeMux
+}
+
+// NewToken mints a fresh access token. One per run: nothing persists it,
+// so a restart invalidates every URL that was handed out.
+func NewToken() (string, error) {
+	raw := make([]byte, 24)
+	if _, err := rand.Read(raw); err != nil {
+		return "", fmt.Errorf("generate token: %w", err)
+	}
+	return hex.EncodeToString(raw), nil
+}
+
+// New builds the server. The token is required, not optional: these
+// routes dispatch agents and stream terminals in every workspace the
+// catalog knows, which is shell access to all of them. There is
+// deliberately no unauthenticated mode to ship by accident.
+func New(service *app.Service, token string) (*Server, error) {
+	if service == nil {
+		return nil, fmt.Errorf("api: a service is required")
+	}
+	if token == "" {
+		return nil, fmt.Errorf("api: a token is required")
+	}
+	s := &Server{
+		service: service,
+		token:   token,
+		events:  newHub(service),
+		mux:     http.NewServeMux(),
+	}
+	s.routes()
+	return s, nil
+}
+
+// Handler is the server as an http.Handler, with authentication in front
+// of every route.
+func (s *Server) Handler() http.Handler {
+	return s.authenticated(s.mux)
+}
+
+// Run starts the background work the event stream needs and returns a
+// stop function. Serving without it yields a working control plane and an
+// event socket that never speaks.
+func (s *Server) Run() (stop func()) {
+	return s.events.run()
+}
+
+func (s *Server) routes() {
+	s.mux.HandleFunc("GET /api/agents", s.listAgents)
+	s.mux.HandleFunc("POST /api/agents", s.dispatchAgent)
+	s.mux.HandleFunc("PATCH /api/agents/{id}", s.renameAgent)
+	s.mux.HandleFunc("DELETE /api/agents/{id}", s.deleteAgent)
+	s.mux.HandleFunc("POST /api/agents/{id}/message", s.sendMessage)
+	s.mux.HandleFunc("POST /api/agents/{id}/interrupt", s.interruptAgent)
+	s.mux.HandleFunc("POST /api/agents/{id}/mark", s.markAgent)
+	s.mux.HandleFunc("POST /api/agents/{id}/clear-attention", s.clearAttention)
+	s.mux.HandleFunc("GET /api/agents/{id}/terminal", s.terminal)
+
+	s.mux.HandleFunc("GET /api/workspaces", s.listWorkspaces)
+	s.mux.HandleFunc("POST /api/workspaces", s.addWorkspace)
+	s.mux.HandleFunc("DELETE /api/workspaces", s.removeWorkspace)
+	s.mux.HandleFunc("PATCH /api/workspaces", s.renameWorkspace)
+
+	s.mux.HandleFunc("GET /api/providers", s.listProviders)
+	s.mux.HandleFunc("GET /api/history", s.listHistory)
+	s.mux.HandleFunc("POST /api/history/{id}/resume", s.resumeHistory)
+
+	s.mux.HandleFunc("GET /api/events", s.eventStream)
+}
+
+// authenticated gates every route on the run's token and, for WebSocket
+// upgrades, on the request's origin.
+//
+// The token may travel as a bearer header or as a query parameter,
+// because a browser cannot set headers on a WebSocket handshake and the
+// terminal socket is the whole point of this server.
+func (s *Server) authenticated(next http.Handler) http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if !s.tokenMatches(r) {
+			// No detail: a wrong token learns nothing about the right one.
+			writeError(w, http.StatusUnauthorized, "unauthorized")
+			return
+		}
+		if isUpgrade(r) && !sameOrigin(r) {
+			// A page the user is merely visiting must not be able to
+			// reach this server just because it is on loopback.
+			writeError(w, http.StatusForbidden, "cross-origin upgrade refused")
+			return
+		}
+		next.ServeHTTP(w, r)
+	})
+}
+
+func (s *Server) tokenMatches(r *http.Request) bool {
+	presented := r.URL.Query().Get("token")
+	if header := r.Header.Get("Authorization"); header != "" {
+		presented = strings.TrimSpace(strings.TrimPrefix(header, "Bearer"))
+	}
+	return subtle.ConstantTimeCompare([]byte(presented), []byte(s.token)) == 1
+}
+
+func isUpgrade(r *http.Request) bool {
+	return strings.EqualFold(r.Header.Get("Upgrade"), "websocket")
+}
+
+// sameOrigin accepts a request with no Origin at all — that is a program,
+// not a page, and programs are the other half of this API's audience —
+// and otherwise requires the origin's host to be the one being served.
+func sameOrigin(r *http.Request) bool {
+	origin := r.Header.Get("Origin")
+	if origin == "" {
+		return true
+	}
+	trimmed := origin
+	for _, scheme := range []string{"http://", "https://"} {
+		trimmed = strings.TrimPrefix(trimmed, scheme)
+	}
+	return trimmed == r.Host
+}
+
+// writeJSON encodes a successful response.
+func writeJSON(w http.ResponseWriter, status int, payload any) {
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(status)
+	if payload == nil {
+		return
+	}
+	if err := json.NewEncoder(w).Encode(payload); err != nil {
+		// The status line is already out; all that is left is a record.
+		diagnostic.Logger().Warn("api response truncated", "error", err)
+	}
+}
+
+// orEmpty makes a nil slice encode as [] rather than null. An empty
+// roster is a normal state — it is what a fresh install looks like — and
+// a client should not have to special-case it before iterating.
+func orEmpty[T any](values []T) []T {
+	if values == nil {
+		return []T{}
+	}
+	return values
+}
+
+// errorBody is the one shape every failure takes, so a client parses one
+// thing.
+type errorBody struct {
+	Error string `json:"error"`
+}
+
+func writeError(w http.ResponseWriter, status int, message string) {
+	writeJSON(w, status, errorBody{Error: message})
+}
+
+// decode reads a JSON request body, refusing unknown fields so a
+// misspelled key is an error rather than a silently ignored intention.
+func decode(r *http.Request, target any) error {
+	decoder := json.NewDecoder(r.Body)
+	decoder.DisallowUnknownFields()
+	if err := decoder.Decode(target); err != nil {
+		return fmt.Errorf("malformed request body: %w", err)
+	}
+	return nil
+}

--- a/internal/api/server_test.go
+++ b/internal/api/server_test.go
@@ -1,0 +1,444 @@
+package api
+
+import (
+	"context"
+	"encoding/json"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/coder/websocket"
+
+	"github.com/trentkm/stormlight/internal/agent"
+	"github.com/trentkm/stormlight/internal/app"
+	"github.com/trentkm/stormlight/internal/provider"
+	"github.com/trentkm/stormlight/internal/session"
+	"github.com/trentkm/stormlight/internal/workspace"
+)
+
+const testToken = "test-token"
+
+// fakeRuntime stands in for the daemon. Embedding the interface means a
+// route that reaches a method this test did not think about panics
+// loudly rather than passing on a nil result.
+type fakeRuntime struct {
+	session.Runtime
+
+	mu       sync.Mutex
+	agents   []agent.Agent
+	sent     []string
+	deleted  []string
+	stream   *fakeStream
+	streamed []string
+}
+
+func (f *fakeRuntime) ListAgents(context.Context) ([]agent.Agent, error) {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	return append([]agent.Agent(nil), f.agents...), nil
+}
+
+func (f *fakeRuntime) Send(_ context.Context, id, message string) error {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	f.sent = append(f.sent, id+": "+message)
+	return nil
+}
+
+func (f *fakeRuntime) Delete(_ context.Context, id string) error {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	f.deleted = append(f.deleted, id)
+	return nil
+}
+
+func (f *fakeRuntime) Update(context.Context, string, session.Update) error {
+	return nil
+}
+
+func (f *fakeRuntime) SetWorkspace(context.Context, string, workspace.Context) error {
+	return nil
+}
+
+func (f *fakeRuntime) AttachTerminal(
+	_ context.Context,
+	id string,
+	cols, rows int,
+) (session.TerminalStream, error) {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	f.streamed = append(f.streamed, id)
+	f.stream.cols, f.stream.rows = cols, rows
+	return f.stream, nil
+}
+
+// fakeStream is one attached terminal: a seed, a channel the test pushes
+// output onto, and a record of what came back the other way.
+type fakeStream struct {
+	seed   []byte
+	output chan []byte
+
+	mu         sync.Mutex
+	written    []byte
+	cols, rows int
+	closed     bool
+}
+
+func (f *fakeStream) Seed() []byte          { return f.seed }
+func (f *fakeStream) Output() <-chan []byte { return f.output }
+func (f *fakeStream) Write(p []byte) error {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	f.written = append(f.written, p...)
+	return nil
+}
+
+func (f *fakeStream) Resize(_ context.Context, cols, rows int) error {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	f.cols, f.rows = cols, rows
+	return nil
+}
+
+func (f *fakeStream) Close() {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	f.closed = true
+}
+
+func (f *fakeStream) input() string {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	return string(f.written)
+}
+
+func (f *fakeStream) size() (int, int) {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	return f.cols, f.rows
+}
+
+func startAPI(t *testing.T) (*httptest.Server, *fakeRuntime) {
+	t.Helper()
+	// The service reads the workspace catalog out of XDG state, and
+	// add/remove/rename write it back. Without this a test run answers
+	// with — and could edit — the catalog of whoever ran it.
+	t.Setenv("XDG_STATE_HOME", t.TempDir())
+	t.Setenv("XDG_CONFIG_HOME", t.TempDir())
+	runtime := &fakeRuntime{
+		agents: []agent.Agent{{
+			ID:       "agent-one",
+			Provider: agent.ProviderClaude,
+			Name:     "cl-tests",
+			Task:     "Run the tests",
+			Cwd:      t.TempDir(),
+			Activity: agent.ActivityWorking,
+		}},
+		stream: &fakeStream{
+			seed:   []byte("exact state"),
+			output: make(chan []byte, 8),
+		},
+	}
+	service := app.NewService(runtime, provider.NewRegistry(), workspace.NewRegistry())
+	server, err := New(service, testToken)
+	if err != nil {
+		t.Fatalf("New: %v", err)
+	}
+	t.Cleanup(server.Run())
+	httpServer := httptest.NewServer(server.Handler())
+	t.Cleanup(httpServer.Close)
+	return httpServer, runtime
+}
+
+// get issues an authenticated request against the test server.
+func get(t *testing.T, server *httptest.Server, path string) *http.Response {
+	t.Helper()
+	response, err := http.Get(server.URL + path + "?token=" + testToken)
+	if err != nil {
+		t.Fatalf("GET %s: %v", path, err)
+	}
+	t.Cleanup(func() { response.Body.Close() })
+	return response
+}
+
+func post(t *testing.T, server *httptest.Server, path, body string) *http.Response {
+	t.Helper()
+	response, err := http.Post(
+		server.URL+path+"?token="+testToken,
+		"application/json",
+		strings.NewReader(body),
+	)
+	if err != nil {
+		t.Fatalf("POST %s: %v", path, err)
+	}
+	t.Cleanup(func() { response.Body.Close() })
+	return response
+}
+
+// TestTokenGuardsEveryRoute: this API dispatches agents and streams
+// terminals across every workspace in the catalog. An unauthenticated
+// mode is not a convenience worth having, so there is not one.
+func TestTokenGuardsEveryRoute(t *testing.T) {
+	server, _ := startAPI(t)
+
+	for _, url := range []string{
+		server.URL + "/api/agents",
+		server.URL + "/api/agents?token=",
+		server.URL + "/api/agents?token=not-the-token",
+	} {
+		response, err := http.Get(url)
+		if err != nil {
+			t.Fatalf("GET: %v", err)
+		}
+		response.Body.Close()
+		if response.StatusCode != http.StatusUnauthorized {
+			t.Fatalf("%s answered %d, want 401", url, response.StatusCode)
+		}
+	}
+
+	// A bearer header is the other accepted form, for clients that can
+	// set one.
+	request, err := http.NewRequest(http.MethodGet, server.URL+"/api/agents", nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	request.Header.Set("Authorization", "Bearer "+testToken)
+	response, err := http.DefaultClient.Do(request)
+	if err != nil {
+		t.Fatalf("GET with bearer: %v", err)
+	}
+	defer response.Body.Close()
+	if response.StatusCode != http.StatusOK {
+		t.Fatalf("bearer token answered %d, want 200", response.StatusCode)
+	}
+}
+
+// TestCrossOriginUpgradeIsRefused: the token travels in a URL, and URLs
+// leak. A page the user merely visited must not be able to open a
+// terminal socket just because the server is on loopback.
+func TestCrossOriginUpgradeIsRefused(t *testing.T) {
+	server, _ := startAPI(t)
+
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+	address := "ws" + strings.TrimPrefix(server.URL, "http") +
+		"/api/agents/agent-one/terminal?token=" + testToken
+	_, _, err := websocket.Dial(ctx, address, &websocket.DialOptions{
+		HTTPHeader: http.Header{"Origin": []string{"http://evil.example"}},
+	})
+	if err == nil {
+		t.Fatal("a cross-origin upgrade was accepted")
+	}
+}
+
+func TestRosterIsServed(t *testing.T) {
+	server, _ := startAPI(t)
+
+	response := get(t, server, "/api/agents")
+	if response.StatusCode != http.StatusOK {
+		t.Fatalf("status %d", response.StatusCode)
+	}
+	var agents []agent.Agent
+	if err := json.NewDecoder(response.Body).Decode(&agents); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	if len(agents) != 1 || agents[0].ID != "agent-one" {
+		t.Fatalf("roster = %#v", agents)
+	}
+}
+
+// TestEmptyListsAreListsNotNull: an empty roster is what a fresh install
+// looks like, and a client iterating it should not have to special-case
+// the difference between "none" and "null".
+func TestEmptyListsAreListsNotNull(t *testing.T) {
+	server, runtime := startAPI(t)
+	runtime.mu.Lock()
+	runtime.agents = nil
+	runtime.mu.Unlock()
+
+	for _, path := range []string{"/api/agents", "/api/workspaces", "/api/history"} {
+		response := get(t, server, path)
+		if response.StatusCode != http.StatusOK {
+			t.Fatalf("%s answered %d", path, response.StatusCode)
+		}
+		body, err := io.ReadAll(response.Body)
+		if err != nil {
+			t.Fatalf("%s: %v", path, err)
+		}
+		if strings.TrimSpace(string(body)) != "[]" {
+			t.Fatalf("%s returned %q, want []", path, strings.TrimSpace(string(body)))
+		}
+	}
+}
+
+// TestControlPlaneReachesTheRuntime walks the routes that act on an
+// agent. Each is meant to be a decode, one Service call and an encode —
+// so what this asserts is that the call actually happened, not that the
+// handler did something clever on the way.
+func TestControlPlaneReachesTheRuntime(t *testing.T) {
+	server, runtime := startAPI(t)
+
+	response := post(t, server, "/api/agents/agent-one/message",
+		`{"message":"ship it"}`)
+	if response.StatusCode != http.StatusNoContent {
+		t.Fatalf("send answered %d, want 204", response.StatusCode)
+	}
+
+	request, err := http.NewRequest(http.MethodDelete,
+		server.URL+"/api/agents/agent-one?token="+testToken, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	deleted, err := http.DefaultClient.Do(request)
+	if err != nil {
+		t.Fatalf("DELETE: %v", err)
+	}
+	deleted.Body.Close()
+	if deleted.StatusCode != http.StatusNoContent {
+		t.Fatalf("delete answered %d, want 204", deleted.StatusCode)
+	}
+
+	runtime.mu.Lock()
+	defer runtime.mu.Unlock()
+	if len(runtime.sent) != 1 || runtime.sent[0] != "agent-one: ship it" {
+		t.Fatalf("message did not reach the runtime: %#v", runtime.sent)
+	}
+	if len(runtime.deleted) != 1 || runtime.deleted[0] != "agent-one" {
+		t.Fatalf("delete did not reach the runtime: %#v", runtime.deleted)
+	}
+}
+
+// TestRejectsUnknownFields: a misspelled field is a client bug, and
+// silently ignoring it means the caller thinks it asked for something it
+// did not.
+func TestRejectsUnknownFields(t *testing.T) {
+	server, _ := startAPI(t)
+	response := post(t, server, "/api/agents/agent-one/message",
+		`{"mesage":"typo"}`)
+	if response.StatusCode != http.StatusBadRequest {
+		t.Fatalf("status %d, want 400", response.StatusCode)
+	}
+}
+
+// TestTerminalRelayCarriesBytesBothWays is the data plane's contract: the
+// seed announces itself and arrives as state, live output follows as raw
+// binary, and keystrokes reach the terminal unwrapped.
+func TestTerminalRelayCarriesBytesBothWays(t *testing.T) {
+	server, runtime := startAPI(t)
+
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+	address := "ws" + strings.TrimPrefix(server.URL, "http") +
+		"/api/agents/agent-one/terminal?token=" + testToken + "&cols=120&rows=40"
+	conn, _, err := websocket.Dial(ctx, address, nil)
+	if err != nil {
+		t.Fatalf("dial terminal: %v", err)
+	}
+	defer conn.CloseNow()
+
+	// The seed is state, so it is announced before it arrives: a client
+	// must replace its replica rather than append to it.
+	kind, payload, err := conn.Read(ctx)
+	if err != nil {
+		t.Fatalf("read seed notice: %v", err)
+	}
+	if kind != websocket.MessageText {
+		t.Fatalf("seed notice was %v, want text", kind)
+	}
+	var notice controlMessage
+	if err := json.Unmarshal(payload, &notice); err != nil {
+		t.Fatalf("decode notice: %v", err)
+	}
+	if notice.Type != controlSeed {
+		t.Fatalf("notice type %q, want %q", notice.Type, controlSeed)
+	}
+
+	kind, payload, err = conn.Read(ctx)
+	if err != nil {
+		t.Fatalf("read seed: %v", err)
+	}
+	if kind != websocket.MessageBinary || string(payload) != "exact state" {
+		t.Fatalf("seed = %v %q", kind, payload)
+	}
+
+	// Live output arrives as raw bytes, not wrapped in anything.
+	runtime.stream.output <- []byte("hello from the pty")
+	kind, payload, err = conn.Read(ctx)
+	if err != nil {
+		t.Fatalf("read output: %v", err)
+	}
+	if kind != websocket.MessageBinary || string(payload) != "hello from the pty" {
+		t.Fatalf("output = %v %q", kind, payload)
+	}
+
+	// Input goes the other way the same way.
+	if err := conn.Write(ctx, websocket.MessageBinary, []byte("typed\r")); err != nil {
+		t.Fatalf("write input: %v", err)
+	}
+	waitFor(t, "input to reach the terminal", func() bool {
+		return runtime.stream.input() == "typed\r"
+	})
+
+	// Size travels on the text channel, which is the only thing it is for.
+	if err := conn.Write(ctx, websocket.MessageText,
+		[]byte(`{"type":"resize","cols":100,"rows":30}`)); err != nil {
+		t.Fatalf("write resize: %v", err)
+	}
+	waitFor(t, "resize to reach the terminal", func() bool {
+		cols, rows := runtime.stream.size()
+		return cols == 100 && rows == 30
+	})
+
+	runtime.mu.Lock()
+	streamed := append([]string(nil), runtime.streamed...)
+	runtime.mu.Unlock()
+	if len(streamed) != 1 || streamed[0] != "agent-one" {
+		t.Fatalf("attached to %#v", streamed)
+	}
+}
+
+// TestEventStreamPushesTheRoster: a client should never poll. It gets the
+// roster on connect, without waiting for something to change.
+func TestEventStreamPushesTheRoster(t *testing.T) {
+	server, _ := startAPI(t)
+
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+	address := "ws" + strings.TrimPrefix(server.URL, "http") +
+		"/api/events?token=" + testToken
+	conn, _, err := websocket.Dial(ctx, address, nil)
+	if err != nil {
+		t.Fatalf("dial events: %v", err)
+	}
+	defer conn.CloseNow()
+
+	kind, payload, err := conn.Read(ctx)
+	if err != nil {
+		t.Fatalf("read event: %v", err)
+	}
+	if kind != websocket.MessageText {
+		t.Fatalf("event was %v, want text", kind)
+	}
+	var event rosterEvent
+	if err := json.Unmarshal(payload, &event); err != nil {
+		t.Fatalf("decode event: %v", err)
+	}
+	if event.Type != "agents" || len(event.Agents) != 1 {
+		t.Fatalf("event = %#v", event)
+	}
+}
+
+func waitFor(t *testing.T, what string, condition func() bool) {
+	t.Helper()
+	deadline := time.Now().Add(5 * time.Second)
+	for !condition() {
+		if time.Now().After(deadline) {
+			t.Fatalf("timed out waiting for %s", what)
+		}
+		time.Sleep(10 * time.Millisecond)
+	}
+}

--- a/internal/api/server_test.go
+++ b/internal/api/server_test.go
@@ -70,10 +70,13 @@ func (f *fakeRuntime) AttachTerminal(
 	cols, rows int,
 ) (session.TerminalStream, error) {
 	f.mu.Lock()
-	defer f.mu.Unlock()
 	f.streamed = append(f.streamed, id)
-	f.stream.cols, f.stream.rows = cols, rows
-	return f.stream, nil
+	stream := f.stream
+	f.mu.Unlock()
+	// The stream guards its own fields; reaching past that from here is
+	// how the test, not the server, grew a race.
+	_ = stream.Resize(context.Background(), cols, rows)
+	return stream, nil
 }
 
 // fakeStream is one attached terminal: a seed, a channel the test pushes
@@ -232,6 +235,200 @@ func TestCrossOriginUpgradeIsRefused(t *testing.T) {
 	})
 	if err == nil {
 		t.Fatal("a cross-origin upgrade was accepted")
+	}
+}
+
+// TestCrossOriginRequestsAreRefused: guarding only the upgrades leaves
+// the control plane open. A cross-origin POST with a text/plain body is a
+// *simple* request — no preflight, so the browser sends it and the side
+// effect lands even though the reply is opaque to the attacker. Dispatch
+// takes a working directory and starts a process, which is exactly the
+// side effect not to hand out.
+func TestCrossOriginRequestsAreRefused(t *testing.T) {
+	server, runtime := startAPI(t)
+
+	request, err := http.NewRequest(http.MethodPost,
+		server.URL+"/api/agents/agent-one/message?token="+testToken,
+		strings.NewReader(`{"message":"from a page you visited"}`))
+	if err != nil {
+		t.Fatal(err)
+	}
+	request.Header.Set("Origin", "http://evil.example")
+	request.Header.Set("Content-Type", "text/plain")
+	response, err := http.DefaultClient.Do(request)
+	if err != nil {
+		t.Fatalf("POST: %v", err)
+	}
+	defer response.Body.Close()
+	if response.StatusCode != http.StatusForbidden {
+		t.Fatalf("cross-origin POST answered %d, want 403", response.StatusCode)
+	}
+	runtime.mu.Lock()
+	defer runtime.mu.Unlock()
+	if len(runtime.sent) != 0 {
+		t.Fatalf("a cross-origin request reached the runtime: %#v", runtime.sent)
+	}
+}
+
+// TestRebindingHostIsRefused: comparing Origin against the request's own
+// Host makes the check self-referential. Under DNS rebinding both carry
+// the attacker's name and match each other perfectly, so the Host has to
+// be one this server actually answers to.
+func TestRebindingHostIsRefused(t *testing.T) {
+	server, _ := startAPI(t)
+
+	request, err := http.NewRequest(http.MethodGet,
+		server.URL+"/api/agents?token="+testToken, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	request.Host = "evil.example"
+	request.Header.Set("Origin", "http://evil.example")
+	response, err := http.DefaultClient.Do(request)
+	if err != nil {
+		t.Fatalf("GET: %v", err)
+	}
+	defer response.Body.Close()
+	if response.StatusCode != http.StatusForbidden {
+		t.Fatalf("a rebound host answered %d, want 403", response.StatusCode)
+	}
+}
+
+// TestBearerHeaderParsing: the scheme is case-insensitive and its space
+// is not optional, and an unrelated Authorization header — a proxy's
+// Basic, a browser replaying cached credentials for 127.0.0.1 — must not
+// void a perfectly good query token.
+func TestBearerHeaderParsing(t *testing.T) {
+	server, _ := startAPI(t)
+
+	for _, testCase := range []struct {
+		name   string
+		header string
+		query  bool
+		want   int
+	}{
+		{"lowercase scheme", "bearer " + testToken, false, http.StatusOK},
+		{"no space", "Bearer" + testToken, false, http.StatusUnauthorized},
+		{"bare scheme", "Bearer", false, http.StatusUnauthorized},
+		{"unrelated header beside a good query token",
+			"Basic dXNlcjpwYXNz", true, http.StatusOK},
+	} {
+		t.Run(testCase.name, func(t *testing.T) {
+			url := server.URL + "/api/agents"
+			if testCase.query {
+				url += "?token=" + testToken
+			}
+			request, err := http.NewRequest(http.MethodGet, url, nil)
+			if err != nil {
+				t.Fatal(err)
+			}
+			request.Header.Set("Authorization", testCase.header)
+			response, err := http.DefaultClient.Do(request)
+			if err != nil {
+				t.Fatalf("GET: %v", err)
+			}
+			defer response.Body.Close()
+			if response.StatusCode != testCase.want {
+				t.Fatalf("answered %d, want %d", response.StatusCode, testCase.want)
+			}
+		})
+	}
+}
+
+// TestTerminalGeometryIsBounded: this is the one place a client's number
+// reaches the daemon's emulator, which allocates the grid it is told to.
+// The daemon owns every agent's process, so an unbounded size is a way to
+// take down the whole fleet from one query string.
+func TestTerminalGeometryIsBounded(t *testing.T) {
+	server, runtime := startAPI(t)
+
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+	address := "ws" + strings.TrimPrefix(server.URL, "http") +
+		"/api/agents/agent-one/terminal?token=" + testToken +
+		"&cols=100000&rows=100000"
+	conn, _, err := websocket.Dial(ctx, address, nil)
+	if err != nil {
+		t.Fatalf("dial: %v", err)
+	}
+	defer conn.CloseNow()
+
+	waitFor(t, "the attach to land", func() bool {
+		cols, rows := runtime.stream.size()
+		return cols > 0 && rows > 0
+	})
+	cols, rows := runtime.stream.size()
+	if cols > maxTerminalDimension || rows > maxTerminalDimension {
+		t.Fatalf("the daemon was asked for %dx%d", cols, rows)
+	}
+
+	// The resize control message is the same number by another route.
+	if err := conn.Write(ctx, websocket.MessageText,
+		[]byte(`{"type":"resize","cols":99999,"rows":99999}`)); err != nil {
+		t.Fatalf("write resize: %v", err)
+	}
+	waitFor(t, "the resize to land", func() bool {
+		cols, rows := runtime.stream.size()
+		return cols == maxTerminalDimension && rows == maxTerminalDimension
+	})
+}
+
+// TestPlainGetDoesNotDisturbTheTerminal: attaching resizes the agent's
+// terminal, and every viewer shares one. A request that cannot become a
+// terminal at all must not reflow the pane a dashboard user is reading.
+func TestPlainGetDoesNotDisturbTheTerminal(t *testing.T) {
+	server, runtime := startAPI(t)
+	runtime.stream.mu.Lock()
+	runtime.stream.cols, runtime.stream.rows = 213, 57
+	runtime.stream.mu.Unlock()
+
+	response := get(t, server, "/api/agents/agent-one/terminal")
+	defer response.Body.Close()
+
+	if cols, rows := runtime.stream.size(); cols != 213 || rows != 57 {
+		t.Fatalf("a plain GET resized the shared terminal to %dx%d", cols, rows)
+	}
+	runtime.mu.Lock()
+	defer runtime.mu.Unlock()
+	if len(runtime.streamed) != 0 {
+		t.Fatalf("a plain GET attached to %#v", runtime.streamed)
+	}
+}
+
+// TestLargePasteSurvives: xterm.js sends a paste as one message, and the
+// library's default read limit is 32 KiB. Exceeding it does not reject
+// the message — it tears down the whole attachment, so the user loses
+// both the paste and the terminal.
+func TestLargePasteSurvives(t *testing.T) {
+	server, runtime := startAPI(t)
+
+	ctx, cancel := context.WithTimeout(context.Background(), 15*time.Second)
+	defer cancel()
+	address := "ws" + strings.TrimPrefix(server.URL, "http") +
+		"/api/agents/agent-one/terminal?token=" + testToken
+	conn, _, err := websocket.Dial(ctx, address, nil)
+	if err != nil {
+		t.Fatalf("dial: %v", err)
+	}
+	defer conn.CloseNow()
+	drainSeed(t, ctx, conn)
+
+	paste := strings.Repeat("x", 200_000)
+	if err := conn.Write(ctx, websocket.MessageBinary, []byte(paste)); err != nil {
+		t.Fatalf("write paste: %v", err)
+	}
+	waitFor(t, "the whole paste to reach the terminal", func() bool {
+		return len(runtime.stream.input()) == len(paste)
+	})
+}
+
+// drainSeed reads the seed notice and the state behind it.
+func drainSeed(t *testing.T, ctx context.Context, conn *websocket.Conn) {
+	t.Helper()
+	for i := 0; i < 2; i++ {
+		if _, _, err := conn.Read(ctx); err != nil {
+			t.Fatalf("read seed: %v", err)
+		}
 	}
 }
 

--- a/internal/api/server_test.go
+++ b/internal/api/server_test.go
@@ -88,7 +88,11 @@ type fakeStream struct {
 	mu         sync.Mutex
 	written    []byte
 	cols, rows int
-	closed     bool
+	// resizes records every size the terminal was asked for, because a
+	// bad one that is corrected a moment later still reflowed the
+	// terminal every viewer shares.
+	resizes [][2]int
+	closed  bool
 }
 
 func (f *fakeStream) Seed() []byte          { return f.seed }
@@ -104,7 +108,14 @@ func (f *fakeStream) Resize(_ context.Context, cols, rows int) error {
 	f.mu.Lock()
 	defer f.mu.Unlock()
 	f.cols, f.rows = cols, rows
+	f.resizes = append(f.resizes, [2]int{cols, rows})
 	return nil
+}
+
+func (f *fakeStream) resizeHistory() [][2]int {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	return append([][2]int(nil), f.resizes...)
 }
 
 func (f *fakeStream) Close() {
@@ -270,6 +281,44 @@ func TestCrossOriginRequestsAreRefused(t *testing.T) {
 	}
 }
 
+// TestSameOriginRequestsAreAllowed is the other half of the origin
+// tests, and the half that fails if the policy is merely strict: a page
+// this server serves must be able to call it. Refusing everything would
+// satisfy every "is it refused" test ever written.
+func TestSameOriginRequestsAreAllowed(t *testing.T) {
+	server, _ := startAPI(t)
+
+	request, err := http.NewRequest(http.MethodPost,
+		server.URL+"/api/agents/agent-one/message?token="+testToken,
+		strings.NewReader(`{"message":"from the page you served me"}`))
+	if err != nil {
+		t.Fatal(err)
+	}
+	// What a browser sends for a page loaded from this very server.
+	request.Header.Set("Origin", server.URL)
+	response, err := http.DefaultClient.Do(request)
+	if err != nil {
+		t.Fatalf("POST: %v", err)
+	}
+	defer response.Body.Close()
+	if response.StatusCode != http.StatusNoContent {
+		t.Fatalf("a same-origin request answered %d, want 204", response.StatusCode)
+	}
+
+	// And a terminal socket from that same page.
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+	address := "ws" + strings.TrimPrefix(server.URL, "http") +
+		"/api/agents/agent-one/terminal?token=" + testToken
+	conn, _, err := websocket.Dial(ctx, address, &websocket.DialOptions{
+		HTTPHeader: http.Header{"Origin": []string{server.URL}},
+	})
+	if err != nil {
+		t.Fatalf("a same-origin upgrade was refused: %v", err)
+	}
+	conn.CloseNow()
+}
+
 // TestRebindingHostIsRefused: comparing Origin against the request's own
 // Host makes the check self-referential. Under DNS rebinding both carry
 // the attacker's name and match each other perfectly, so the Host has to
@@ -358,8 +407,13 @@ func TestTerminalGeometryIsBounded(t *testing.T) {
 		return cols > 0 && rows > 0
 	})
 	cols, rows := runtime.stream.size()
-	if cols > maxTerminalDimension || rows > maxTerminalDimension {
+	if !usableSize(cols, rows) {
 		t.Fatalf("the daemon was asked for %dx%d", cols, rows)
+	}
+	// Refused, not corrected: a size nobody can use must leave the
+	// terminal where it was.
+	if cols != 80 || rows != 24 {
+		t.Fatalf("an unusable size became %dx%d instead of the default", cols, rows)
 	}
 
 	// The resize control message is the same number by another route.
@@ -367,10 +421,35 @@ func TestTerminalGeometryIsBounded(t *testing.T) {
 		[]byte(`{"type":"resize","cols":99999,"rows":99999}`)); err != nil {
 		t.Fatalf("write resize: %v", err)
 	}
-	waitFor(t, "the resize to land", func() bool {
+	// A resize the terminal cannot be is ignored, not clamped: flooring
+	// it would let one message reflow the terminal every viewer shares.
+	if err := conn.Write(ctx, websocket.MessageText,
+		[]byte(`{"type":"resize"}`)); err != nil {
+		t.Fatalf("write empty resize: %v", err)
+	}
+	if err := conn.Write(ctx, websocket.MessageText,
+		[]byte(`{"type":"resize","cols":120,"rows":40}`)); err != nil {
+		t.Fatalf("write resize: %v", err)
+	}
+	// The good one lands, which also proves the bad ones did not: they
+	// were sent first, on one ordered socket.
+	waitFor(t, "the usable resize to land", func() bool {
 		cols, rows := runtime.stream.size()
-		return cols == maxTerminalDimension && rows == maxTerminalDimension
+		return cols == 120 && rows == 40
 	})
+	// The socket is ordered, so the unusable ones were handled before the
+	// one that landed. None of them may have reached the terminal — a
+	// size corrected to 2x2 a moment later still reflowed the pane every
+	// viewer shares, which is the whole failure being prevented.
+	for _, size := range runtime.stream.resizeHistory() {
+		if !usableSize(size[0], size[1]) {
+			t.Fatalf("the terminal was resized to %dx%d", size[0], size[1])
+		}
+		if size[0] == 2 || size[1] == 2 {
+			t.Fatalf("an unusable resize was floored to %dx%d instead of refused",
+				size[0], size[1])
+		}
+	}
 }
 
 // TestPlainGetDoesNotDisturbTheTerminal: attaching resizes the agent's

--- a/internal/api/terminal.go
+++ b/internal/api/terminal.go
@@ -6,6 +6,7 @@ import (
 
 	"net/http"
 	"strconv"
+	"time"
 
 	"github.com/coder/websocket"
 
@@ -42,21 +43,28 @@ const (
 // terminal relays one agent's live terminal over one WebSocket.
 func (s *Server) terminal(w http.ResponseWriter, r *http.Request) {
 	cols, rows := terminalSize(r)
-	transport, err := s.service.AttachTerminal(r.Context(), r.PathValue("id"), cols, rows)
-	if err != nil {
-		writeError(w, http.StatusBadRequest, err.Error())
-		return
-	}
 
+	// Upgrade before attaching. Attaching resizes the agent's terminal —
+	// the daemon owns one terminal per agent and every viewer shares it —
+	// so doing it first would let a plain GET, which cannot become a
+	// terminal at all, reflow the pane a dashboard user is reading.
 	conn, err := websocket.Accept(w, r, &websocket.AcceptOptions{
-		// Origin is checked in the auth middleware, against the host
-		// actually being served rather than a list maintained here.
+		// Origin is checked in the auth middleware, against the loopback
+		// hosts this server actually serves.
 		InsecureSkipVerify: true,
 	})
 	if err != nil {
-		transport.Close()
 		return
 	}
+	transport, err := s.service.AttachTerminal(r.Context(), r.PathValue("id"), cols, rows)
+	if err != nil {
+		_ = conn.Close(websocket.StatusInternalError, "attach failed")
+		return
+	}
+	// A paste is one message, and terminals receive large ones. The
+	// library's default read limit is 32 KiB, which would not reject the
+	// paste but tear down the whole attachment.
+	conn.SetReadLimit(maxTerminalMessage)
 	// A terminal is a long conversation; nothing about it should time out
 	// for being quiet, so the relay runs on a context of its own that
 	// ends when either side hangs up.
@@ -84,6 +92,7 @@ func (s *Server) terminal(w http.ResponseWriter, r *http.Request) {
 	}
 
 	go s.pumpInput(ctx, cancel, conn, transport)
+	go keepalive(ctx, cancel, conn)
 
 	// Output goes out as it arrives. No coalescing here: the transport
 	// hands over whole chunks already, and holding one back to merge it
@@ -133,11 +142,41 @@ func (s *Server) pumpInput(
 			if message.Type != controlResize {
 				continue
 			}
-			if err := transport.Resize(ctx, message.Cols, message.Rows); err != nil {
+			// The same bound as the query string: this number reaches the
+			// daemon's emulator, which allocates what it is told to.
+			cols := min(max(message.Cols, 2), maxTerminalDimension)
+			rows := min(max(message.Rows, 2), maxTerminalDimension)
+			if err := transport.Resize(ctx, cols, rows); err != nil {
 				// A resize that loses a race with the session ending is
 				// not worth dropping the connection over.
 				diagnostic.Logger().Debug("terminal resize failed", "error", err)
 			}
+		}
+	}
+}
+
+// keepaliveInterval paces the ping that proves a viewer is still there.
+// A laptop that sleeps or a wifi drop leaves a connection that looks open
+// and never speaks again; without this the server holds the goroutine and
+// the daemon attachment behind it until the OS gives up on the socket,
+// which can be hours.
+const keepaliveInterval = 30 * time.Second
+
+func keepalive(ctx context.Context, cancel context.CancelFunc, conn *websocket.Conn) {
+	defer cancel()
+	ticker := time.NewTicker(keepaliveInterval)
+	defer ticker.Stop()
+	for {
+		select {
+		case <-ctx.Done():
+			return
+		case <-ticker.C:
+		}
+		pingCtx, timeout := context.WithTimeout(ctx, keepaliveInterval)
+		err := conn.Ping(pingCtx)
+		timeout()
+		if err != nil {
+			return
 		}
 	}
 }
@@ -157,19 +196,30 @@ func writeControl(ctx context.Context, conn *websocket.Conn, message controlMess
 	return conn.Write(ctx, websocket.MessageText, payload)
 }
 
+// A terminal's geometry is not a matter of opinion, and this is the one
+// place a client's number reaches the daemon's emulator. The emulator
+// allocates the whole grid, so an unbounded size is an out-of-memory
+// request served on demand: the daemon owns every agent's process, and
+// taking it down takes the fleet with it. maxTerminalDimension is far
+// past any real display and cheap at the limit.
+const maxTerminalDimension = 1000
+
+// maxTerminalMessage bounds one inbound message — a keystroke, or a
+// paste. Generous enough for pasting a file, small enough that a client
+// cannot make the server hold an arbitrary buffer.
+const maxTerminalMessage = 4 << 20
+
 // terminalSize reads the viewer's geometry from the query string. A
 // viewer that does not say gets a conventional terminal; it will resize
 // as soon as it has laid itself out.
 func terminalSize(r *http.Request) (cols, rows int) {
-	cols = positiveQuery(r, "cols", 80)
-	rows = positiveQuery(r, "rows", 24)
-	return cols, rows
+	return boundedQuery(r, "cols", 80), boundedQuery(r, "rows", 24)
 }
 
-func positiveQuery(r *http.Request, name string, fallback int) int {
+func boundedQuery(r *http.Request, name string, fallback int) int {
 	value, err := strconv.Atoi(r.URL.Query().Get(name))
 	if err != nil || value < 2 {
 		return fallback
 	}
-	return value
+	return min(value, maxTerminalDimension)
 }

--- a/internal/api/terminal.go
+++ b/internal/api/terminal.go
@@ -1,0 +1,175 @@
+package api
+
+import (
+	"context"
+	"encoding/json"
+
+	"net/http"
+	"strconv"
+
+	"github.com/coder/websocket"
+
+	"github.com/trentkm/stormlight/internal/diagnostic"
+	"github.com/trentkm/stormlight/internal/pty"
+)
+
+// The terminal socket is deliberately not a JSON protocol.
+//
+// Binary messages are terminal bytes, raw and unwrapped, in both
+// directions: the daemon's exact snapshot arrives first, then live
+// output; keystrokes travel back the same way. Wrapping a keypress in
+// JSON would put an encode, a decode and an allocation on the path
+// between a key and the process that answers it, for no gain — the frame
+// already carries the length.
+//
+// Text messages are the control channel: a size, or a notice that the
+// terminal moved under this viewer. There are few of them and they are
+// never in the typing path.
+type controlMessage struct {
+	Type string `json:"type"`
+	Cols int    `json:"cols,omitempty"`
+	Rows int    `json:"rows,omitempty"`
+}
+
+const (
+	controlResize = "resize"
+	// controlSeed precedes a binary message that replaces the replica
+	// rather than extending it: the first one at attach, and any later
+	// one when the daemon resynced a viewer that fell behind.
+	controlSeed = "seed"
+)
+
+// terminal relays one agent's live terminal over one WebSocket.
+func (s *Server) terminal(w http.ResponseWriter, r *http.Request) {
+	cols, rows := terminalSize(r)
+	transport, err := s.service.AttachTerminal(r.Context(), r.PathValue("id"), cols, rows)
+	if err != nil {
+		writeError(w, http.StatusBadRequest, err.Error())
+		return
+	}
+
+	conn, err := websocket.Accept(w, r, &websocket.AcceptOptions{
+		// Origin is checked in the auth middleware, against the host
+		// actually being served rather than a list maintained here.
+		InsecureSkipVerify: true,
+	})
+	if err != nil {
+		transport.Close()
+		return
+	}
+	// A terminal is a long conversation; nothing about it should time out
+	// for being quiet, so the relay runs on a context of its own that
+	// ends when either side hangs up.
+	ctx, cancel := context.WithCancel(context.WithoutCancel(r.Context()))
+	defer cancel()
+	defer transport.Close()
+	defer conn.CloseNow()
+
+	// The daemon's snapshot is state, not output: it replaces whatever the
+	// replica had. Say so before sending it, so a reconnecting client
+	// never appends a screen to the one it was already showing.
+	if err := writeSeed(ctx, conn, transport.Seed()); err != nil {
+		return
+	}
+
+	// A terminal this viewer shares can be resized by someone else — the
+	// dashboard, a full-screen attach — and a replica painting at a size
+	// nobody else is using is a diverged replica.
+	if notifier, ok := transport.(pty.ResizeNotifier); ok {
+		notifier.OnResize(func(cols, rows int) {
+			_ = writeControl(ctx, conn, controlMessage{
+				Type: controlResize, Cols: cols, Rows: rows,
+			})
+		})
+	}
+
+	go s.pumpInput(ctx, cancel, conn, transport)
+
+	// Output goes out as it arrives. No coalescing here: the transport
+	// hands over whole chunks already, and holding one back to merge it
+	// with the next would trade the responsiveness this plane exists for
+	// against nothing.
+	for {
+		select {
+		case <-ctx.Done():
+			return
+		case chunk, ok := <-transport.Output():
+			if !ok {
+				// The session ended; let the client see a clean close
+				// rather than a dropped connection.
+				_ = conn.Close(websocket.StatusNormalClosure, "session ended")
+				return
+			}
+			if err := conn.Write(ctx, websocket.MessageBinary, chunk); err != nil {
+				return
+			}
+		}
+	}
+}
+
+// pumpInput carries the client's keystrokes and resizes to the terminal.
+func (s *Server) pumpInput(
+	ctx context.Context,
+	cancel context.CancelFunc,
+	conn *websocket.Conn,
+	transport pty.Transport,
+) {
+	defer cancel()
+	for {
+		kind, payload, err := conn.Read(ctx)
+		if err != nil {
+			return
+		}
+		switch kind {
+		case websocket.MessageBinary:
+			if err := transport.Write(payload); err != nil {
+				return
+			}
+		case websocket.MessageText:
+			var message controlMessage
+			if err := json.Unmarshal(payload, &message); err != nil {
+				continue
+			}
+			if message.Type != controlResize {
+				continue
+			}
+			if err := transport.Resize(ctx, message.Cols, message.Rows); err != nil {
+				// A resize that loses a race with the session ending is
+				// not worth dropping the connection over.
+				diagnostic.Logger().Debug("terminal resize failed", "error", err)
+			}
+		}
+	}
+}
+
+func writeSeed(ctx context.Context, conn *websocket.Conn, seed []byte) error {
+	if err := writeControl(ctx, conn, controlMessage{Type: controlSeed}); err != nil {
+		return err
+	}
+	return conn.Write(ctx, websocket.MessageBinary, seed)
+}
+
+func writeControl(ctx context.Context, conn *websocket.Conn, message controlMessage) error {
+	payload, err := json.Marshal(message)
+	if err != nil {
+		return err
+	}
+	return conn.Write(ctx, websocket.MessageText, payload)
+}
+
+// terminalSize reads the viewer's geometry from the query string. A
+// viewer that does not say gets a conventional terminal; it will resize
+// as soon as it has laid itself out.
+func terminalSize(r *http.Request) (cols, rows int) {
+	cols = positiveQuery(r, "cols", 80)
+	rows = positiveQuery(r, "rows", 24)
+	return cols, rows
+}
+
+func positiveQuery(r *http.Request, name string, fallback int) int {
+	value, err := strconv.Atoi(r.URL.Query().Get(name))
+	if err != nil || value < 2 {
+		return fallback
+	}
+	return value
+}

--- a/internal/api/terminal.go
+++ b/internal/api/terminal.go
@@ -104,9 +104,15 @@ func (s *Server) terminal(w http.ResponseWriter, r *http.Request) {
 			return
 		case chunk, ok := <-transport.Output():
 			if !ok {
-				// The session ended; let the client see a clean close
-				// rather than a dropped connection.
-				_ = conn.Close(websocket.StatusNormalClosure, "session ended")
+				// The stream ended — and this layer cannot say why. The
+				// agent may have exited, or the daemon may have dropped
+				// this attachment for falling behind, which it does
+				// silently and which a burst of output makes ordinary
+				// (trentkm/windrunner#15, fixed by the resync attach in
+				// trentkm/windrunner#17). Saying "session ended" here
+				// would have a live agent read as a dead one; the client
+				// reconnects and asks the roster, which knows.
+				_ = conn.Close(websocket.StatusNormalClosure, "stream ended")
 				return
 			}
 			if err := conn.Write(ctx, websocket.MessageBinary, chunk); err != nil {
@@ -142,11 +148,16 @@ func (s *Server) pumpInput(
 			if message.Type != controlResize {
 				continue
 			}
-			// The same bound as the query string: this number reaches the
-			// daemon's emulator, which allocates what it is told to.
-			cols := min(max(message.Cols, 2), maxTerminalDimension)
-			rows := min(max(message.Rows, 2), maxTerminalDimension)
-			if err := transport.Resize(ctx, cols, rows); err != nil {
+			// Refuse a size rather than correct it. Clamping upward looks
+			// harmless and is not: a message with no size at all would
+			// become a legal 2x2, and one resize reflows the terminal
+			// every viewer shares — including the dashboard someone is
+			// reading. An unusable number is a client bug; the terminal
+			// is not the place to absorb it.
+			if !usableSize(message.Cols, message.Rows) {
+				continue
+			}
+			if err := transport.Resize(ctx, message.Cols, message.Rows); err != nil {
 				// A resize that loses a race with the session ending is
 				// not worth dropping the connection over.
 				diagnostic.Logger().Debug("terminal resize failed", "error", err)
@@ -198,11 +209,27 @@ func writeControl(ctx context.Context, conn *websocket.Conn, message controlMess
 
 // A terminal's geometry is not a matter of opinion, and this is the one
 // place a client's number reaches the daemon's emulator. The emulator
-// allocates the whole grid, so an unbounded size is an out-of-memory
-// request served on demand: the daemon owns every agent's process, and
-// taking it down takes the fleet with it. maxTerminalDimension is far
-// past any real display and cheap at the limit.
-const maxTerminalDimension = 1000
+// allocates the whole grid — screen and scrollback both — so an unbounded
+// size is an out-of-memory request served on demand, and the daemon that
+// serves it owns every agent's process.
+//
+// The bounds are sized against real displays with room to spare, not
+// against what the format allows: an ultrawide monitor at a small font
+// reaches perhaps 400 columns, and rows past a couple of hundred are a
+// scrollback question rather than a screen one. Generous limits are not
+// free here — scrollback is columns times its line count, so width is
+// what actually costs, and a cap ten times any real terminal would mean
+// hundreds of megabytes per session for no one's benefit.
+const (
+	maxTerminalCols = 500
+	maxTerminalRows = 200
+)
+
+// usableSize reports whether a client's geometry is one a terminal can
+// actually be.
+func usableSize(cols, rows int) bool {
+	return cols >= 2 && rows >= 2 && cols <= maxTerminalCols && rows <= maxTerminalRows
+}
 
 // maxTerminalMessage bounds one inbound message — a keystroke, or a
 // paste. Generous enough for pasting a file, small enough that a client
@@ -210,16 +237,23 @@ const maxTerminalDimension = 1000
 const maxTerminalMessage = 4 << 20
 
 // terminalSize reads the viewer's geometry from the query string. A
-// viewer that does not say gets a conventional terminal; it will resize
-// as soon as it has laid itself out.
+// viewer that does not say — or says something a terminal cannot be —
+// gets a conventional one; it will resize as soon as it has laid itself
+// out. Unlike the resize message, there is no client to inform here, and
+// refusing the whole attachment over a query string would be a worse
+// answer than starting at 80x24.
 func terminalSize(r *http.Request) (cols, rows int) {
-	return boundedQuery(r, "cols", 80), boundedQuery(r, "rows", 24)
+	cols, rows = queryInt(r, "cols"), queryInt(r, "rows")
+	if !usableSize(cols, rows) {
+		return 80, 24
+	}
+	return cols, rows
 }
 
-func boundedQuery(r *http.Request, name string, fallback int) int {
+func queryInt(r *http.Request, name string) int {
 	value, err := strconv.Atoi(r.URL.Query().Get(name))
-	if err != nil || value < 2 {
-		return fallback
+	if err != nil {
+		return 0
 	}
-	return min(value, maxTerminalDimension)
+	return value
 }

--- a/internal/api/workspaces.go
+++ b/internal/api/workspaces.go
@@ -1,0 +1,80 @@
+package api
+
+import (
+	"net/http"
+
+	"github.com/trentkm/stormlight/internal/workspace"
+)
+
+func (s *Server) listWorkspaces(w http.ResponseWriter, r *http.Request) {
+	ctx, cancel := call(r)
+	defer cancel()
+	values, err := s.service.ListWorkspaces(ctx)
+	if err != nil {
+		writeError(w, http.StatusBadGateway, err.Error())
+		return
+	}
+	writeJSON(w, http.StatusOK, orEmpty(values))
+}
+
+type workspaceBody struct {
+	Host string `json:"host,omitempty"`
+	Path string `json:"path"`
+}
+
+func (s *Server) addWorkspace(w http.ResponseWriter, r *http.Request) {
+	var body workspaceBody
+	if err := decode(r, &body); err != nil {
+		writeError(w, http.StatusBadRequest, err.Error())
+		return
+	}
+	ctx, cancel := call(r)
+	defer cancel()
+	// Resolution runs on the machine that has the path, so host and path
+	// travel together; the catalog then holds what the resolver said.
+	added, err := s.service.AddWorkspace(ctx, body.Host, body.Path)
+	if err != nil {
+		writeError(w, http.StatusBadRequest, err.Error())
+		return
+	}
+	writeJSON(w, http.StatusCreated, added)
+}
+
+// workspaceRef identifies a catalogued workspace for the routes that act
+// on one. It is the resolved context rather than a path: the catalog is
+// keyed by what the resolver decided, and a client that just listed the
+// workspaces already holds it.
+type workspaceRef struct {
+	Workspace workspace.Context `json:"workspace"`
+	Name      string            `json:"name,omitempty"`
+}
+
+func (s *Server) removeWorkspace(w http.ResponseWriter, r *http.Request) {
+	var body workspaceRef
+	if err := decode(r, &body); err != nil {
+		writeError(w, http.StatusBadRequest, err.Error())
+		return
+	}
+	ctx, cancel := call(r)
+	defer cancel()
+	if err := s.service.RemoveWorkspace(ctx, body.Workspace); err != nil {
+		writeError(w, http.StatusBadRequest, err.Error())
+		return
+	}
+	writeJSON(w, http.StatusNoContent, nil)
+}
+
+func (s *Server) renameWorkspace(w http.ResponseWriter, r *http.Request) {
+	var body workspaceRef
+	if err := decode(r, &body); err != nil {
+		writeError(w, http.StatusBadRequest, err.Error())
+		return
+	}
+	ctx, cancel := call(r)
+	defer cancel()
+	if err := s.service.RenameWorkspace(ctx, body.Workspace, body.Name); err != nil {
+		writeError(w, http.StatusBadRequest, err.Error())
+		return
+	}
+	writeJSON(w, http.StatusNoContent, nil)
+}

--- a/internal/api/workspaces.go
+++ b/internal/api/workspaces.go
@@ -24,7 +24,7 @@ type workspaceBody struct {
 
 func (s *Server) addWorkspace(w http.ResponseWriter, r *http.Request) {
 	var body workspaceBody
-	if err := decode(r, &body); err != nil {
+	if err := decode(w, r, &body); err != nil {
 		writeError(w, http.StatusBadRequest, err.Error())
 		return
 	}
@@ -51,7 +51,7 @@ type workspaceRef struct {
 
 func (s *Server) removeWorkspace(w http.ResponseWriter, r *http.Request) {
 	var body workspaceRef
-	if err := decode(r, &body); err != nil {
+	if err := decode(w, r, &body); err != nil {
 		writeError(w, http.StatusBadRequest, err.Error())
 		return
 	}
@@ -66,7 +66,7 @@ func (s *Server) removeWorkspace(w http.ResponseWriter, r *http.Request) {
 
 func (s *Server) renameWorkspace(w http.ResponseWriter, r *http.Request) {
 	var body workspaceRef
-	if err := decode(r, &body); err != nil {
+	if err := decode(w, r, &body); err != nil {
 		writeError(w, http.StatusBadRequest, err.Error())
 		return
 	}

--- a/main.go
+++ b/main.go
@@ -125,6 +125,7 @@ func newRootCommand() *cobra.Command {
 		newResolveCommand(),
 		newReadCommand(),
 		newBenchCommand(),
+		newServeCommand(cfg),
 	)
 	return root
 }

--- a/serve.go
+++ b/serve.go
@@ -68,9 +68,13 @@ func newServeCommand(cfg config.Config) *cobra.Command {
 			fmt.Fprintf(cmd.OutOrStdout(), "Stormlight API on %s\n", address)
 			diagnostic.Logger().Info("api serving", "address", listener.Addr().String())
 
-			// Ctrl-C should close the listener and let in-flight
-			// attachments end, rather than killing the process out from
-			// under a terminal someone is typing into.
+			// Ctrl-C stops accepting and lets in-flight *requests*
+			// finish. It does not wait for terminal sockets: a WebSocket
+			// is a hijacked connection, which Shutdown explicitly does
+			// not track, and waiting on attachments that are meant to
+			// last for hours would be waiting forever. Those clients see
+			// the connection drop and reconnect; the agents themselves
+			// are in the daemon and never notice.
 			ctx, stop := signal.NotifyContext(cmd.Context(),
 				os.Interrupt, syscall.SIGTERM)
 			defer stop()

--- a/serve.go
+++ b/serve.go
@@ -1,0 +1,98 @@
+package main
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"net"
+	"net/http"
+	"os"
+	"os/signal"
+	"syscall"
+	"time"
+
+	"github.com/spf13/cobra"
+
+	"github.com/trentkm/stormlight/internal/api"
+	"github.com/trentkm/stormlight/internal/config"
+	"github.com/trentkm/stormlight/internal/diagnostic"
+)
+
+// newServeCommand runs the HTTP API: the same domain the dashboard drives,
+// reachable by a second client.
+//
+// It binds loopback and nothing else. These routes dispatch agents and
+// stream terminals in every workspace the catalog knows, which is shell
+// access to all of them — reaching them from another machine is a tunnel
+// the operator opens deliberately (`ssh -L`, Tailscale), never a default
+// this command chose for them.
+func newServeCommand(cfg config.Config) *cobra.Command {
+	var port int
+	var token string
+
+	command := &cobra.Command{
+		Use:   "serve",
+		Short: "Serve the HTTP API for web clients",
+		RunE: func(cmd *cobra.Command, args []string) error {
+			service, err := newService(cfg)
+			if err != nil {
+				return err
+			}
+			if token == "" {
+				if token, err = api.NewToken(); err != nil {
+					return err
+				}
+			}
+			server, err := api.New(service, token)
+			if err != nil {
+				return err
+			}
+
+			listener, err := net.Listen("tcp", fmt.Sprintf("127.0.0.1:%d", port))
+			if err != nil {
+				return fmt.Errorf("listen: %w", err)
+			}
+			stopEvents := server.Run()
+			defer stopEvents()
+
+			httpServer := &http.Server{
+				Handler: server.Handler(),
+				// No write timeout: a terminal socket and an event stream
+				// are meant to outlive any request. Reading a request head
+				// is still bounded, so a connection that never speaks
+				// cannot hold a slot forever.
+				ReadHeaderTimeout: 10 * time.Second,
+			}
+
+			address := fmt.Sprintf("http://%s/?token=%s", listener.Addr(), token)
+			fmt.Fprintf(cmd.OutOrStdout(), "Stormlight API on %s\n", address)
+			diagnostic.Logger().Info("api serving", "address", listener.Addr().String())
+
+			// Ctrl-C should close the listener and let in-flight
+			// attachments end, rather than killing the process out from
+			// under a terminal someone is typing into.
+			ctx, stop := signal.NotifyContext(cmd.Context(),
+				os.Interrupt, syscall.SIGTERM)
+			defer stop()
+			done := make(chan error, 1)
+			go func() { done <- httpServer.Serve(listener) }()
+
+			select {
+			case err := <-done:
+				if errors.Is(err, http.ErrServerClosed) {
+					return nil
+				}
+				return err
+			case <-ctx.Done():
+				shutdownCtx, cancel := context.WithTimeout(
+					context.Background(), 5*time.Second)
+				defer cancel()
+				return httpServer.Shutdown(shutdownCtx)
+			}
+		},
+	}
+	command.Flags().IntVar(&port, "port", 7331, "loopback port to listen on")
+	command.Flags().StringVar(&token, "token", "",
+		"access token; generated per run when unset")
+	return command
+}

--- a/serve.go
+++ b/serve.go
@@ -24,8 +24,11 @@ import (
 // It binds loopback and nothing else. These routes dispatch agents and
 // stream terminals in every workspace the catalog knows, which is shell
 // access to all of them — reaching them from another machine is a tunnel
-// the operator opens deliberately (`ssh -L`, Tailscale), never a default
-// this command chose for them.
+// the operator opens deliberately, never a default this command chose for
+// them. Port forwarding (`ssh -L`) is the shape that works: the request
+// still arrives as localhost, which is what the server requires. A proxy
+// that presents some other hostname is refused, deliberately — that is
+// the same check that stops a rebound DNS name.
 func newServeCommand(cfg config.Config) *cobra.Command {
 	var port int
 	var token string

--- a/site/docs/architecture.html
+++ b/site/docs/architecture.html
@@ -37,6 +37,7 @@
     <li><a href="#layers">Layers</a></li>
     <li class="sub"><a href="#provider-adapters">Provider adapters</a></li>
     <li class="sub"><a href="#application-service">Application service</a></li>
+    <li class="sub"><a href="#http-api">HTTP API</a></li>
     <li class="sub"><a href="#windrunner-runtime">windrunner runtime</a></li>
     <li class="sub"><a href="#remote-hosts">Remote hosts</a></li>
     <li class="sub"><a href="#terminal-seam">The terminal seam</a></li>
@@ -92,9 +93,9 @@
 
     <h3 id="application-service">Application service</h3>
     <p>The application service validates requests, resolves a provider and workspace, and
-    delegates terminal operations to the runtime. The TUI and CLI use the same service. A
-    persistent workspace catalog supplies workspaces that do not currently contain an
-    agent.</p>
+    delegates terminal operations to the runtime. The TUI, the CLI, and the HTTP API all
+    use the same service. A persistent workspace catalog supplies workspaces that do not
+    currently contain an agent.</p>
     <p>Workspace resolvers return a stable group ID, a group root, an execution root, and
     optional component metadata. External executable resolvers run before the built-in Git
     resolver, followed by a canonical-directory fallback. Resolvers may also enumerate a
@@ -103,6 +104,28 @@
     claimed the workspace and is bounded, cached, and best-effort, so a failed external
     integration cannot block dashboard refresh. This keeps environment-specific workspace
     semantics outside the public runtime.</p>
+
+    <h3 id="http-api">HTTP API</h3>
+    <p><code>stormlight serve</code> exposes the application service to clients that are
+    not a terminal — a browser front end first among them. It is a peer of the TUI, not a
+    layer above or below it: both drive the same service, so a rule about what a dispatch
+    means or when an agent needs attention is written once.</p>
+    <p>Two planes share the listener and never mix. The control plane is JSON over HTTP —
+    roster, workspaces, dispatch, history — where latency is irrelevant. The data plane is
+    one WebSocket per attached terminal carrying raw bytes in both directions: the daemon's
+    exact snapshot arrives first as state, then live output, and keystrokes travel back
+    unwrapped. Terminal input is never queued behind a control request and never encoded as
+    JSON, because everything about how typing feels lives on that path. Sizes and resync
+    notices ride the same socket as text messages, which are rare and never in the typing
+    path.</p>
+    <p>A second client attaching changes nothing for the first: the daemon owns the
+    terminal, so the dashboard and a browser can hold the same agent at once, each seeded
+    with its own exact snapshot.</p>
+    <p>The server binds loopback only and requires a per-run token on every request and
+    upgrade — these routes dispatch agents and stream terminals in every workspace the
+    catalog knows. Reaching them from another machine is a tunnel the operator opens
+    deliberately, never a default. WebSocket upgrades also check <code>Origin</code>, so a
+    page the user merely visited cannot reach the API just because it is on localhost.</p>
 
     <h3 id="windrunner-runtime">windrunner runtime</h3>
     <p>Process and terminal ownership live in a daemon built on the

--- a/site/docs/architecture.html
+++ b/site/docs/architecture.html
@@ -118,9 +118,12 @@
     JSON, because everything about how typing feels lives on that path. Sizes and resync
     notices ride the same socket as text messages, which are rare and never in the typing
     path.</p>
-    <p>A second client attaching changes nothing for the first: the daemon owns the
-    terminal, so the dashboard and a browser can hold the same agent at once, each seeded
-    with its own exact snapshot.</p>
+    <p>The dashboard and a browser can hold the same agent at once, each seeded with its
+    own exact snapshot, because the daemon owns the terminal rather than any client. What
+    they cannot have is their own geometry: an agent has one terminal, so the newest
+    viewer's size becomes everyone's, and the others are told over their own streams and
+    repaint. Sharing the size is what keeps the replicas identical — the alternative is
+    each client rendering a different reflow of the same program's output.</p>
     <p>The server binds loopback only and requires a per-run token on every request and
     upgrade — these routes dispatch agents and stream terminals in every workspace the
     catalog knows. Reaching them from another machine is a tunnel the operator opens


### PR DESCRIPTION
Phase 2 of the Stormlight Web epic (#125). Closes #133.

## The carve-out turned out to be unnecessary

#125 planned a refactor first — pull roster and dispatch logic out of `internal/ui` so the TUI and an API become peers. That work already existed: `internal/app.Service` holds every rule, and what is left in `internal/ui` is rendering. So this is **additive only** — a new package plus a new subcommand, with no change to anything the dashboard runs, which retires the TUI-regression risk the epic flagged for this phase.

## What landed

`internal/api` and `stormlight serve`.

**Control plane** — JSON over HTTP: roster, dispatch, message, interrupt, mark, clear-attention, rename, delete, workspaces (list/add/remove/rename), providers, history, resume. Every handler is a decode, one `Service` call, and an encode; anything that wants to be cleverer belongs in `internal/app`, where the dashboard gets it too.

**Data plane** — one WebSocket per terminal, `AttachTerminal` relayed straight through. Binary messages are terminal bytes in both directions: the daemon's exact snapshot first (announced as state, so a client replaces its replica rather than appending), then live output, with keystrokes travelling back unwrapped. Text messages carry size and resync notices only — rare, and never in the typing path. Wrapping a keypress in JSON would put an encode, a decode and an allocation between a key and the process that answers it.

**Events** — a WebSocket that pushes the roster so no client polls. Backed for now by the same ~700ms refresh the dashboard already does, shared across every viewer and skipped entirely when nobody is connected. The client contract is "here is the roster", never "here is what happened", so moving to the daemon's own event feed later changes nothing visible.

**Security** — loopback bind, a per-run token required on every request and upgrade (no unauthenticated mode exists to ship by accident), and an `Origin` check on upgrades so a page the user merely visited cannot open a terminal just because the server is on localhost.

## Verification

Tests cover auth (missing/empty/wrong token, bearer form), the cross-origin refusal, the roster, the control plane reaching the runtime, unknown-field rejection, the terminal relay in both directions including resize, and the event stream. `go test -race ./...` green.

Beyond tests, per CLAUDE.md, the real thing: an isolated run (own `XDG_*`, own `WINDRUNNER_DIR`) with a custom shell provider, where an agent was **dispatched over the API**, then attached from **two WebSocket clients and the dashboard at once** — all three live on one daemon, each with its own exact seed, with input from a socket reaching the PTY and its echo reaching every viewer. Viewer A also received the resize notice when B attached, which is the shared-terminal path working end to end.

That run is what caught an empty roster serializing as `null` instead of `[]` — a real client would have broken on it — and a test that was reading my actual workspace catalog because it had not isolated `XDG_STATE_HOME`.

## Docs

`docs/architecture.md` gains an HTTP API layer, and `site/docs/architecture.html` is updated in the same PR with a matching sidebar anchor, per the drift rule in CLAUDE.md.

## Not in this PR

The frontend (`web/`, phase 3), the diff endpoint and structured transcript JSON (phase 4), the Wails wrap (phase 5). The resync attach from trentkm/windrunner#17 is wired for as soon as it lands: the seed notice already exists so a mid-stream resync has a way to reach a client.

🤖 Generated with [Claude Code](https://claude.com/claude-code)