### PR TITLE
A host is known because something names it

### DIFF
--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -205,8 +205,17 @@ agent's host is discovered by asking rather than remembered, so ownership
 is rebuilt from every listing and never persisted anywhere.
 
 Dispatch follows the workspace it resolved: the context already names the
-machine, because resolution happened there. Hosts are configured under
-`[hosts.<name>]`, and the name is what qualifies workspace IDs.
+machine, because resolution happened there. The name is also what
+qualifies workspace IDs.
+
+A host is known because something names it, not because it was
+configured: a workspace on it, a dispatch aimed at it, a name picked out
+of `~/.ssh/config`. Members exist at start-up for the machines the
+catalog says hold a workspace — listing names no host, so without that a
+machine's agents would be invisible until something mentioned one — and
+any other joins the moment it is first named. `[hosts.<name>]` is where a
+machine differs from its name: a different destination, a binary a
+non-interactive shell will not find, extra ssh flags.
 
 #### The terminal seam
 

--- a/docs/config-design.md
+++ b/docs/config-design.md
@@ -104,9 +104,12 @@ provider = "claude"
 # [providers.aider.mode_args]
 # auto = ["--yes-always"]
 
-# Other machines this dashboard works. Each runs its own daemon and its
-# own agents, reached over SSH; the key is the name Stormlight calls it,
-# and what qualifies the workspace IDs of everything running there.
+# How a machine differs from its name. A host does not have to appear
+# here to be used — naming one is enough, and ssh already knows what a
+# name means. This is where a host needs something other than the
+# default: a different destination, a binary somewhere unusual, extra
+# ssh flags. Names come from ~/.ssh/config, from the workspaces you have
+# on them, or from you typing one.
 [hosts.devbox]
 # destination  = "trent@10.0.0.4"  # defaults to the key; an ssh_config
 #                                  # alias or a tailnet name works too

--- a/internal/fleet/fleet.go
+++ b/internal/fleet/fleet.go
@@ -18,6 +18,7 @@ import (
 	"context"
 	"fmt"
 	"io"
+	"slices"
 	"sync"
 	"time"
 
@@ -51,23 +52,44 @@ type member struct {
 	failedAt time.Time
 }
 
+// Discover supplies a member for a host that was not passed to New.
+//
+// A host is known because something names it — a workspace on it, a
+// dispatch aimed at it, an entry in the user's SSH configuration — not
+// because it was configured. Configuration says how to reach a host
+// differently from the default; it is not the list of them. A nil
+// Discover means only the members given to New exist.
+type Discover func(host string) Member
+
 // Runtime fans one session.Runtime out over several daemons.
 type Runtime struct {
-	members []*member
+	discover Discover
 
+	// mu guards both the member list and the ownership cache. Members
+	// arrive while the dashboard is running, the moment a host is first
+	// named.
+	mu      sync.RWMutex
+	members []*member
 	// owner maps an agent to the member that last answered for it. It is
 	// a cache of the last listing, not a record: an agent that has moved
 	// or vanished is corrected by the next one.
-	mu    sync.RWMutex
 	owner map[string]*member
 }
 
-func New(members ...Member) *Runtime {
-	fleet := &Runtime{owner: make(map[string]*member)}
+func New(discover Discover, members ...Member) *Runtime {
+	fleet := &Runtime{discover: discover, owner: make(map[string]*member)}
 	for _, m := range members {
 		fleet.members = append(fleet.members, &member{host: m.Host, connect: m.Connect})
 	}
 	return fleet
+}
+
+// roster is the current member list, copied so a caller can range over it
+// while another goroutine adds a host.
+func (f *Runtime) roster() []*member {
+	f.mu.RLock()
+	defer f.mu.RUnlock()
+	return slices.Clone(f.members)
 }
 
 // Status is one member's reachability, for a dashboard that wants to say
@@ -78,8 +100,9 @@ type Status struct {
 }
 
 func (f *Runtime) Status() []Status {
-	statuses := make([]Status, 0, len(f.members))
-	for _, m := range f.members {
+	members := f.roster()
+	statuses := make([]Status, 0, len(members))
+	for _, m := range members {
 		m.mu.Lock()
 		statuses = append(statuses, Status{Host: m.host, Error: m.failure})
 		m.mu.Unlock()
@@ -142,9 +165,10 @@ func (f *Runtime) ListAgents(ctx context.Context) ([]agent.Agent, error) {
 		agents []agent.Agent
 		err    error
 	}
-	results := make([]result, len(f.members))
+	members := f.roster()
+	results := make([]result, len(members))
 	var wait sync.WaitGroup
-	for index, m := range f.members {
+	for index, m := range members {
 		wait.Add(1)
 		go func() {
 			defer wait.Done()
@@ -191,7 +215,7 @@ func (f *Runtime) ListAgents(ctx context.Context) ([]agent.Agent, error) {
 	// A host being down is its own absence, not the dashboard's failure —
 	// unless every host is, in which case there is nothing to show and
 	// saying so beats an empty roster that looks like an idle morning.
-	if len(failures) == len(f.members) && len(failures) > 0 {
+	if len(failures) == len(members) && len(failures) > 0 {
 		return nil, failures[0]
 	}
 	return agents, nil
@@ -201,8 +225,8 @@ func (f *Runtime) ListAgents(ctx context.Context) ([]agent.Agent, error) {
 // an agent dispatched a moment ago has not been listed yet, so the roster
 // is refreshed once before giving up.
 func (f *Runtime) memberFor(ctx context.Context, id string) (session.Runtime, error) {
-	if len(f.members) == 1 {
-		return f.members[0].resolve()
+	if members := f.roster(); len(members) == 1 {
+		return members[0].resolve()
 	}
 	if runtime, ok := f.lookup(id); ok {
 		return runtime, nil
@@ -247,13 +271,27 @@ func (f *Runtime) lookup(id string) (session.Runtime, bool) {
 
 // hostFor is memberFor by host name rather than by agent: dispatch names
 // the machine it means through the workspace it resolved.
+//
+// A host nobody has mentioned before joins the fleet here. Nothing else
+// needs to have heard of it — naming it is what makes it real, and
+// whether it answers is between it and ssh.
 func (f *Runtime) hostFor(host string) (session.Runtime, error) {
+	f.mu.Lock()
 	for _, m := range f.members {
 		if m.host == host {
+			f.mu.Unlock()
 			return m.resolve()
 		}
 	}
-	return nil, fmt.Errorf("no host named %q", hostName(host))
+	if f.discover == nil {
+		f.mu.Unlock()
+		return nil, fmt.Errorf("no host named %q", hostName(host))
+	}
+	discovered := f.discover(host)
+	joined := &member{host: host, connect: discovered.Connect}
+	f.members = append(f.members, joined)
+	f.mu.Unlock()
+	return joined.resolve()
 }
 
 func hostName(host string) string {

--- a/internal/fleet/fleet_test.go
+++ b/internal/fleet/fleet_test.go
@@ -95,7 +95,7 @@ func unreachable(host string, err error) Member {
 func TestRosterMergesAndStampsTheHost(t *testing.T) {
 	local := &stub{agents: []agent.Agent{{ID: "aaa"}}}
 	devbox := &stub{agents: []agent.Agent{{ID: "bbb"}, {ID: "ccc"}}}
-	f := New(reachable("", local), reachable("devbox", devbox))
+	f := New(nil, reachable("", local), reachable("devbox", devbox))
 
 	agents, err := f.ListAgents(context.Background())
 	if err != nil {
@@ -118,7 +118,7 @@ func TestRosterMergesAndStampsTheHost(t *testing.T) {
 // failure, and none of them may hide the agents that are still there.
 func TestAnUnreachableHostIsItsOwnAbsence(t *testing.T) {
 	local := &stub{agents: []agent.Agent{{ID: "aaa"}}}
-	f := New(reachable("", local), unreachable("devbox", errors.New("ssh: no route to host")))
+	f := New(nil, reachable("", local), unreachable("devbox", errors.New("ssh: no route to host")))
 
 	agents, err := f.ListAgents(context.Background())
 	if err != nil {
@@ -144,8 +144,7 @@ func TestAnUnreachableHostIsItsOwnAbsence(t *testing.T) {
 // TestEveryHostDownIsAnError: an empty roster reads as a quiet morning.
 // When nothing could be reached, say so.
 func TestEveryHostDownIsAnError(t *testing.T) {
-	f := New(
-		unreachable("", errors.New("no daemon")),
+	f := New(nil, unreachable("", errors.New("no daemon")),
 		unreachable("devbox", errors.New("ssh: no route to host")),
 	)
 	if _, err := f.ListAgents(context.Background()); err == nil {
@@ -159,7 +158,7 @@ func TestEveryHostDownIsAnError(t *testing.T) {
 func TestOperationsFollowTheAgentToItsHost(t *testing.T) {
 	local := &stub{agents: []agent.Agent{{ID: "aaa"}}}
 	devbox := &stub{agents: []agent.Agent{{ID: "bbb"}}}
-	f := New(reachable("", local), reachable("devbox", devbox))
+	f := New(nil, reachable("", local), reachable("devbox", devbox))
 
 	if err := f.Send(context.Background(), "bbb", "hello"); err != nil {
 		t.Fatalf("Send: %v", err)
@@ -181,7 +180,7 @@ func TestOperationsFollowTheAgentToItsHost(t *testing.T) {
 func TestAnAgentNobodyHasListedIsStillFound(t *testing.T) {
 	local := &stub{}
 	devbox := &stub{agents: []agent.Agent{{ID: "bbb"}}}
-	f := New(reachable("", local), reachable("devbox", devbox))
+	f := New(nil, reachable("", local), reachable("devbox", devbox))
 
 	// No ListAgents has been called, so ownership is unknown.
 	if err := f.Send(context.Background(), "bbb", "hello"); err != nil {
@@ -200,7 +199,7 @@ func TestAnAgentNobodyHasListedIsStillFound(t *testing.T) {
 func TestAPrefixNamesAnAgentAcrossHosts(t *testing.T) {
 	local := &stub{agents: []agent.Agent{{ID: "aaa11111"}}}
 	devbox := &stub{agents: []agent.Agent{{ID: "bbb22222"}}}
-	f := New(reachable("", local), reachable("devbox", devbox))
+	f := New(nil, reachable("", local), reachable("devbox", devbox))
 	if _, err := f.ListAgents(context.Background()); err != nil {
 		t.Fatalf("ListAgents: %v", err)
 	}
@@ -218,7 +217,7 @@ func TestAPrefixNamesAnAgentAcrossHosts(t *testing.T) {
 func TestDispatchFollowsTheWorkspace(t *testing.T) {
 	local := &stub{}
 	devbox := &stub{}
-	f := New(reachable("", local), reachable("devbox", devbox))
+	f := New(nil, reachable("", local), reachable("devbox", devbox))
 
 	dispatched, err := f.Dispatch(context.Background(), session.DispatchRequest{
 		Cwd:       "/srv/api",
@@ -247,8 +246,7 @@ func TestDispatchFollowsTheWorkspace(t *testing.T) {
 // stall the user feels on every frame.
 func TestAFailedHostIsNotDialledEveryRefresh(t *testing.T) {
 	attempts := 0
-	f := New(
-		reachable("", &stub{}),
+	f := New(nil, reachable("", &stub{}),
 		Member{Host: "devbox", Connect: func() (session.Runtime, error) {
 			attempts++
 			return nil, errors.New("ssh: connection timed out")
@@ -271,8 +269,7 @@ func TestALostConnectionIsRebuilt(t *testing.T) {
 	broken := &stub{listErr: errors.New("broken pipe")}
 	healthy := &stub{agents: []agent.Agent{{ID: "bbb"}}}
 	connects := 0
-	f := New(
-		reachable("", &stub{}),
+	f := New(nil, reachable("", &stub{}),
 		Member{Host: "devbox", Connect: func() (session.Runtime, error) {
 			connects++
 			if connects == 1 {
@@ -306,7 +303,7 @@ func TestALostConnectionIsRebuilt(t *testing.T) {
 // straight through without a listing.
 func TestAFleetOfOneIsJustTheRuntime(t *testing.T) {
 	local := &stub{}
-	f := New(reachable("", local))
+	f := New(nil, reachable("", local))
 
 	if err := f.Send(context.Background(), "aaa", "hello"); err != nil {
 		t.Fatalf("Send: %v", err)
@@ -325,7 +322,7 @@ func TestAFleetOfOneIsJustTheRuntime(t *testing.T) {
 func TestFileReadsFollowTheAgentToItsHost(t *testing.T) {
 	local := &stub{agents: []agent.Agent{{ID: "aaa"}}}
 	devbox := &stub{agents: []agent.Agent{{ID: "bbb"}}}
-	f := New(reachable("", local), reachable("devbox", devbox))
+	f := New(nil, reachable("", local), reachable("devbox", devbox))
 
 	source, err := f.ReadAgentFile(context.Background(), "bbb", "/home/trent/t.jsonl")
 	if err != nil {
@@ -353,7 +350,7 @@ func TestFileReadsFollowTheAgentToItsHost(t *testing.T) {
 func TestTheLocalDaemonIsRetriedImmediately(t *testing.T) {
 	healthy := &stub{agents: []agent.Agent{{ID: "aaa"}}}
 	connects := 0
-	f := New(Member{Host: "", Connect: func() (session.Runtime, error) {
+	f := New(nil, Member{Host: "", Connect: func() (session.Runtime, error) {
 		connects++
 		if connects == 1 {
 			return nil, errors.New("dial unix: connection refused")
@@ -377,7 +374,7 @@ func TestTheLocalDaemonIsRetriedImmediately(t *testing.T) {
 // costs an SSH handshake.
 func TestARemoteHostStillWaits(t *testing.T) {
 	attempts := 0
-	f := New(reachable("", &stub{}), Member{
+	f := New(nil, reachable("", &stub{}), Member{
 		Host: "devbox",
 		Connect: func() (session.Runtime, error) {
 			attempts++
@@ -391,5 +388,67 @@ func TestARemoteHostStillWaits(t *testing.T) {
 	}
 	if attempts != 1 {
 		t.Fatalf("dialled %d times; the window should hold it to 1", attempts)
+	}
+}
+
+// TestAHostJoinsWhenSomethingNamesIt: a machine picked out of
+// ~/.ssh/config, or named by a workspace added while the dashboard was
+// running, has to work without a restart and without being configured.
+// Configuration says how a host differs from its name — it is not the
+// list of which hosts there are.
+func TestAHostJoinsWhenSomethingNamesIt(t *testing.T) {
+	discovered := &stub{}
+	asked := []string{}
+	f := New(
+		func(host string) Member {
+			asked = append(asked, host)
+			return reachable(host, discovered)
+		},
+		reachable("", &stub{}),
+	)
+
+	_, err := f.Dispatch(context.Background(), session.DispatchRequest{
+		Workspace: workspace.Context{Host: "devbox"},
+	})
+	if err != nil {
+		t.Fatalf("Dispatch to an undeclared host: %v", err)
+	}
+	if len(discovered.launched) != 1 {
+		t.Fatalf("the discovered host should have run it: %+v", discovered.launched)
+	}
+	if len(asked) != 1 || asked[0] != "devbox" {
+		t.Fatalf("discovery asked for %v", asked)
+	}
+
+	// It joined: the next dispatch reuses it rather than discovering again,
+	// and its agents appear in the roster.
+	if _, err := f.Dispatch(context.Background(), session.DispatchRequest{
+		Workspace: workspace.Context{Host: "devbox"},
+	}); err != nil {
+		t.Fatalf("second Dispatch: %v", err)
+	}
+	if len(asked) != 1 {
+		t.Fatalf("the host should have joined, not been rediscovered: %v", asked)
+	}
+
+	discovered.agents = []agent.Agent{{ID: "bbb"}}
+	agents, err := f.ListAgents(context.Background())
+	if err != nil {
+		t.Fatalf("ListAgents: %v", err)
+	}
+	if len(agents) != 1 || agents[0].Host != "devbox" {
+		t.Fatalf("a joined host belongs in the roster: %+v", agents)
+	}
+}
+
+// TestWithoutDiscoveryAnUnknownHostIsStillAnError: the CLI paths that
+// build a fleet of one should not quietly invent machines.
+func TestWithoutDiscoveryAnUnknownHostIsStillAnError(t *testing.T) {
+	f := New(nil, reachable("", &stub{}))
+	_, err := f.Dispatch(context.Background(), session.DispatchRequest{
+		Workspace: workspace.Context{Host: "devbox"},
+	})
+	if err == nil {
+		t.Fatal("an unknown host must not resolve when nothing can supply it")
 	}
 }

--- a/internal/remote/sshconfig.go
+++ b/internal/remote/sshconfig.go
@@ -1,0 +1,125 @@
+package remote
+
+import (
+	"bufio"
+	"os"
+	"path/filepath"
+	"slices"
+	"strings"
+)
+
+// maxIncludeDepth stops an Include cycle. Real configurations nest one or
+// two deep; anything past this is a loop, and following it forever is a
+// dashboard that never opens its own modal.
+const maxIncludeDepth = 8
+
+// KnownHosts reads the host names out of the user's SSH configuration, in
+// the order they appear, as suggestions for a machine to work on.
+//
+// They are suggestions rather than a roster: Stormlight can reach any
+// destination ssh can, whether or not it is named in a file. Plenty of
+// people have no ssh config at all — this returns nothing for them, and
+// typing a destination has to work just as well.
+//
+// Patterns are skipped. `Host *.internal` and `Host build-*` configure
+// whatever matches them; neither is a machine anyone can connect to, so
+// offering them as choices would be offering something that cannot work.
+// A negated pattern (`!prod`) is exclusion, not a name.
+func KnownHosts() []string {
+	return knownHostsFrom(defaultSSHConfigPath(), 0)
+}
+
+func knownHostsFrom(path string, depth int) []string {
+	if depth > maxIncludeDepth || strings.TrimSpace(path) == "" {
+		return nil
+	}
+	file, err := os.Open(path)
+	if err != nil {
+		// No configuration is the ordinary case, not a failure.
+		return nil
+	}
+	defer file.Close()
+
+	var hosts []string
+	scanner := bufio.NewScanner(file)
+	for scanner.Scan() {
+		keyword, rest, ok := splitDirective(scanner.Text())
+		if !ok {
+			continue
+		}
+		switch keyword {
+		case "host":
+			for _, pattern := range strings.Fields(rest) {
+				if isHostPattern(pattern) {
+					continue
+				}
+				if !slices.Contains(hosts, pattern) {
+					hosts = append(hosts, pattern)
+				}
+			}
+		case "include":
+			for _, included := range strings.Fields(rest) {
+				for _, match := range expandInclude(included) {
+					for _, host := range knownHostsFrom(match, depth+1) {
+						if !slices.Contains(hosts, host) {
+							hosts = append(hosts, host)
+						}
+					}
+				}
+			}
+		}
+	}
+	return hosts
+}
+
+// splitDirective reads one configuration line. ssh accepts `Keyword value`
+// and `Keyword = value`, and is case-insensitive about the keyword.
+func splitDirective(line string) (keyword, rest string, ok bool) {
+	line = strings.TrimSpace(line)
+	if line == "" || strings.HasPrefix(line, "#") {
+		return "", "", false
+	}
+	line = strings.ReplaceAll(line, "=", " ")
+	fields := strings.Fields(line)
+	if len(fields) < 2 {
+		return "", "", false
+	}
+	return strings.ToLower(fields[0]), strings.Join(fields[1:], " "), true
+}
+
+func isHostPattern(pattern string) bool {
+	return strings.ContainsAny(pattern, "*?") || strings.HasPrefix(pattern, "!")
+}
+
+// expandInclude resolves an Include path the way ssh does: relative paths
+// are relative to ~/.ssh, and globs are allowed.
+func expandInclude(pattern string) []string {
+	pattern = strings.Trim(pattern, `"`)
+	if strings.HasPrefix(pattern, "~/") {
+		home, err := os.UserHomeDir()
+		if err != nil {
+			return nil
+		}
+		pattern = filepath.Join(home, pattern[2:])
+	}
+	if !filepath.IsAbs(pattern) {
+		home, err := os.UserHomeDir()
+		if err != nil {
+			return nil
+		}
+		pattern = filepath.Join(home, ".ssh", pattern)
+	}
+	matches, err := filepath.Glob(pattern)
+	if err != nil {
+		return nil
+	}
+	return matches
+}
+
+func defaultSSHConfigPath() string {
+	home, err := os.UserHomeDir()
+	if err != nil {
+		return ""
+	}
+	return filepath.Join(home, ".ssh", "config")
+}

--- a/internal/remote/sshconfig_test.go
+++ b/internal/remote/sshconfig_test.go
@@ -1,0 +1,122 @@
+package remote
+
+import (
+	"os"
+	"path/filepath"
+	"slices"
+	"testing"
+	"time"
+)
+
+func writeSSHConfig(t *testing.T, content string) {
+	t.Helper()
+	home := t.TempDir()
+	if err := os.MkdirAll(filepath.Join(home, ".ssh"), 0o700); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(
+		filepath.Join(home, ".ssh", "config"), []byte(content), 0o600,
+	); err != nil {
+		t.Fatal(err)
+	}
+	t.Setenv("HOME", home)
+}
+
+func TestKnownHostsReadsHostEntries(t *testing.T) {
+	writeSSHConfig(t, `
+# a comment
+Host devbox
+  HostName 10.0.0.4
+  User trent
+
+Host build ci
+  HostName builder.internal
+`)
+	hosts := KnownHosts()
+	want := []string{"devbox", "build", "ci"}
+	if !slices.Equal(hosts, want) {
+		t.Fatalf("hosts = %v, want %v (in file order)", hosts, want)
+	}
+}
+
+// TestKnownHostsSkipsPatterns: `Host *.internal` configures whatever
+// matches it. It is not a machine, and offering it as one offers
+// something that cannot work.
+func TestKnownHostsSkipsPatterns(t *testing.T) {
+	writeSSHConfig(t, `
+Host *
+  AddKeysToAgent yes
+
+Host *.internal
+  User deploy
+
+Host build-*
+  Port 2222
+
+Host !prod
+  User ci
+
+Host devbox
+  HostName 10.0.0.4
+`)
+	hosts := KnownHosts()
+	if !slices.Equal(hosts, []string{"devbox"}) {
+		t.Fatalf("hosts = %v, want only the one real name", hosts)
+	}
+}
+
+// TestKnownHostsFollowsInclude: splitting the config is common enough —
+// work in one file, personal machines in another — that a host list which
+// ignored Include would be missing exactly the machines people organised.
+func TestKnownHostsFollowsInclude(t *testing.T) {
+	writeSSHConfig(t, `
+Include work/*.conf
+Host laptop
+`)
+	home, _ := os.UserHomeDir()
+	if err := os.MkdirAll(filepath.Join(home, ".ssh", "work"), 0o700); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(
+		filepath.Join(home, ".ssh", "work", "hosts.conf"),
+		[]byte("Host devbox\n  HostName 10.0.0.4\n"), 0o600,
+	); err != nil {
+		t.Fatal(err)
+	}
+
+	hosts := KnownHosts()
+	if !slices.Contains(hosts, "devbox") || !slices.Contains(hosts, "laptop") {
+		t.Fatalf("hosts = %v, want both the included and the direct entry", hosts)
+	}
+}
+
+func TestKnownHostsSurvivesAnIncludeLoop(t *testing.T) {
+	writeSSHConfig(t, "Include config\nHost devbox\n")
+	done := make(chan []string, 1)
+	go func() { done <- KnownHosts() }()
+	select {
+	case hosts := <-done:
+		if !slices.Contains(hosts, "devbox") {
+			t.Fatalf("hosts = %v", hosts)
+		}
+	case <-time.After(5 * time.Second):
+		t.Fatal("a self-including config should stop, not spin")
+	}
+}
+
+// TestNoSSHConfigIsNotAFailure: plenty of people have never written one,
+// and Stormlight can still reach any destination ssh can. The suggestion
+// list is simply empty.
+func TestNoSSHConfigIsNotAFailure(t *testing.T) {
+	t.Setenv("HOME", t.TempDir())
+	if hosts := KnownHosts(); len(hosts) != 0 {
+		t.Fatalf("hosts = %v, want none", hosts)
+	}
+}
+
+func TestKnownHostsAcceptsEqualsForm(t *testing.T) {
+	writeSSHConfig(t, "Host=devbox\n  HostName=10.0.0.4\n")
+	if hosts := KnownHosts(); !slices.Equal(hosts, []string{"devbox"}) {
+		t.Fatalf("hosts = %v", hosts)
+	}
+}

--- a/internal/workspace/remote.go
+++ b/internal/workspace/remote.go
@@ -61,13 +61,31 @@ func (r *Registry) ResolveOn(ctx context.Context, host, path string) (Context, e
 	return hosted.Resolve(ctx, path)
 }
 
+// forHost is the registry that answers about one machine, made on first
+// use. A host does not have to be configured to exist: naming it is
+// enough, and AddHost only supplies the details that differ from what ssh
+// would do with the name on its own.
 func (r *Registry) forHost(host string) (*Registry, error) {
 	r.mu.RLock()
 	hosted, ok := r.hosts[host]
 	r.mu.RUnlock()
-	if !ok {
-		return nil, fmt.Errorf("no host named %q is configured", host)
+	if ok {
+		return hosted, nil
 	}
+	if strings.TrimSpace(host) == "" {
+		return nil, fmt.Errorf("no host named")
+	}
+
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	if hosted, ok := r.hosts[host]; ok {
+		return hosted, nil
+	}
+	if r.hosts == nil {
+		r.hosts = make(map[string]*Registry)
+	}
+	hosted = NewRegistryForHost(remote.Host{Name: host})
+	r.hosts[host] = hosted
 	return hosted, nil
 }
 

--- a/internal/workspace/remote_test.go
+++ b/internal/workspace/remote_test.go
@@ -155,3 +155,41 @@ func TestLocalRegistryIsUnchangedByHosts(t *testing.T) {
 		t.Fatalf("a local id is never qualified: %q", value.ID)
 	}
 }
+
+// TestAnUnconfiguredHostStillResolves: a machine picked out of
+// ~/.ssh/config was never written into Stormlight's config, and a
+// workspace on it has to resolve anyway. Configuration is how a host
+// differs from its name, not the list of which hosts there are.
+func TestAnUnconfiguredHostStillResolves(t *testing.T) {
+	registry := NewRegistry()
+	// Nothing was added for "devbox"; the name is all there is.
+	_, err := registry.ResolveOn(context.Background(), "devbox", "/srv/api")
+	if err == nil {
+		t.Skip("this machine can actually reach a host called devbox")
+	}
+	// It failed by trying, not by refusing: the error is ssh's, not a
+	// complaint that the host was never configured.
+	if strings.Contains(err.Error(), "configured") {
+		t.Fatalf("an unconfigured host should still be attempted: %v", err)
+	}
+	if !strings.Contains(err.Error(), "devbox") {
+		t.Fatalf("the error should name the host: %v", err)
+	}
+}
+
+// TestAConfiguredHostKeepsItsSettings: AddHost is how a host differs from
+// its bare name — a different destination, an explicit binary — and that
+// has to survive the on-demand path.
+func TestAConfiguredHostKeepsItsSettings(t *testing.T) {
+	registry := NewRegistry()
+	host := fakeHost(t, "devbox", `printf '%s\n' '`+remoteAnswer+`'`)
+	registry.AddHost(host)
+
+	value, err := registry.ResolveOn(context.Background(), "devbox", "/srv/api")
+	if err != nil {
+		t.Fatalf("Resolve: %v", err)
+	}
+	if value.Host != "devbox" || value.Name != "api" {
+		t.Fatalf("the configured host was not used: %+v", value)
+	}
+}

--- a/main.go
+++ b/main.go
@@ -20,6 +20,7 @@ import (
 	"github.com/trentkm/stormlight/internal/config"
 	"github.com/trentkm/stormlight/internal/diagnostic"
 	"github.com/trentkm/stormlight/internal/fleet"
+	"github.com/trentkm/stormlight/internal/history"
 	"github.com/trentkm/stormlight/internal/provider"
 	"github.com/trentkm/stormlight/internal/remote"
 	"github.com/trentkm/stormlight/internal/selfpath"
@@ -472,14 +473,20 @@ func newLogsCommand(logFile *string) *cobra.Command {
 // authoritative state rather than sampled panes — so they outlive every
 // dashboard and every terminal the dashboard ran in.
 func newService(cfg config.Config) (*app.Service, error) {
-	runtime, err := newRuntime(cfg)
+	// One catalog, shared: it is also the standing record of which
+	// machines this dashboard works, which the runtime needs before
+	// anything has named one.
+	catalog := workspace.NewCatalog()
+	runtime, err := newRuntime(cfg, catalog)
 	if err != nil {
 		return nil, err
 	}
 	registry := provider.NewRegistryWithSpecs(providerSpecs(cfg))
 	// Resolution follows a path to the machine that has it, so the
 	// registry needs the same host list the runtime has.
-	return app.NewService(runtime, registry, workspacesWithHosts(cfg)), nil
+	return app.NewServiceWithCatalog(
+		runtime, registry, workspacesWithHosts(cfg), catalog, history.NewLog(),
+	), nil
 }
 
 // newRuntime builds the fleet: this machine's daemon, and one per
@@ -490,19 +497,48 @@ func newService(cfg config.Config) (*app.Service, error) {
 // Members connect lazily and on their own schedule. A host that is asleep
 // or unreachable costs the dashboard its absence and nothing else — never
 // a failed refresh, and never a frame spent waiting on SSH.
-func newRuntime(cfg config.Config) (session.Runtime, error) {
+func newRuntime(cfg config.Config, catalog *workspace.Catalog) (session.Runtime, error) {
 	members := []fleet.Member{{
 		Host:    "",
 		Connect: func() (session.Runtime, error) { return windrun.NewRuntime() },
 	}}
-	for _, name := range slices.Sorted(maps.Keys(cfg.Hosts)) {
-		host := remoteHostFrom(name, cfg.Hosts[name])
-		members = append(members, fleet.Member{
-			Host:    name,
-			Connect: func() (session.Runtime, error) { return windrun.NewRemoteRuntime(host) },
-		})
+	for _, name := range fleetHosts(cfg, catalog) {
+		members = append(members, remoteMember(cfg, name))
 	}
-	return fleet.New(members...), nil
+	// Any other host joins the moment something names it — a workspace on
+	// it, a dispatch aimed at it, a name picked out of ~/.ssh/config.
+	// Configuration is how a host differs from its name, not the list of
+	// which hosts there are.
+	discover := func(host string) fleet.Member { return remoteMember(cfg, host) }
+	return fleet.New(discover, members...), nil
+}
+
+// fleetHosts are the machines to reach at start-up: the ones
+// configuration customises, and the ones the catalog says hold a
+// workspace. The catalog is the answer to "whose agents belong in my
+// roster" — listing names no host, so without it a machine's agents would
+// be invisible until something happened to mention it.
+func fleetHosts(cfg config.Config, catalog *workspace.Catalog) []string {
+	hosts := slices.Sorted(maps.Keys(cfg.Hosts))
+	entries, err := catalog.Entries()
+	if err != nil {
+		diagnostic.Logger().Warn("workspace catalog unavailable", "error", err)
+		return hosts
+	}
+	for _, entry := range entries {
+		if entry.Host != "" && !slices.Contains(hosts, entry.Host) {
+			hosts = append(hosts, entry.Host)
+		}
+	}
+	return hosts
+}
+
+func remoteMember(cfg config.Config, name string) fleet.Member {
+	host := remoteHostFrom(name, cfg.Hosts[name])
+	return fleet.Member{
+		Host:    name,
+		Connect: func() (session.Runtime, error) { return windrun.NewRemoteRuntime(host) },
+	}
 }
 
 func remoteHostFrom(name string, host config.Host) remote.Host {

--- a/site/docs/architecture.html
+++ b/site/docs/architecture.html
@@ -228,8 +228,14 @@
     And an agent's host is discovered by asking rather than remembered, so ownership is
     rebuilt from every listing and never persisted anywhere.</p>
     <p>Dispatch follows the workspace it resolved: the context already names the machine,
-    because resolution happened there. Hosts are configured under
-    <code>[hosts.&lt;name&gt;]</code>, and the name is what qualifies workspace IDs.</p>
+    because resolution happened there. The name is also what qualifies workspace IDs.</p>
+    <p>A host is known because something names it, not because it was configured: a
+    workspace on it, a dispatch aimed at it, a name picked out of <code>~/.ssh/config</code>.
+    Members exist at start-up for the machines the catalog says hold a workspace — listing
+    names no host, so without that a machine's agents would be invisible until something
+    mentioned one — and any other joins the moment it is first named.
+    <code>[hosts.&lt;name&gt;]</code> is where a machine differs from its name: a different
+    destination, a binary a non-interactive shell will not find, extra ssh flags.</p>
 
     <h4 id="terminal-seam">The terminal seam</h4>
     <p>Live terminals reach the dashboard through one narrow seam, declared as an optional

--- a/site/docs/configuration.html
+++ b/site/docs/configuration.html
@@ -134,20 +134,26 @@ provider = <span class="s">"claude"</span>
 <span class="c"># [providers.aider.mode_args]</span>
 <span class="c"># auto = ["--yes-always"]</span>
 
-<span class="c"># Other machines this dashboard works. Each runs its own daemon and</span>
-<span class="c"># its own agents, reached over SSH; the key is the name Stormlight</span>
-<span class="c"># calls it, and what qualifies the workspace IDs of everything there.</span>
+<span class="c"># How a machine differs from its name. A host does not have to appear</span>
+<span class="c"># here to be used — naming one is enough, and ssh already knows what</span>
+<span class="c"># a name means. This is for a host that needs something other than</span>
+<span class="c"># the default.</span>
 <span class="k">[hosts.devbox]</span>
 <span class="c"># destination  = "trent@10.0.0.4"   # defaults to the key</span>
 <span class="c"># bin          = "/opt/bin/stormlight"  # when it is not on PATH</span>
 <span class="c"># options      = ["-p", "2222"]     # extra ssh flags</span>
 <span class="c"># no_multiplex = false              # sharing is on by default</span></code></pre>
-    <p>A configured host joins the dashboard as another daemon: its agents appear in the
-    same roster, its workspaces in the same pane, and <code>dispatch --host</code> starts
-    agents there. Hosts connect lazily and are retried on their own schedule, so one that is
-    asleep costs the dashboard its absence and nothing else. <code>destination</code>
-    defaults to the key, which may be a plain <code>ssh_config</code> alias or a tailnet
-    name — anything <code>ssh</code> already understands.</p>
+    <p>A host joins the dashboard as another daemon: its agents appear in the same roster,
+    its workspaces in the same pane, and <code>dispatch --host</code> starts agents there.
+    Hosts connect lazily and are retried on their own schedule, so one that is asleep costs
+    the dashboard its absence and nothing else.</p>
+    <p>A host does not have to be configured to be used. Naming one is enough — in
+    <code>--host</code>, in a workspace you add, or by picking it out of
+    <code>~/.ssh/config</code> — because <code>ssh</code> already knows what a name means.
+    This table is for the machines that need something other than the default:
+    <code>destination</code> when the name is not what ssh should dial, <code>bin</code>
+    when Stormlight is somewhere a non-interactive shell will not find it,
+    <code>options</code> for extra flags.</p>
     <p>Custom providers appear in the New Agent picker and dispatch like any other.
     Lifecycle integration is the public contract: managed processes receive
     <code>STORMLIGHT_ID</code> and can report state with <code>stormlight event</code> from


### PR DESCRIPTION
First of three for #138 (add a remote workspace from the dashboard). **Stacked
on #137** — review that one first; this targets its branch so the diff stays
readable.

Configuration was the list of machines: a host existed if `[hosts.name]` was in
`config.toml`, and nothing else could make one. That is the wrong way round.
`ssh` already knows what a name means, so naming a machine should be enough —
and it has to be, because the whole point of the modal is picking a name out of
`~/.ssh/config` and using it.

## A host joins on being named

Dispatch to one, add a workspace on one, and the fleet builds a member there
and then; `workspace.Registry` does the same for resolution. `[hosts.name]`
keeps only what differs from the name: a destination that is not the name, a
binary a non-interactive shell will not find, extra ssh flags.

## Start-up needs the catalog

Listing agents names no host — it asks the members it has — so a machine's
agents would be invisible until something happened to mention it. The catalog
is already the standing record of which machines this dashboard works, so its
hosts are members from the first refresh.

That also means one catalog instead of two: the service and the runtime now
share the one they both depended on.

## Reading ~/.ssh/config

`remote.KnownHosts()` returns the names to suggest, in file order. It follows
`Include` — splitting work machines from personal ones is common enough that
ignoring it would miss exactly the machines someone bothered to organise — and
skips patterns, since `Host *.internal` configures whatever matches it and is
not a machine anyone can connect to. `Host a b` yields both names; `Keyword =
value` parses; a self-including config terminates.

This machine has no `~/.ssh/config` at all, which is a useful reminder: the
suggestion list is often empty, so typing a destination has to be first-class
in the UI rather than a fallback. Nothing consumes this yet — the modal does,
in the third PR.

## Testing

`go test ./...` and `go vet ./...` green; fleet tests also under `-race`. New
coverage: a host joins when named and is reused rather than rediscovered; its
agents appear in the roster; without a discoverer an unknown host is still an
error (the CLI paths that build a fleet of one must not invent machines); an
unconfigured host is *attempted* rather than refused; a configured one keeps
its settings; and the ssh_config cases above.

**End to end with a config naming no hosts whatsoever**: a workspace added on
`devbox` resolves, an agent dispatched there runs on its daemon, and both the
roster and the dashboard show it in a fresh process — on the strength of the
catalog alone.

## Next

2. An answer channel for overlays, so the Yazi picker can run on the far side.
3. The tab itself.
