### PR TITLE
An overlay answers through its session, not through a file

### DIFF
--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -277,8 +277,20 @@ runtime-owned session (`session.OverlayHost`, a runtime capability beside
 `TerminalStreamer`), and the dashboard renders its terminal through the
 same widget as the Spanreed, composited into a modal frame. The keyboard
 belongs to the floating program while it is up — `Ctrl-q` cancels, which
-destroys the session — and results return through permission-restricted
-temporary handoff files when the program exits. Overlay sessions carry no
+destroys the session.
+
+Results come back through the session, not through a file. The directory
+picker runs on the machine whose directories are being chosen, and Yazi
+answers through files it writes beside itself — paths that are neither
+readable nor meaningful anywhere else. So `stormlight _pick` runs Yazi
+where it belongs, reads those files where they are, and writes the answer
+into its own session's metadata; the dashboard reads it before `Close`
+takes the session with it. The session is the one thing both ends already
+hold, so the same path works local and remote, and an overlay asking for
+Stormlight by an empty program path gets whichever machine's copy it
+lands on. The task editor stays file-based: it is seeded with the task as
+it stands, so it needs a file written before it opens, and it only ever
+edits text this dashboard already holds. Overlay sessions carry no
 agent document, so the roster never sees them, and Close always removes
 them from the daemon: an overlay resurrected from persistence would be a
 ghost with nothing waiting on its exit.

--- a/internal/picker/picker.go
+++ b/internal/picker/picker.go
@@ -1,0 +1,136 @@
+// Package picker runs the interactive directory chooser.
+//
+// It runs on the machine whose directories are being chosen, which is not
+// always the machine with the dashboard on it. That is the whole reason
+// this is a package rather than a few lines in the UI: Yazi answers
+// through files it writes beside itself, and those files are only
+// readable, and only meaningful, where it ran.
+package picker
+
+import (
+	"fmt"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+)
+
+// Choose runs the chooser over the caller's own terminal and reports the
+// directory the user settled on. An empty answer means they quit without
+// choosing, which is not an error.
+func Choose(binary, start string) (string, error) {
+	if strings.TrimSpace(binary) == "" {
+		resolved, err := exec.LookPath("yazi")
+		if err != nil {
+			return "", fmt.Errorf("yazi is not installed or not on PATH")
+		}
+		binary = resolved
+	}
+	if !isDirectory(start) {
+		working, err := os.Getwd()
+		if err != nil {
+			return "", err
+		}
+		start = working
+	}
+
+	choiceHandoff, err := createHandoff("choice")
+	if err != nil {
+		return "", err
+	}
+	defer os.Remove(choiceHandoff)
+	cwdHandoff, err := createHandoff("cwd")
+	if err != nil {
+		return "", err
+	}
+	defer os.Remove(cwdHandoff)
+
+	command := exec.Command(binary,
+		"--chooser-file", choiceHandoff,
+		"--cwd-file", cwdHandoff,
+		start,
+	)
+	command.Dir = start
+	// The caller is a terminal — a windrunner session's PTY — and Yazi is
+	// meant to own it.
+	command.Stdin, command.Stdout, command.Stderr = os.Stdin, os.Stdout, os.Stderr
+	if err := command.Run(); err != nil {
+		return "", fmt.Errorf("run Yazi: %w", err)
+	}
+
+	choice, err := os.ReadFile(choiceHandoff)
+	if err != nil {
+		return "", fmt.Errorf("read Yazi choice: %w", err)
+	}
+	cwd, err := os.ReadFile(cwdHandoff)
+	if err != nil {
+		return "", fmt.Errorf("read Yazi directory: %w", err)
+	}
+	return resolveDirectory(choice, cwd)
+}
+
+// resolveDirectory reads the two answers Yazi leaves: the file or
+// directory the user chose, and the directory it was sitting in. A chosen
+// file means the directory holding it — nobody picks a file when they
+// were asked for a workspace.
+func resolveDirectory(choice, cwd []byte) (string, error) {
+	selected := firstPath(choice)
+	if selected == "" {
+		selected = firstPath(cwd)
+	}
+	if selected == "" {
+		return "", nil
+	}
+
+	selected = filepath.Clean(selected)
+	info, err := os.Stat(selected)
+	if err != nil {
+		return "", fmt.Errorf("Yazi selected path is unavailable: %s", selected)
+	}
+	if !info.IsDir() {
+		selected = filepath.Dir(selected)
+	}
+	if !isDirectory(selected) {
+		return "", fmt.Errorf("Yazi selected directory is unavailable: %s", selected)
+	}
+	return selected, nil
+}
+
+func firstPath(data []byte) string {
+	for _, line := range strings.Split(string(data), "\n") {
+		line = strings.TrimSuffix(line, "\r")
+		if line != "" {
+			return line
+		}
+	}
+	return ""
+}
+
+// createHandoff makes a file only this user can read. Yazi writes the
+// answer into it, and until it does the file is empty rather than absent,
+// so a chooser that never ran is told apart from one that chose nothing.
+func createHandoff(kind string) (string, error) {
+	file, err := os.CreateTemp("", "stormlight-yazi-"+kind+"-*")
+	if err != nil {
+		return "", fmt.Errorf("create Yazi handoff file: %w", err)
+	}
+	path := file.Name()
+	if err := file.Chmod(0o600); err != nil {
+		_ = file.Close()
+		_ = os.Remove(path)
+		return "", fmt.Errorf("set Yazi handoff permissions: %w", err)
+	}
+	if err := file.Close(); err != nil {
+		_ = os.Remove(path)
+		return "", fmt.Errorf("close Yazi handoff file: %w", err)
+	}
+	return path, nil
+}
+
+func isDirectory(path string) bool {
+	if strings.TrimSpace(path) == "" {
+		return false
+	}
+	info, err := os.Stat(path)
+	return err == nil && info.IsDir()
+}

--- a/internal/picker/picker_test.go
+++ b/internal/picker/picker_test.go
@@ -1,0 +1,86 @@
+package picker
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+// TestResolveDirectoryPrefersTheChoice: Yazi writes two answers, and they
+// disagree whenever someone navigates somewhere and then picks something
+// else. What they chose wins.
+func TestResolveDirectoryPrefersTheChoice(t *testing.T) {
+	chosen := t.TempDir()
+	elsewhere := t.TempDir()
+
+	got, err := resolveDirectory([]byte(chosen+"\n"), []byte(elsewhere+"\n"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got != chosen {
+		t.Fatalf("got %q, want the chosen directory %q", got, chosen)
+	}
+}
+
+// TestResolveDirectoryFallsBackToWhereTheyWere: quitting without choosing
+// still says something — the directory they had navigated to.
+func TestResolveDirectoryFallsBackToWhereTheyWere(t *testing.T) {
+	where := t.TempDir()
+	got, err := resolveDirectory(nil, []byte(where+"\n"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got != where {
+		t.Fatalf("got %q, want %q", got, where)
+	}
+}
+
+// TestAChosenFileMeansItsDirectory: nobody picks a file when they were
+// asked for a workspace, so the directory holding it is what they meant.
+func TestAChosenFileMeansItsDirectory(t *testing.T) {
+	directory := t.TempDir()
+	file := filepath.Join(directory, "main.go")
+	if err := os.WriteFile(file, []byte("package main"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	got, err := resolveDirectory([]byte(file+"\n"), nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got != directory {
+		t.Fatalf("got %q, want %q", got, directory)
+	}
+}
+
+func TestNothingChosenIsNotAnError(t *testing.T) {
+	got, err := resolveDirectory(nil, nil)
+	if err != nil || got != "" {
+		t.Fatalf("got %q, %v — want an empty answer and no error", got, err)
+	}
+}
+
+// TestHandoffsAreOnlyReadableByTheirOwner: the file carries a path the
+// user chose, on a machine that may have other people on it.
+func TestHandoffsAreOnlyReadableByTheirOwner(t *testing.T) {
+	path, err := createHandoff("choice")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer os.Remove(path)
+
+	info, err := os.Stat(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if mode := info.Mode().Perm(); mode != 0o600 {
+		t.Fatalf("handoff mode = %o, want 600", mode)
+	}
+}
+
+func TestChooseRefusesWithoutYazi(t *testing.T) {
+	t.Setenv("PATH", t.TempDir())
+	if _, err := Choose("", t.TempDir()); err == nil {
+		t.Fatal("a machine without yazi should say so")
+	}
+}

--- a/internal/session/runtime.go
+++ b/internal/session/runtime.go
@@ -71,6 +71,15 @@ type OverlayRequest struct {
 type Overlay interface {
 	TerminalStream
 	Exited() <-chan int
+	// Result is the answer the program left behind, read after it exits
+	// and before Close takes the session with it. Empty means it left
+	// none: a picker the user quit without choosing.
+	//
+	// The answer comes back through the session rather than through a
+	// file, because the program runs on the machine it is choosing from
+	// and a file it wrote there is not one this process can read. The
+	// session is the one thing both ends already hold.
+	Result(ctx context.Context) (string, error)
 }
 
 // OverlayHost is an optional runtime capability: run a short-lived

--- a/internal/ui/commands.go
+++ b/internal/ui/commands.go
@@ -115,14 +115,13 @@ func actionCmd(label string, action func(context.Context) error) tea.Cmd {
 	}
 }
 
-// addWorkspaceCmd adds a directory the human picked. The picker runs on
-// this machine, so the path is on this machine; adding one from another
-// host waits on the picker learning to run there (#127).
-func addWorkspaceCmd(backend Backend, path string) tea.Cmd {
+// addWorkspaceCmd adds a directory the human picked, on the machine they
+// picked it from.
+func addWorkspaceCmd(backend Backend, host, path string) tea.Cmd {
 	return func() tea.Msg {
 		ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
 		defer cancel()
-		value, err := backend.AddWorkspace(ctx, "", path)
+		value, err := backend.AddWorkspace(ctx, host, path)
 		return workspaceAddedMsg{value: value, err: err}
 	}
 }

--- a/internal/ui/input_test.go
+++ b/internal/ui/input_test.go
@@ -1167,7 +1167,7 @@ func TestTaskEditorRoundTripsThroughTheHandoffFile(t *testing.T) {
 
 	// The editor "session": what is in the handoff when it exits is the
 	// task that comes back.
-	message := spec.result(nil)
+	message := spec.result("", nil)
 	edited, ok := message.(taskEditedMsg)
 	if !ok || edited.err != nil || edited.task != "Review this workspace" {
 		t.Fatalf("editor result = %#v", message)
@@ -1324,83 +1324,47 @@ func TestDirectorySelectorUpdatesPathAndPickerResult(t *testing.T) {
 	}
 }
 
-func TestResolveYaziDirectory(t *testing.T) {
-	cwd := t.TempDir()
-	choice := t.TempDir()
-	file := filepath.Join(choice, "selected.go")
-	if err := os.WriteFile(file, []byte("package selected"), 0600); err != nil {
-		t.Fatal(err)
-	}
-
-	tests := []struct {
-		name   string
-		choice string
-		cwd    string
-		want   string
-	}{
-		{
-			name:   "selected directory",
-			choice: choice + "\n",
-			cwd:    cwd,
-			want:   choice,
-		},
-		{
-			name:   "selected file uses parent",
-			choice: file + "\n",
-			cwd:    cwd,
-			want:   choice,
-		},
-		{
-			name: "quit uses current directory",
-			cwd:  cwd + "\n",
-			want: cwd,
-		},
-		{
-			name: "cancel leaves directory unchanged",
-		},
-	}
-
-	for _, test := range tests {
-		t.Run(test.name, func(t *testing.T) {
-			got, err := resolveYaziDirectory(
-				[]byte(test.choice),
-				[]byte(test.cwd),
-			)
-			if err != nil {
-				t.Fatal(err)
-			}
-			if got != test.want {
-				t.Fatalf("got %q, want %q", got, test.want)
-			}
-		})
-	}
-}
-
-func TestYaziPickerBuildsHandoffsAndResolvesTheChoice(t *testing.T) {
+func TestYaziPickerRunsStormlightOnTheMachineBeingBrowsed(t *testing.T) {
 	start := t.TempDir()
-	spec, err := yaziPickerSpec("/usr/local/bin/yazi", start)
-	if err != nil {
-		t.Fatal(err)
+	local := yaziPickerSpec("", start, "/usr/local/bin/yazi")
+
+	// An empty path is "this host's Stormlight" — the runtime fills it in
+	// on whichever machine the overlay lands on.
+	if local.path != "" || local.dir != start || local.host != "" {
+		t.Fatalf("picker spec = %#v", local)
+	}
+	args := strings.Join(local.args, " ")
+	if !strings.Contains(args, "_pick") || !strings.Contains(args, start) {
+		t.Fatalf("picker args = %#v", local.args)
+	}
+	// The configured Yazi is this machine's, so it is only offered here.
+	if !strings.Contains(args, "--yazi /usr/local/bin/yazi") {
+		t.Fatalf("local picker should use the configured yazi: %#v", local.args)
 	}
 
-	if spec.path != "/usr/local/bin/yazi" || spec.dir != start {
-		t.Fatalf("picker spec = %#v", spec)
+	remote := yaziPickerSpec("devbox", start, "/usr/local/bin/yazi")
+	if remote.host != "devbox" {
+		t.Fatalf("picker spec = %#v", remote)
 	}
-	args := strings.Join(spec.args, " ")
-	if !strings.Contains(args, "--chooser-file") ||
-		!strings.Contains(args, "--cwd-file") {
-		t.Fatalf("Yazi handoff args = %#v", spec.args)
+	if strings.Contains(strings.Join(remote.args, " "), "--yazi") {
+		t.Fatalf("this machine's yazi path means nothing over there: %#v", remote.args)
 	}
 
-	// Empty handoffs are a cancelled pick, which completes cleanly with
-	// no path.
-	message := spec.result(nil)
+	// Quitting without choosing leaves no answer, and that is not a
+	// failure — the form keeps whatever it had.
+	message := remote.result("", nil)
 	picked, ok := message.(directoryPickedMsg)
 	if !ok || picked.err != nil || picked.path != "" {
+		t.Fatalf("cancelled picker = %#v", message)
+	}
+
+	// An answer carries the machine it was chosen on.
+	message = remote.result("/srv/api", nil)
+	picked, ok = message.(directoryPickedMsg)
+	if !ok || picked.path != "/srv/api" || picked.host != "devbox" {
 		t.Fatalf("picker result = %#v", message)
 	}
 }
-
 func TestVimPaneNavigation(t *testing.T) {
 	firstWorkspace := workspace.DirectoryContext("/workspace/one")
 	secondWorkspace := workspace.DirectoryContext("/workspace/two")

--- a/internal/ui/model.go
+++ b/internal/ui/model.go
@@ -252,6 +252,10 @@ type attachMsg struct {
 }
 
 type directoryPickedMsg struct {
+	// host is the machine the picker browsed; empty is this one. It
+	// travels with the path because a path alone does not say where it
+	// is, and the two are one answer.
+	host string
 	path string
 	err  error
 }
@@ -574,10 +578,9 @@ func (m Model) Update(message tea.Msg) (tea.Model, tea.Cmd) {
 		}
 		if m.mode == modeAddWorkspace {
 			m.cwdInput.SetValue(msg.path)
-			return m, addWorkspaceCmd(m.backend, msg.path)
+			return m, addWorkspaceCmd(m.backend, msg.host, msg.path)
 		}
-		// The picker runs on this machine, so what it returns is here.
-		m.prepareDirectoryChoices("", msg.path)
+		m.prepareDirectoryChoices(msg.host, msg.path)
 		m.cwdInput.SetValue(msg.path)
 		m.formFocus = dispatchTask
 		m.focusForm()

--- a/internal/ui/overlay_test.go
+++ b/internal/ui/overlay_test.go
@@ -2,6 +2,7 @@ package ui
 
 import (
 	"context"
+	"errors"
 	"strings"
 	"sync"
 	"testing"
@@ -15,11 +16,26 @@ type fakeOverlaySession struct {
 	seed   string
 	output chan []byte
 	exited chan int
+	answer string
 
 	mu     sync.Mutex
 	writes []byte
 	closed bool
 }
+
+// Result is what the program left in its session. Reading it after Close
+// would be reading a session that no longer exists, so the test records
+// whether that happened.
+func (f *fakeOverlaySession) Result(context.Context) (string, error) {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	if f.closed {
+		return "", errClosedBeforeRead
+	}
+	return f.answer, nil
+}
+
+var errClosedBeforeRead = errors.New("session was closed before its answer was read")
 
 func newFakeOverlaySession(seed string) *fakeOverlaySession {
 	return &fakeOverlaySession{
@@ -119,7 +135,7 @@ func TestOverlayCancelDestroysTheSessionUnread(t *testing.T) {
 	model = openFakeOverlay(t, model, session, overlaySpec{
 		title:   "Yazi",
 		cleanup: func() { cleaned = true },
-		result:  func(error) tea.Msg { resultRan = true; return nil },
+		result:  func(string, error) tea.Msg { resultRan = true; return nil },
 	})
 	generation := model.overlay.generation
 
@@ -147,11 +163,13 @@ func TestOverlayCancelDestroysTheSessionUnread(t *testing.T) {
 func TestOverlayExitReadsTheAnswerBack(t *testing.T) {
 	model := flowModelFixture(t, stubBackend{})
 	session := newFakeOverlaySession("seed")
+	// What the program left behind, in the session it was running in.
+	session.answer = "/picked"
 	model = openFakeOverlay(t, model, session, overlaySpec{
 		title:   "Yazi",
 		cleanup: func() {},
-		result: func(err error) tea.Msg {
-			return directoryPickedMsg{path: "/picked", err: err}
+		result: func(answer string, err error) tea.Msg {
+			return directoryPickedMsg{path: answer, err: err}
 		},
 	})
 
@@ -163,6 +181,9 @@ func TestOverlayExitReadsTheAnswerBack(t *testing.T) {
 	if model.overlay != nil {
 		t.Fatal("exit left the overlay up")
 	}
+	// The answer has to be read before Close, because Close destroys the
+	// session holding it. The fake returns an error if it is asked after
+	// closing, so the order is asserted rather than assumed.
 	picked, ok := cmd().(directoryPickedMsg)
 	if !ok || picked.err != nil || picked.path != "/picked" {
 		t.Fatalf("exit result = %#v", picked)

--- a/internal/ui/overlays.go
+++ b/internal/ui/overlays.go
@@ -19,11 +19,15 @@ import (
 // overlaySpec is one floating program the dashboard can host: what to run,
 // how to read its answer back, and how to clean up if it never answers.
 type overlaySpec struct {
-	title   string
-	path    string
-	args    []string
-	dir     string
-	result  func(error) tea.Msg
+	title string
+	host  string
+	path  string
+	args  []string
+	dir   string
+	// result turns the program's exit into a message. answer is what it
+	// left in its session — empty when it left none, which is what
+	// quitting without choosing looks like.
+	result  func(answer string, err error) tea.Msg
 	cleanup func()
 }
 
@@ -65,6 +69,7 @@ func (m *Model) openOverlay(spec overlaySpec) tea.Cmd {
 	generation := m.overlayGeneration
 	outerWidth, outerHeight := m.overlayDimensions()
 	request := app.OverlayRequest{
+		Host: spec.host,
 		Path: spec.path,
 		Args: spec.args,
 		Dir:  spec.dir,
@@ -127,12 +132,18 @@ func (m Model) handleOverlayExited(msg overlayExitedMsg) (tea.Model, tea.Cmd) {
 	view := m.overlay
 	m.overlay = nil
 	return m, func() tea.Msg {
+		// Read the answer before closing: Close destroys the session, and
+		// the session is where the answer is.
+		answer, answerErr := view.session.Result(context.Background())
 		view.widget.Close()
 		if msg.code != 0 {
-			return view.spec.result(fmt.Errorf(
+			return view.spec.result("", fmt.Errorf(
 				"%s exited with status %d", strings.TrimSpace(view.spec.title), msg.code))
 		}
-		return view.spec.result(nil)
+		if answerErr != nil {
+			return view.spec.result("", answerErr)
+		}
+		return view.spec.result(answer, nil)
 	}
 }
 
@@ -223,7 +234,10 @@ func taskEditorSpec(binary, cwd, task string) (overlaySpec, error) {
 		return overlaySpec{}, fmt.Errorf("close task editor file: %w", err)
 	}
 
-	result := func(runErr error) tea.Msg {
+	// The editor stays file-based: it is seeded with the task as it
+	// stands, so it needs a file written before it opens, and it only
+	// ever edits text this dashboard already holds.
+	result := func(_ string, runErr error) tea.Msg {
 		defer cleanup()
 		if runErr != nil {
 			return taskEditedMsg{err: fmt.Errorf("run Neovim: %w", runErr)}
@@ -262,114 +276,44 @@ func (m Model) openYazi() (tea.Model, tea.Cmd) {
 	if !isDirectory(start) {
 		start = m.initialCwd
 	}
-	spec, err := yaziPickerSpec(m.yaziPath, start)
-	if err != nil {
-		m.err = err
-		return m, nil
-	}
-	return m, m.openOverlay(spec)
+	return m, m.openOverlay(yaziPickerSpec("", start, m.yaziPath))
 }
 
-// yaziPickerSpec builds the picker overlay: the invocation, and the
-// completion handler that resolves the chosen directory from the handoff
-// files.
-func yaziPickerSpec(binary, start string) (overlaySpec, error) {
-	choiceHandoff, err := createYaziHandoff("choice")
-	if err != nil {
-		return overlaySpec{}, err
+// yaziPickerSpec builds the picker overlay.
+//
+// The program is Stormlight itself on the machine being browsed, because
+// the answer has to be recorded there: Yazi writes its choice into files
+// beside itself, and on another machine those are paths this process
+// cannot read. `_pick` runs Yazi, reads them where they are, and leaves
+// the answer in the session both ends already hold.
+//
+// The configured Yazi path is only passed for this machine. On another
+// one it names a binary that may not be there, and that host's own PATH
+// is the right place to look.
+func yaziPickerSpec(host, start, localYazi string) overlaySpec {
+	args := []string{"_pick"}
+	if host == "" && strings.TrimSpace(localYazi) != "" {
+		args = append(args, "--yazi", localYazi)
 	}
-	cwdHandoff, err := createYaziHandoff("cwd")
-	if err != nil {
-		_ = os.Remove(choiceHandoff)
-		return overlaySpec{}, err
-	}
-
-	pickerArgs := []string{
-		"--chooser-file", choiceHandoff,
-		"--cwd-file", cwdHandoff,
-		start,
-	}
-	result := func(runErr error) tea.Msg {
-		defer os.Remove(choiceHandoff)
-		defer os.Remove(cwdHandoff)
-		if runErr != nil {
-			return directoryPickedMsg{err: fmt.Errorf("run Yazi: %w", runErr)}
-		}
-		choice, err := os.ReadFile(choiceHandoff)
-		if err != nil {
-			return directoryPickedMsg{err: fmt.Errorf("read Yazi choice: %w", err)}
-		}
-		cwd, err := os.ReadFile(cwdHandoff)
-		if err != nil {
-			return directoryPickedMsg{err: fmt.Errorf("read Yazi directory: %w", err)}
-		}
-		selected, err := resolveYaziDirectory(choice, cwd)
-		if err != nil {
-			return directoryPickedMsg{err: err}
-		}
-		if selected == "" {
-			return directoryPickedMsg{}
-		}
-		return directoryPickedMsg{path: selected}
-	}
+	args = append(args, start)
 
 	return overlaySpec{
-		title:  "Yazi",
-		path:   binary,
-		args:   pickerArgs,
-		dir:    start,
-		result: result,
-		cleanup: func() {
-			_ = os.Remove(choiceHandoff)
-			_ = os.Remove(cwdHandoff)
+		title: "Yazi",
+		host:  host,
+		// Empty path means this host's Stormlight, whichever machine
+		// that turns out to be.
+		path: "",
+		args: args,
+		dir:  start,
+		result: func(answer string, runErr error) tea.Msg {
+			if runErr != nil {
+				return directoryPickedMsg{err: runErr}
+			}
+			// No answer is a picker someone quit, not a failure.
+			return directoryPickedMsg{host: host, path: answer}
 		},
-	}, nil
-}
-
-func createYaziHandoff(kind string) (string, error) {
-	file, err := os.CreateTemp("", "stormlight-yazi-"+kind+"-*")
-	if err != nil {
-		return "", fmt.Errorf("create Yazi handoff file: %w", err)
+		cleanup: func() {},
 	}
-	path := file.Name()
-	if err := file.Close(); err != nil {
-		_ = os.Remove(path)
-		return "", fmt.Errorf("close Yazi handoff file: %w", err)
-	}
-	return path, nil
-}
-
-func resolveYaziDirectory(choice, cwd []byte) (string, error) {
-	selected := firstYaziPath(choice)
-	if selected == "" {
-		selected = firstYaziPath(cwd)
-	}
-	if selected == "" {
-		return "", nil
-	}
-
-	selected = filepath.Clean(selected)
-	info, err := os.Stat(selected)
-	if err != nil {
-		return "", fmt.Errorf("Yazi selected path is unavailable: %s", selected)
-	}
-	if !info.IsDir() {
-		selected = filepath.Dir(selected)
-	}
-	if !isDirectory(selected) {
-		return "", fmt.Errorf("Yazi selected directory is unavailable: %s", selected)
-	}
-	return selected, nil
-}
-
-func firstYaziPath(data []byte) string {
-	for _, line := range strings.Split(string(data), "\n") {
-		line = strings.TrimSuffix(line, "\r")
-		if line != "" {
-			return line
-		}
-	}
-	return ""
 }
 
 // choiceKey identifies a directory choice. The host is part of it: the

--- a/internal/ui/workspaces.go
+++ b/internal/ui/workspaces.go
@@ -432,5 +432,8 @@ func (m Model) submitAddWorkspace(path string) (tea.Model, tea.Cmd) {
 		return m, nil
 	}
 	m.blurForm()
-	return m, addWorkspaceCmd(m.backend, path)
+	// A typed path is this machine's until the modal grows a host
+	// selector (#138); one browsed with the picker already carries the
+	// machine it was browsed on.
+	return m, addWorkspaceCmd(m.backend, "", path)
 }

--- a/internal/windrun/overlay.go
+++ b/internal/windrun/overlay.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"os"
+	"strings"
 
 	"github.com/trentkm/windrunner/client"
 	"github.com/trentkm/windrunner/wire"
@@ -16,13 +17,31 @@ import (
 // them legible in `windrunner ls` and debugging.
 const overlayMetadataKey = "stormlight_overlay"
 
+// OverlayResultKey is where an overlay program leaves its answer: its own
+// session's metadata, which the daemon stores without reading and the
+// dashboard can read from anywhere it can reach that daemon. The program
+// writes it through the daemon on its own machine; nothing crosses a
+// filesystem boundary that was never crossable.
+const OverlayResultKey = "stormlight_overlay_result"
+
 // StartOverlay runs a short-lived interactive program in its own session
 // and hands back its terminal. The session dies with the overlay — Close
 // removes it — because an overlay resurrected from daemon persistence
 // would be a ghost with nothing waiting on its exit.
 func (r *Runtime) StartOverlay(ctx context.Context, request session.OverlayRequest) (session.Overlay, error) {
+	// An empty path means this host's Stormlight — the way an overlay
+	// asks for a program that exists on whichever machine it lands on,
+	// without the dashboard having to know where that machine keeps it.
+	command := request.Path
+	if strings.TrimSpace(command) == "" {
+		binPath, _, err := r.dispatchTarget()
+		if err != nil {
+			return nil, err
+		}
+		command = binPath
+	}
 	spawn := wire.Request{
-		Command:  request.Path,
+		Command:  command,
 		Args:     request.Args,
 		Dir:      request.Dir,
 		Cols:     max(2, request.Cols),
@@ -32,12 +51,19 @@ func (r *Runtime) StartOverlay(ctx context.Context, request session.OverlayReque
 	// On a remote host the environment is that host's: an overlay browses
 	// the filesystem the agents are on, so it wants that machine's HOME
 	// and PATH, not this one's.
+	socketDir := SocketDir()
 	if r.transport == nil {
 		spawn.Env = os.Environ()
+	} else {
+		socketDir = r.transport.Hello().SocketDir
 	}
+	// The program inside needs to reach the daemon holding it, to leave
+	// its answer there. WINDRUNNER_SESSION names the session; this says
+	// which daemon to say it to.
+	spawn.EnvOverride = []string{"WINDRUNNER_DIR=" + socketDir}
 	info, err := r.client.Spawn(spawn)
 	if err != nil {
-		return nil, fmt.Errorf("spawn overlay %s: %w", request.Path, err)
+		return nil, fmt.Errorf("spawn overlay %s: %w", command, err)
 	}
 	attachment, err := r.client.Attach(info.ID, 256)
 	if err != nil {
@@ -58,6 +84,17 @@ type overlay struct {
 }
 
 func (o *overlay) Exited() <-chan int { return o.attachment.Exited() }
+
+// Result reads what the program left in its session. The session is still
+// there because Close has not run yet — which is the whole reason the
+// dashboard reads before it closes.
+func (o *overlay) Result(_ context.Context) (string, error) {
+	info, err := o.client.Info(o.id)
+	if err != nil {
+		return "", err
+	}
+	return info.Metadata[OverlayResultKey], nil
+}
 
 // Close detaches and removes the session in one motion; Remove also ends
 // the process when it is still running (the cancel path).

--- a/internal/windrun/remote_test.go
+++ b/internal/windrun/remote_test.go
@@ -247,3 +247,108 @@ func waitForScreen(t *testing.T, runtime *Runtime, id, want string) string {
 		time.Sleep(25 * time.Millisecond)
 	}
 }
+
+// TestARemoteOverlayCanReachTheDaemonHoldingIt: an overlay program leaves
+// its answer in its own session, which means finding the daemon on the
+// machine it is running on. WINDRUNNER_SESSION names the session; without
+// WINDRUNNER_DIR there is nothing to say it to.
+func TestARemoteOverlayCanReachTheDaemonHoldingIt(t *testing.T) {
+	runtime := remoteRuntime(t)
+	overlay, err := runtime.StartOverlay(context.Background(), session.OverlayRequest{
+		Path: "/bin/sh",
+		Args: []string{"-c", `printf 'dir=%s\nsession=%s\nend\n' ` +
+			`"$WINDRUNNER_DIR" "$WINDRUNNER_SESSION"; sleep 60`},
+		Cols: 80,
+		Rows: 24,
+	})
+	if err != nil {
+		t.Fatalf("StartOverlay: %v", err)
+	}
+	defer overlay.Close()
+
+	screen := drainOverlay(t, overlay, "end")
+	if !strings.Contains(screen, "dir="+helperSocketDir) {
+		t.Fatalf("the overlay was not told which daemon holds it:\n%s", screen)
+	}
+	if !strings.Contains(screen, "session=") ||
+		strings.Contains(screen, "session=\n") {
+		t.Fatalf("the overlay was not told its own session:\n%s", screen)
+	}
+}
+
+// TestAnOverlayAnswersThroughItsSession: the channel the picker uses. The
+// program writes into the session's metadata on its own machine, and the
+// dashboard reads it from wherever it is.
+func TestAnOverlayAnswersThroughItsSession(t *testing.T) {
+	runtime := remoteRuntime(t)
+	overlay, err := runtime.StartOverlay(context.Background(), session.OverlayRequest{
+		Path: "/bin/sh",
+		Args: []string{"-c", "sleep 60"},
+		Cols: 80,
+		Rows: 24,
+	})
+	if err != nil {
+		t.Fatalf("StartOverlay: %v", err)
+	}
+	defer overlay.Close()
+
+	if answer, err := overlay.Result(context.Background()); err != nil || answer != "" {
+		t.Fatalf("an overlay that has answered nothing = %q, %v", answer, err)
+	}
+
+	// Stand in for the program: write the answer into its session, the
+	// way `stormlight _pick` does from inside.
+	answerTheOverlay(t, runtime, "/srv/api")
+
+	answer, err := overlay.Result(context.Background())
+	if err != nil {
+		t.Fatalf("Result: %v", err)
+	}
+	if answer != "/srv/api" {
+		t.Fatalf("answer = %q", answer)
+	}
+}
+
+// answerTheOverlay finds the overlay session and writes a result into it,
+// which is what the program inside does through the daemon on its own
+// machine.
+func answerTheOverlay(t *testing.T, runtime *Runtime, answer string) {
+	t.Helper()
+	sessions, err := runtime.client.List()
+	if err != nil {
+		t.Fatalf("List: %v", err)
+	}
+	for _, info := range sessions {
+		if _, ours := info.Metadata[overlayMetadataKey]; !ours {
+			continue
+		}
+		metadata := info.Metadata
+		if metadata == nil {
+			metadata = map[string]string{}
+		}
+		metadata[OverlayResultKey] = answer
+		if err := runtime.client.SetMetadata(info.ID, metadata); err != nil {
+			t.Fatalf("SetMetadata: %v", err)
+		}
+		return
+	}
+	t.Fatal("no overlay session to answer")
+}
+
+func drainOverlay(t *testing.T, overlay session.Overlay, want string) string {
+	t.Helper()
+	collected := string(overlay.Seed())
+	deadline := time.After(10 * time.Second)
+	for !strings.Contains(collected, want) {
+		select {
+		case chunk, ok := <-overlay.Output():
+			if !ok {
+				t.Fatalf("overlay stream closed before %q; got:\n%s", want, collected)
+			}
+			collected += string(chunk)
+		case <-deadline:
+			t.Fatalf("timed out waiting for %q; got:\n%s", want, collected)
+		}
+	}
+	return collected
+}

--- a/main.go
+++ b/main.go
@@ -21,6 +21,7 @@ import (
 	"github.com/trentkm/stormlight/internal/diagnostic"
 	"github.com/trentkm/stormlight/internal/fleet"
 	"github.com/trentkm/stormlight/internal/history"
+	"github.com/trentkm/stormlight/internal/picker"
 	"github.com/trentkm/stormlight/internal/provider"
 	"github.com/trentkm/stormlight/internal/remote"
 	"github.com/trentkm/stormlight/internal/selfpath"
@@ -125,6 +126,7 @@ func newRootCommand() *cobra.Command {
 		newWindrunnerBridgeCommand(),
 		newResolveCommand(),
 		newReadCommand(),
+		newPickCommand(),
 		newBenchCommand(),
 		newServeCommand(cfg),
 	)
@@ -250,6 +252,69 @@ func newReadCommand() *cobra.Command {
 			return err
 		},
 	}
+}
+
+// newPickCommand is the directory chooser, running on the machine whose
+// directories are being chosen.
+//
+// It answers through its own windrunner session rather than through a
+// file: Yazi writes its choice beside itself, and on another machine that
+// is a path the dashboard cannot read. The session is the one thing both
+// ends already hold, so the answer goes into its metadata — written to
+// the daemon on this machine, read by the dashboard over the tunnel it
+// already has.
+func newPickCommand() *cobra.Command {
+	var yaziPath string
+	command := &cobra.Command{
+		Use:    "_pick <start-directory>",
+		Hidden: true,
+		Args:   cobra.MaximumNArgs(1),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			start := ""
+			if len(args) == 1 {
+				start = args[0]
+			}
+			chosen, err := picker.Choose(yaziPath, start)
+			if err != nil {
+				return err
+			}
+			return recordPick(chosen)
+		},
+	}
+	command.Flags().StringVar(&yaziPath, "yazi", "",
+		"path to yazi; found on PATH when unset")
+	return command
+}
+
+// recordPick writes the answer into this process's own session. Quitting
+// without choosing records nothing, which is how the dashboard tells a
+// cancelled picker from one that chose.
+func recordPick(chosen string) error {
+	if strings.TrimSpace(chosen) == "" {
+		return nil
+	}
+	sessionID := os.Getenv("WINDRUNNER_SESSION")
+	if sessionID == "" {
+		// Run by hand rather than as an overlay: say the answer instead
+		// of filing it.
+		fmt.Println(chosen)
+		return nil
+	}
+	c, err := wrclient.Dial(windrun.SocketPath())
+	if err != nil {
+		return fmt.Errorf("reach the daemon holding this session: %w", err)
+	}
+	defer c.Close()
+	info, err := c.Info(sessionID)
+	if err != nil {
+		return err
+	}
+	metadata := info.Metadata
+	if metadata == nil {
+		metadata = map[string]string{}
+	}
+	metadata[windrun.OverlayResultKey] = chosen
+	return c.SetMetadata(sessionID, metadata)
 }
 
 // newWindrunnerAttachCommand is the F key's other half: a full-terminal

--- a/site/docs/architecture.html
+++ b/site/docs/architecture.html
@@ -291,8 +291,17 @@
     <code>TerminalStreamer</code>), and the dashboard renders its terminal through the same
     widget as the Spanreed, composited into a modal frame. The keyboard belongs to the
     floating program while it is up — <code>Ctrl-q</code> cancels, which destroys the
-    session — and results return through permission-restricted temporary handoff files when
-    the program exits. Overlay sessions carry no agent document, so the roster never sees
+    session.</p>
+    <p>Results come back through the session, not through a file. The directory picker runs
+    on the machine whose directories are being chosen, and Yazi answers through files it
+    writes beside itself — paths that are neither readable nor meaningful anywhere else. So
+    <code>stormlight _pick</code> runs Yazi where it belongs, reads those files where they
+    are, and writes the answer into its own session's metadata; the dashboard reads it
+    before <code>Close</code> takes the session with it. The session is the one thing both
+    ends already hold, so the same path works local and remote, and an overlay asking for
+    Stormlight by an empty program path gets whichever machine's copy it lands on. The task
+    editor stays file-based: it is seeded with the task as it stands, so it needs a file
+    written before it opens, and it only ever edits text this dashboard already holds. Overlay sessions carry no agent document, so the roster never sees
     them, and Close always removes them from the daemon: an overlay resurrected from
     persistence would be a ghost with nothing waiting on its exit.</p>
 


### PR DESCRIPTION
Second of three for #138. **Stacked on #139**, which is stacked on #137.

The picker returns its choice through files Yazi writes beside itself. That
works exactly as long as the picker runs on the machine reading them — which
is the machine it has to stop running on.

Teaching the dashboard to create, read, and delete files on another host would
be building a small remote filesystem for one answer. The session is already
there: both ends hold it, the daemon stores metadata without reading it, and
the program inside knows its own session id.

So `stormlight _pick` runs Yazi where the directories are, reads the handoff
files where they were written, and puts the answer into its own session's
metadata. The dashboard reads it before `Close` takes the session with it —
asserted, not assumed: the test's fake session returns an error if asked after
closing.

## What follows from one mechanism

- The local picker moves to it too, so the handoff plumbing leaves
  `internal/ui` entirely and lands in `internal/picker`, where the code runs on
  the machine it is about.
- Overlays are told `WINDRUNNER_DIR`, so the program inside can reach the
  daemon holding it.
- An overlay whose program path is empty runs Stormlight — whichever machine's
  copy it lands on. The runtime knows where that is; the dashboard cannot.
- The configured Yazi path is only passed for this machine; over there, that
  host's own PATH is the right place to look.

The task editor keeps its file. It is seeded with the task as it stands, so it
needs something written before it opens, and it only ever edits text this
dashboard already holds.

## Testing

`go test ./...` and `go vet ./...` green. New coverage: choice beats cwd; a
chosen file means its directory; quitting without choosing is an empty answer
and not an error; handoffs are 0600; a machine without Yazi says so; the picker
spec runs Stormlight rather than Yazi and carries its host; the answer is read
before the session closes.

**Locally, in the dashboard**: browsed with Yazi, quit, and the directory it
was sitting in came back through the session and became a workspace. The popup
renders byte-identically to the file-based one it replaced.

**Remotely, at the runtime layer**: an overlay on another machine's daemon is
told which daemon holds it and which session it is, and an answer written into
that session is read back over the tunnel.

Driving the remote picker from the dashboard needs the host selector, which is
the third PR — that is where the end-to-end remote browse gets exercised.