### PR TITLE
A directory choice carries the machine it is on

### DIFF
--- a/internal/fleet/fleet.go
+++ b/internal/fleet/fleet.go
@@ -95,7 +95,7 @@ func (m *member) resolve() (session.Runtime, error) {
 	if m.runtime != nil {
 		return m.runtime, nil
 	}
-	if m.failure != nil && time.Since(m.failedAt) < retryAfter {
+	if m.failure != nil && time.Since(m.failedAt) < m.retryWindow() {
 		return nil, m.failure
 	}
 	runtime, err := m.connect()
@@ -107,6 +107,22 @@ func (m *member) resolve() (session.Runtime, error) {
 	m.runtime = runtime
 	m.failure = nil
 	return runtime, nil
+}
+
+// retryWindow is how long this member waits before trying again.
+//
+// The window exists because dialling costs something, and for a remote
+// host it costs an SSH handshake — a sleeping laptop must not be dialled
+// on every refresh. The local daemon costs a unix connect, and the
+// runtime that connects to it will start one if none is listening, so
+// there is nothing to protect against and everything to lose: a daemon
+// that died would otherwise leave the dashboard dark for half a minute
+// after it could have been back.
+func (m *member) retryWindow() time.Duration {
+	if m.host == "" {
+		return 0
+	}
+	return retryAfter
 }
 
 // drop forgets a connection so the next call rebuilds it. A tunnel dies

--- a/internal/fleet/fleet_test.go
+++ b/internal/fleet/fleet_test.go
@@ -344,3 +344,52 @@ func TestFileReadsFollowTheAgentToItsHost(t *testing.T) {
 			local.readPaths, devbox.readPaths)
 	}
 }
+
+// TestTheLocalDaemonIsRetriedImmediately: a daemon that died takes its
+// agents with it, and the runtime will start a new one on the next
+// connect. Holding the local member off for the remote retry window
+// leaves the dashboard dark for half a minute after it could have been
+// back — which is what a killed daemon looked like before this.
+func TestTheLocalDaemonIsRetriedImmediately(t *testing.T) {
+	healthy := &stub{agents: []agent.Agent{{ID: "aaa"}}}
+	connects := 0
+	f := New(Member{Host: "", Connect: func() (session.Runtime, error) {
+		connects++
+		if connects == 1 {
+			return nil, errors.New("dial unix: connection refused")
+		}
+		return healthy, nil
+	}})
+
+	if _, err := f.ListAgents(context.Background()); err == nil {
+		t.Fatal("the first refresh should report the daemon down")
+	}
+	agents, err := f.ListAgents(context.Background())
+	if err != nil {
+		t.Fatalf("the very next refresh should reconnect: %v", err)
+	}
+	if len(agents) != 1 || agents[0].ID != "aaa" {
+		t.Fatalf("agents = %+v", agents)
+	}
+}
+
+// TestARemoteHostStillWaits: the window earns its keep where dialling
+// costs an SSH handshake.
+func TestARemoteHostStillWaits(t *testing.T) {
+	attempts := 0
+	f := New(reachable("", &stub{}), Member{
+		Host: "devbox",
+		Connect: func() (session.Runtime, error) {
+			attempts++
+			return nil, errors.New("ssh: connection timed out")
+		},
+	})
+	for range 3 {
+		if _, err := f.ListAgents(context.Background()); err != nil {
+			t.Fatalf("ListAgents: %v", err)
+		}
+	}
+	if attempts != 1 {
+		t.Fatalf("dialled %d times; the window should hold it to 1", attempts)
+	}
+}

--- a/internal/ui/dispatch.go
+++ b/internal/ui/dispatch.go
@@ -695,6 +695,11 @@ func (m Model) renderDirectoryRow(
 ) string {
 	kind := strings.ToUpper(choice.workspaceKind)
 	detail := shortPath(choice.path)
+	if choice.host != "" {
+		// scp's own shorthand, and unambiguous: a bare path here would
+		// read as this machine's.
+		detail = choice.host + ":" + detail
+	}
 	switch choice.kind {
 	case directoryYazi:
 		kind = "YAZI"
@@ -702,6 +707,12 @@ func (m Model) renderDirectoryRow(
 	case directoryCustom:
 		kind = "PATH"
 		detail = "Enter a directory"
+		// A typed path inherits the machine the form is aimed at, so the
+		// row says which one rather than leaving it to be discovered
+		// after the agent starts somewhere else.
+		if m.dispatchHost != "" {
+			detail = m.dispatchHost + ": " + detail
+		}
 	}
 	if kind == "" {
 		kind = "DIRECTORY"
@@ -919,16 +930,16 @@ func (m *Model) blurForm() {
 	m.taskInput.Blur()
 }
 
-func (m *Model) prepareDirectoryChoices(preferred string) {
+func (m *Model) prepareDirectoryChoices(host, preferred string) {
 	m.pickerStart = preferred
 	choices := make([]directoryChoice, 0)
 	indexes := make(map[string]int)
-	addPath := func(path, label, workspaceKind string) int {
+	addPath := func(host, path, label, workspaceKind string) int {
 		path = strings.TrimSpace(path)
 		if path == "" {
 			return -1
 		}
-		key := directoryKey(path)
+		key := choiceKey(host, path)
 		if index, ok := indexes[key]; ok {
 			return index
 		}
@@ -936,6 +947,7 @@ func (m *Model) prepareDirectoryChoices(preferred string) {
 		indexes[key] = index
 		choices = append(choices, directoryChoice{
 			kind:          directoryPath,
+			host:          host,
 			label:         label,
 			path:          filepath.Clean(path),
 			workspaceKind: workspaceKind,
@@ -952,7 +964,7 @@ func (m *Model) prepareDirectoryChoices(preferred string) {
 		} else if directoryKey(value.ExecutionRoot) != directoryKey(value.Root) {
 			label += " / " + filepath.Base(value.ExecutionRoot)
 		}
-		addPath(value.ExecutionRoot, label, value.Kind)
+		addPath(value.Host, value.ExecutionRoot, label, value.Kind)
 	}
 
 	for _, group := range m.groups {
@@ -960,7 +972,7 @@ func (m *Model) prepareDirectoryChoices(preferred string) {
 		if groupRoot == "" {
 			groupRoot = group.context.Root
 		}
-		addPath(groupRoot, group.context.Name, group.context.Kind)
+		addPath(group.context.Host, groupRoot, group.context.Name, group.context.Kind)
 		for _, managedAgent := range group.agents {
 			value := effectiveWorkspace(managedAgent)
 			executionRoot := value.ExecutionRoot
@@ -975,7 +987,7 @@ func (m *Model) prepareDirectoryChoices(preferred string) {
 			} else if directoryKey(executionRoot) != directoryKey(groupRoot) {
 				label += " / " + filepath.Base(executionRoot)
 			}
-			addPath(executionRoot, label, value.Kind)
+			addPath(value.Host, executionRoot, label, value.Kind)
 			if value.ComponentRoot != "" &&
 				directoryKey(value.ComponentRoot) != directoryKey(executionRoot) {
 				component := value.ComponentName
@@ -983,6 +995,7 @@ func (m *Model) prepareDirectoryChoices(preferred string) {
 					component = filepath.Base(value.ComponentRoot)
 				}
 				addPath(
+					value.Host,
 					value.ComponentRoot,
 					value.Name+" / "+component,
 					value.Kind,
@@ -992,6 +1005,7 @@ func (m *Model) prepareDirectoryChoices(preferred string) {
 				directoryKey(managedAgent.Cwd) != directoryKey(executionRoot) &&
 				directoryKey(managedAgent.Cwd) != directoryKey(value.ComponentRoot) {
 				addPath(
+					managedAgent.Host,
 					managedAgent.Cwd,
 					value.Name+" / "+filepath.Base(managedAgent.Cwd),
 					value.Kind,
@@ -1000,7 +1014,9 @@ func (m *Model) prepareDirectoryChoices(preferred string) {
 		}
 	}
 
+	// The directory the dashboard was started in is always this machine's.
 	currentIndex := addPath(
+		"",
 		m.initialCwd,
 		filepath.Base(filepath.Clean(m.initialCwd))+" (current)",
 		workspace.KindDirectory,
@@ -1011,17 +1027,17 @@ func (m *Model) prepareDirectoryChoices(preferred string) {
 		choices[currentIndex].label += " (current)"
 	}
 
-	preferredKey := directoryKey(preferred)
-	preferredIndex, ok := indexes[preferredKey]
+	preferredIndex, ok := indexes[choiceKey(host, preferred)]
 	if !ok {
 		preferredIndex = addPath(
+			host,
 			preferred,
 			"Selected / "+filepath.Base(filepath.Clean(preferred)),
 			workspace.KindDirectory,
 		)
 	}
 	if len(choices) == 0 {
-		preferredIndex = addPath(m.initialCwd, "Current", workspace.KindDirectory)
+		preferredIndex = addPath("", m.initialCwd, "Current", workspace.KindDirectory)
 	}
 	if m.yaziPath != "" {
 		choices = append(choices, directoryChoice{
@@ -1036,10 +1052,20 @@ func (m *Model) prepareDirectoryChoices(preferred string) {
 
 	m.directories = choices
 	m.directoryIndex = clamp(preferredIndex, 0, max(0, len(choices)-1))
-	if selected, ok := m.selectedDirectory(); ok && selected.kind == directoryPath {
-		m.cwdInput.SetValue(selected.path)
-		m.pickerStart = selected.path
+	m.adoptSelectedDirectory()
+}
+
+// adoptSelectedDirectory moves the highlighted choice into the form. The
+// host moves with it: a path and the machine it is on are one answer, and
+// carrying half of it is how an agent lands on the wrong box.
+func (m *Model) adoptSelectedDirectory() {
+	selected, ok := m.selectedDirectory()
+	if !ok || selected.kind != directoryPath {
+		return
 	}
+	m.cwdInput.SetValue(selected.path)
+	m.pickerStart = selected.path
+	m.dispatchHost = selected.host
 }
 
 func (m *Model) prepareAddWorkspaceChoices(start string) {
@@ -1077,10 +1103,7 @@ func (m *Model) selectDirectoryIndex(index int) {
 		return
 	}
 	m.directoryIndex = clamp(index, 0, len(m.directories)-1)
-	if selected, ok := m.selectedDirectory(); ok && selected.kind == directoryPath {
-		m.cwdInput.SetValue(selected.path)
-		m.pickerStart = selected.path
-	}
+	m.adoptSelectedDirectory()
 }
 
 func (m *Model) editSelectedDirectory() {
@@ -1169,12 +1192,17 @@ func (m Model) submitDispatch() (tea.Model, tea.Cmd) {
 		Cwd:      strings.TrimSpace(m.cwdInput.Value()),
 		Task:     strings.TrimSpace(m.taskInput.Value()),
 		Mode:     m.dispatchMode,
+		Host:     m.dispatchHost,
 	}
 	if request.Task == "" {
 		m.err = fmt.Errorf("task cannot be empty")
 		return m, nil
 	}
-	if !isDirectory(request.Cwd) {
+	// Only this machine's directories can be checked here. On another
+	// machine the answer would be about the wrong filesystem — and a
+	// path that happens to exist here too would pass for the wrong
+	// reason. That host resolves it, and says so if it cannot.
+	if request.Host == "" && !isDirectory(request.Cwd) {
 		m.err = fmt.Errorf("working directory is unavailable: %s", request.Cwd)
 		return m, nil
 	}
@@ -1194,9 +1222,13 @@ func (m Model) selectedDirectory() (directoryChoice, bool) {
 
 func (m Model) beginDispatch(chooseDirectory bool) (tea.Model, tea.Cmd) {
 	directory := m.initialCwd
+	// The form opens on the machine whatever it opened from is on: the
+	// selected workspace, the selected agent, or failing both, this one.
+	host := ""
 	selectedWorkspace, hasWorkspace := m.selectedWorkspace()
 	if hasWorkspace {
 		selected := selectedWorkspace
+		host = selected.Host
 		directory = selected.ExecutionRoot
 		if directory == "" {
 			directory = selected.Root
@@ -1207,17 +1239,19 @@ func (m Model) beginDispatch(chooseDirectory bool) (tea.Model, tea.Cmd) {
 	}
 	if selected, ok := m.selectedAgent(); ok &&
 		(chooseDirectory || m.activePane == paneInteraction) {
+		host = selected.Host
 		directory = selected.Cwd
 	}
+	m.dispatchHost = host
 	m.chooseDispatchDirectory = chooseDirectory
 	if chooseDirectory {
-		m.prepareDirectoryChoices(directory)
+		m.prepareDirectoryChoices(host, directory)
 		m.formFocus = dispatchDirectory
 	} else {
 		m.cwdInput.SetValue(directory)
 		m.formFocus = dispatchProvider
 	}
-	m.applyDispatchOverrides(directory)
+	m.applyDispatchOverrides(host, directory)
 	m.mode = modeDispatch
 	m.dispatchPrefix = ""
 	m.focusForm()
@@ -1229,7 +1263,14 @@ func (m Model) beginDispatch(chooseDirectory bool) (tea.Model, tea.Cmd) {
 // applyDispatchOverrides applies per-workspace config defaults for the
 // directory the form opens in. The user's in-form choices still win — this
 // only presets the fields.
-func (m *Model) applyDispatchOverrides(directory string) {
+//
+// They are keyed by directories in this machine's config, so they say
+// nothing about a path on another machine — where the same string is a
+// different repository.
+func (m *Model) applyDispatchOverrides(host, directory string) {
+	if host != "" {
+		return
+	}
 	if m.modeForDir != nil {
 		if mode, ok := m.modeForDir(directory); ok {
 			m.dispatchMode = mode

--- a/internal/ui/input_test.go
+++ b/internal/ui/input_test.go
@@ -269,7 +269,7 @@ func TestDispatchViewFitsEightyColumnTmuxPane(t *testing.T) {
 	}
 	model := NewModel(backend)
 	model.yaziPath = "/opt/homebrew/bin/yazi"
-	model.prepareDirectoryChoices(model.initialCwd)
+	model.prepareDirectoryChoices("", model.initialCwd)
 	updated, _ := model.Update(tea.WindowSizeMsg{Width: 80, Height: 24})
 	model = updated.(Model)
 	model.mode = modeDispatch
@@ -298,7 +298,7 @@ func TestDispatchCustomPathFitsShortPane(t *testing.T) {
 	} {
 		model := NewModel(stubBackend{})
 		model.yaziPath = "/opt/homebrew/bin/yazi"
-		model.prepareDirectoryChoices(model.initialCwd)
+		model.prepareDirectoryChoices("", model.initialCwd)
 		for index, choice := range model.directories {
 			if choice.kind == directoryCustom {
 				model.directoryIndex = index
@@ -626,7 +626,7 @@ func TestDispatchFormFitsEveryHeight(t *testing.T) {
 				model := dispatchTaskFixture(t, width, height)
 				model.chooseDispatchDirectory = picker
 				if picker {
-					model.prepareDirectoryChoices(model.initialCwd)
+					model.prepareDirectoryChoices("", model.initialCwd)
 					model.directoryIndex = 0
 				}
 				model.syncTaskComposerSize()
@@ -669,7 +669,7 @@ func TestDispatchNameSurvivesAnExtraDirectoryRow(t *testing.T) {
 		model := dispatchTaskFixture(t, 100, 30)
 		model.chooseDispatchDirectory = true
 		model.yaziPath = yazi
-		model.prepareDirectoryChoices(model.initialCwd)
+		model.prepareDirectoryChoices("", model.initialCwd)
 		model.syncTaskComposerSize()
 
 		if !model.dispatchNameVisible() {
@@ -1262,7 +1262,7 @@ func TestNewAgentUsesSelectedWorkspaceWithoutDirectoryStep(t *testing.T) {
 func TestDispatchLocationUsesVimNavigation(t *testing.T) {
 	model := NewModel(stubBackend{})
 	model.yaziPath = "/opt/homebrew/bin/yazi"
-	model.prepareDirectoryChoices(model.initialCwd)
+	model.prepareDirectoryChoices("", model.initialCwd)
 	model.mode = modeDispatch
 	model.chooseDispatchDirectory = true
 	model.formFocus = dispatchDirectory
@@ -1297,7 +1297,7 @@ func TestDirectorySelectorUpdatesPathAndPickerResult(t *testing.T) {
 	model := NewModel(stubBackend{})
 	model.initialCwd = current
 	model.yaziPath = "/opt/homebrew/bin/yazi"
-	model.prepareDirectoryChoices(current)
+	model.prepareDirectoryChoices("", current)
 	model.mode = modeDispatch
 	model.chooseDispatchDirectory = true
 	model.formFocus = dispatchDirectory
@@ -2432,7 +2432,7 @@ func TestDirectoryPickerIncludesDiscoveredExecutionRoots(t *testing.T) {
 	}
 	model := NewModel(&recordingBackend{})
 	model.workspaceRoots = []workspace.Context{primary, linked}
-	model.prepareDirectoryChoices(root)
+	model.prepareDirectoryChoices("", root)
 
 	labels := make(map[string]string)
 	for _, choice := range model.directories {

--- a/internal/ui/model.go
+++ b/internal/ui/model.go
@@ -110,7 +110,10 @@ const (
 )
 
 type directoryChoice struct {
-	kind          directoryChoiceKind
+	kind directoryChoiceKind
+	// host is the machine the path is on; empty is this one. Two
+	// machines can offer the same path, and they are different choices.
+	host          string
 	label         string
 	path          string
 	workspaceKind string
@@ -133,14 +136,18 @@ type Model struct {
 	catalogWorkspaces []workspace.Context
 	workspaceRoots    []workspace.Context
 	groups            []workspaceGroup
-	workspaceCursor   int
-	agentCursor       int
-	activePane        pane
-	rowsExpanded      bool
-	interaction       viewport.Model
-	width             int
-	height            int
-	ready             bool
+	// dispatchHost is the machine the open dispatch form is aimed at. It
+	// travels with the directory rather than being asked for separately:
+	// a path only means anything alongside the machine it is on.
+	dispatchHost    string
+	workspaceCursor int
+	agentCursor     int
+	activePane      pane
+	rowsExpanded    bool
+	interaction     viewport.Model
+	width           int
+	height          int
+	ready           bool
 
 	mode                    mode
 	formFocus               dispatchFocus
@@ -347,7 +354,7 @@ func NewModelWithOptions(backend Backend, options Options) Model {
 			break
 		}
 	}
-	model.prepareDirectoryChoices(cwd)
+	model.prepareDirectoryChoices("", cwd)
 	return model
 }
 
@@ -569,7 +576,8 @@ func (m Model) Update(message tea.Msg) (tea.Model, tea.Cmd) {
 			m.cwdInput.SetValue(msg.path)
 			return m, addWorkspaceCmd(m.backend, msg.path)
 		}
-		m.prepareDirectoryChoices(msg.path)
+		// The picker runs on this machine, so what it returns is here.
+		m.prepareDirectoryChoices("", msg.path)
 		m.cwdInput.SetValue(msg.path)
 		m.formFocus = dispatchTask
 		m.focusForm()

--- a/internal/ui/overlays.go
+++ b/internal/ui/overlays.go
@@ -372,6 +372,14 @@ func firstYaziPath(data []byte) string {
 	return ""
 }
 
+// choiceKey identifies a directory choice. The host is part of it: the
+// same path on two machines is two different places to start an agent,
+// and folding them together would offer one row that runs on whichever
+// happened to be listed first.
+func choiceKey(host, path string) string {
+	return host + "\x00" + directoryKey(path)
+}
+
 func directoryKey(path string) string {
 	path = strings.TrimSpace(path)
 	if path == "" {

--- a/internal/ui/remote_dispatch_test.go
+++ b/internal/ui/remote_dispatch_test.go
@@ -1,0 +1,174 @@
+package ui
+
+import (
+	"strings"
+	"testing"
+
+	tea "charm.land/bubbletea/v2"
+
+	"github.com/trentkm/stormlight/internal/agent"
+	"github.com/trentkm/stormlight/internal/provider"
+	"github.com/trentkm/stormlight/internal/workspace"
+)
+
+// remoteDispatchFixture is a model whose text inputs are real: the dispatch
+// form drives a textarea, and a zero Model has none.
+func remoteDispatchFixture(t *testing.T, backend Backend) Model {
+	t.Helper()
+	model := NewModel(backend)
+	model.ptyEnabled = false
+	updated, _ := model.Update(tea.WindowSizeMsg{Width: 100, Height: 30})
+	model = updated.(Model)
+	model.providers = []provider.Info{{ID: agent.Provider("claude"), Label: "Claude"}}
+	model.providerIndex = 0
+	return model
+}
+
+func localWorkspace(root string) workspace.Context {
+	return workspace.Context{
+		ID: "git:" + root + "/.git", Kind: "git", Name: "api",
+		Root: root, ExecutionRoot: root,
+	}
+}
+
+func remoteWorkspace(host, root string) workspace.Context {
+	value := localWorkspace(root)
+	value.Host = host
+	value.ID = host + ":" + value.ID
+	return value
+}
+
+// TestTheSamePathOnTwoMachinesIsTwoChoices: folding them together would
+// offer one row that starts an agent on whichever host happened to be
+// listed first — and both rows look identical while it happens.
+func TestTheSamePathOnTwoMachinesIsTwoChoices(t *testing.T) {
+	model := remoteDispatchFixture(t, &recordingBackend{})
+	model.workspaceRoots = []workspace.Context{
+		localWorkspace("/srv/api"),
+		remoteWorkspace("devbox", "/srv/api"),
+	}
+	model.initialCwd = "/srv/api"
+	model.prepareDirectoryChoices("", "/srv/api")
+
+	hosts := map[string]bool{}
+	for _, choice := range model.directories {
+		if choice.kind == directoryPath && choice.path == "/srv/api" {
+			hosts[choice.host] = true
+		}
+	}
+	if !hosts[""] || !hosts["devbox"] {
+		t.Fatalf("both machines' /srv/api should be offered: %+v", model.directories)
+	}
+}
+
+// TestDispatchCarriesTheChosenMachine: a path and the machine it is on
+// are one answer. Carrying half of it starts the agent on the wrong box,
+// in a directory that may well exist there.
+func TestDispatchCarriesTheChosenMachine(t *testing.T) {
+	backend := &recordingBackend{}
+	model := remoteDispatchFixture(t, backend)
+	model.workspaceRoots = []workspace.Context{remoteWorkspace("devbox", "/srv/api")}
+	model.initialCwd = "/srv/api"
+	model.prepareDirectoryChoices("devbox", "/srv/api")
+	if model.dispatchHost != "devbox" {
+		t.Fatalf("the form should be aimed at devbox: %q", model.dispatchHost)
+	}
+	model.taskInput.SetValue("fix the flaky test")
+
+	if _, cmd := model.submitDispatch(); cmd == nil {
+		t.Fatalf("dispatch was refused: %v", model.err)
+	} else {
+		cmd()
+	}
+	if backend.request.Host != "devbox" {
+		t.Fatalf("dispatch host = %q, want devbox", backend.request.Host)
+	}
+	if backend.request.Cwd != "/srv/api" {
+		t.Fatalf("dispatch cwd = %q", backend.request.Cwd)
+	}
+}
+
+// TestARemotePathIsNotCheckedAgainstThisFilesystem: /srv/api need not
+// exist here, and the check that it does would either refuse a perfectly
+// good dispatch or — worse — pass because something else lives there.
+func TestARemotePathIsNotCheckedAgainstThisFilesystem(t *testing.T) {
+	backend := &recordingBackend{}
+	model := remoteDispatchFixture(t, backend)
+	model.dispatchHost = "devbox"
+	model.cwdInput.SetValue("/nowhere/near/this/machine")
+	model.taskInput.SetValue("prove it")
+
+	_, cmd := model.submitDispatch()
+	if cmd == nil {
+		t.Fatalf("a remote path must not be refused for being absent here: %v", model.err)
+	}
+	cmd()
+	if backend.request.Cwd != "/nowhere/near/this/machine" {
+		t.Fatalf("cwd = %q", backend.request.Cwd)
+	}
+
+	// The same path with no host is this machine's, and is checked.
+	model.dispatchHost = ""
+	next, cmd := model.submitDispatch()
+	if cmd != nil {
+		t.Fatal("a local path that does not exist should be refused")
+	}
+	if next.(Model).err == nil {
+		t.Fatal("refusing a missing local directory should say so")
+	}
+}
+
+// TestARemoteRowSaysWhichMachine: two rows reading "api  GIT  /srv/api"
+// are the same row as far as anyone can tell.
+func TestARemoteRowSaysWhichMachine(t *testing.T) {
+	model := remoteDispatchFixture(t, &recordingBackend{})
+	remote := model.renderDirectoryRow(
+		directoryChoice{kind: directoryPath, host: "devbox",
+			label: "api", path: "/srv/api", workspaceKind: "git"},
+		false, 80,
+	)
+	if !strings.Contains(remote, "devbox:") {
+		t.Fatalf("a remote row should name its machine: %q", remote)
+	}
+	local := model.renderDirectoryRow(
+		directoryChoice{kind: directoryPath,
+			label: "api", path: "/srv/api", workspaceKind: "git"},
+		false, 80,
+	)
+	if strings.Contains(local, "devbox") {
+		t.Fatalf("a local row should say nothing about hosts: %q", local)
+	}
+
+	// A typed path inherits the machine the form is aimed at, so the row
+	// says so rather than leaving it to be discovered afterwards.
+	model.dispatchHost = "devbox"
+	custom := model.renderDirectoryRow(
+		directoryChoice{kind: directoryCustom, label: "Enter a path"}, false, 80)
+	if !strings.Contains(custom, "devbox") {
+		t.Fatalf("the typed-path row should name the machine it would use: %q", custom)
+	}
+}
+
+// TestPerDirectoryOverridesStayLocal: the [workspaces."/path"] table is
+// keyed by directories in this machine's config, so it says nothing about
+// the same string on another machine.
+func TestPerDirectoryOverridesStayLocal(t *testing.T) {
+	model := remoteDispatchFixture(t, &recordingBackend{})
+	model.providers = []provider.Info{
+		{ID: agent.Provider("codex"), Label: "Codex"},
+		{ID: agent.Provider("claude"), Label: "Claude"},
+	}
+	model.providerForDir = func(string) (agent.Provider, bool) {
+		return agent.Provider("claude"), true
+	}
+	model.applyDispatchOverrides("", "/srv/api")
+	if model.providers[model.providerIndex].ID != agent.Provider("claude") {
+		t.Fatal("a local directory's override should apply")
+	}
+
+	model.providerIndex = 0
+	model.applyDispatchOverrides("devbox", "/srv/api")
+	if model.providers[model.providerIndex].ID != agent.Provider("codex") {
+		t.Fatal("another machine's path must not take this machine's override")
+	}
+}


### PR DESCRIPTION
Phase 5a of #127. Dispatching to another machine worked from the CLI and
nowhere else.

The dashboard's new-agent form asked for a path and nothing more, so a remote
workspace could be selected in the roster and the agent it started landed
*here* — in whatever happened to be at that path, if anything.

## The host travels with the directory

A path and the machine it is on are one answer, so it is never asked for
separately. Every choice carries the host — workspace roots, group roots,
component roots, an agent's own cwd — and so does the choice key: `/srv/api`
here and `/srv/api` on `devbox` are two places to start an agent, and folding
them into one row would run on whichever was listed first with nothing on
screen to say which.

Rows name their machine the way `scp` does (`devbox:/srv/api`), and the typed-
path row says which machine it will inherit rather than leaving that to be
discovered after the agent starts somewhere else.

Two checks become local-only, both for the reason this epic keeps running
into: the existence check (on another machine it answers about the wrong
filesystem, and a path that happens to exist here too passes for the wrong
reason), and per-directory config overrides (`[workspaces."/path"]` is keyed
by directories in *this* machine's config).

## A fix from running it

A daemon that dies takes its agents with it, and the runtime that reconnects
will start a new one — but the fleet's retry window held the *local* member
off for thirty seconds either way, so a dashboard whose daemon died stayed
dark long after it could have been back. I hit this while driving the UI and
watched it repeat "broken pipe" every 700ms for the full window.

The window exists because dialling costs something, and for a remote host that
is an SSH handshake. A unix connect costs nothing, and the local runtime will
start a daemon if none is listening. It now applies where the cost is.

## Testing

`go test ./...` and `go vet ./...` green; fleet tests also under `-race`. New
coverage: the same path on two machines is two choices; dispatch carries the
chosen machine; a remote path is not checked against this filesystem (and the
same path with no host still is); a remote row names its machine and a local
one does not; per-directory overrides stay local; the local daemon is retried
on the very next refresh while a remote host still waits.

**In the dashboard**: with a local and a remote workspace catalogued, the
picker lists both and labels the remote one, and agents dispatched from each
row land on that row's daemon — confirmed against both daemons' own session
lists, in both directions.

**Non-regression** (#125 guardrail, since this touches `internal/ui`): branch
and `main` built and driven through the tmux harness to the *open dispatch
picker*, and the `capture-pane` dumps are byte-identical.

## Still open in #127

The Yazi picker itself still browses this machine, so *adding* a workspace on
another host is CLI-only (`workspace add --host`). Running the picker remotely
needs an answer channel for overlay results, which is the next piece. Also
open: per-host history and resume, and `remote add`.
