### PR TITLE
Add a workspace on another machine, from the dashboard

### DIFF
--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -210,7 +210,8 @@ qualifies workspace IDs.
 
 A host is known because something names it, not because it was
 configured: a workspace on it, a dispatch aimed at it, a name picked out
-of `~/.ssh/config`. Members exist at start-up for the machines the
+of `~/.ssh/config` in the Add Workspace modal, which offers this machine
+first and then whatever that file names. Members exist at start-up for the machines the
 catalog says hold a workspace — listing names no host, so without that a
 machine's agents would be invisible until something mentioned one — and
 any other joins the moment it is first named. `[hosts.<name>]` is where a

--- a/internal/ui/dispatch.go
+++ b/internal/ui/dispatch.go
@@ -221,6 +221,8 @@ func (m Model) renderAddWorkspaceAt(width, height int) string {
 	lines := []string{
 		titleStyle().Render("  Add workspace"),
 		"",
+		"  " + m.renderMachineStrip(contentWidth),
+		"",
 		"  " + m.renderDispatchSectionTitle(
 			accentStyle(),
 			"Choose a directory",
@@ -255,6 +257,33 @@ func (m Model) renderAddWorkspaceAt(width, height int) string {
 		)...)
 	}
 	return strings.Join(lines, "\n")
+}
+
+// renderMachineStrip is the machine the modal is adding a workspace on.
+//
+// It reads as one row rather than a list because it usually has one
+// answer — this machine — and because a directory only means anything
+// once you know which machine it is on, so it belongs above the
+// directory rows rather than beside them.
+func (m Model) renderMachineStrip(width int) string {
+	name := "This machine"
+	if host := m.addWorkspaceHostName(); host != "" {
+		name = host
+	}
+	hint := "no other machines in ~/.ssh/config"
+	if len(m.hosts) > 1 {
+		hint = fmt.Sprintf("%d of %d · h/l", m.addWorkspaceHost+1, len(m.hosts))
+	}
+	label := mutedStyle().Copy().Bold(true).Render("Machine")
+	value := accentStyle().Render(name)
+	detail := mutedStyle().Render(hint)
+
+	plain := "Machine  " + name + "  " + hint
+	styled := label + "  " + value + "  " + detail
+	if lipgloss.Width(plain) > width {
+		return label + "  " + value
+	}
+	return styled
 }
 
 // The task composer's floor and ceiling. Under three rows a wrapped task
@@ -1073,20 +1102,59 @@ func (m *Model) prepareAddWorkspaceChoices(start string) {
 		start = m.initialCwd
 	}
 	m.pickerStart = start
+	m.addWorkspaceHost = 0
+	m.setAddWorkspaceChoices()
+	m.cwdInput.SetValue("")
+}
+
+// setAddWorkspaceChoices rebuilds the rows for the machine now selected.
+// Browsing needs a picker on that machine, and this one's Yazi says
+// nothing about whether another has it — so the row is offered and the
+// far side answers.
+func (m *Model) setAddWorkspaceChoices() {
 	choices := make([]directoryChoice, 0, 2)
-	if m.yaziPath != "" {
+	if m.yaziPath != "" || m.addWorkspaceHostName() != "" {
 		choices = append(choices, directoryChoice{
 			kind:  directoryYazi,
+			host:  m.addWorkspaceHostName(),
 			label: "Browse with Yazi",
 		})
 	}
 	choices = append(choices, directoryChoice{
 		kind:  directoryCustom,
+		host:  m.addWorkspaceHostName(),
 		label: "Enter a path",
 	})
 	m.directories = choices
 	m.directoryIndex = 0
+}
+
+// addWorkspaceHostName is the machine the modal is on; empty is this one.
+func (m Model) addWorkspaceHostName() string {
+	if m.addWorkspaceHost <= 0 || m.addWorkspaceHost >= len(m.hosts) {
+		return ""
+	}
+	return m.hosts[m.addWorkspaceHost]
+}
+
+// selectAddWorkspaceHost moves along the machine strip. It wraps, because
+// the list is short and a dead end at either side is a keypress that
+// silently does nothing.
+func (m *Model) selectAddWorkspaceHost(delta int) {
+	if len(m.hosts) <= 1 {
+		return
+	}
+	m.addWorkspaceHost = (m.addWorkspaceHost + delta + len(m.hosts)) % len(m.hosts)
+	m.setAddWorkspaceChoices()
+	// The path box was about the machine we just left.
 	m.cwdInput.SetValue("")
+	if m.addWorkspaceHostName() == "" {
+		m.pickerStart = m.initialCwd
+	} else {
+		// Nothing here knows that machine's directories; its own
+		// Stormlight starts the picker wherever it lands.
+		m.pickerStart = ""
+	}
 }
 
 func (m *Model) selectDirectory(delta int) {

--- a/internal/ui/machine_test.go
+++ b/internal/ui/machine_test.go
@@ -1,0 +1,160 @@
+package ui
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/trentkm/stormlight/internal/workspace"
+)
+
+func addWorkspaceFixture(t *testing.T, hosts ...string) Model {
+	t.Helper()
+	model := flowModelFixture(t, &recordingBackend{})
+	model.hosts = append([]string{""}, hosts...)
+	model.yaziPath = "/usr/local/bin/yazi"
+	model.mode = modeAddWorkspace
+	model.formFocus = dispatchDirectory
+	model.prepareAddWorkspaceChoices(t.TempDir())
+	return model
+}
+
+// TestTheModalStartsOnThisMachine: adding a workspace here is the common
+// case and must stay the thing that happens if you press nothing.
+func TestTheModalStartsOnThisMachine(t *testing.T) {
+	model := addWorkspaceFixture(t, "sandbox", "devbox")
+	if model.addWorkspaceHostName() != "" {
+		t.Fatalf("started on %q", model.addWorkspaceHostName())
+	}
+	if !strings.Contains(model.renderMachineStrip(60), "This machine") {
+		t.Fatalf("strip = %q", model.renderMachineStrip(60))
+	}
+}
+
+func TestTheMachineStripWalksTheSSHConfigHosts(t *testing.T) {
+	model := addWorkspaceFixture(t, "sandbox", "devbox")
+
+	model.selectAddWorkspaceHost(1)
+	if model.addWorkspaceHostName() != "sandbox" {
+		t.Fatalf("host = %q", model.addWorkspaceHostName())
+	}
+	model.selectAddWorkspaceHost(1)
+	if model.addWorkspaceHostName() != "devbox" {
+		t.Fatalf("host = %q", model.addWorkspaceHostName())
+	}
+	// It wraps: the list is short, and a dead end is a keypress that
+	// silently does nothing.
+	model.selectAddWorkspaceHost(1)
+	if model.addWorkspaceHostName() != "" {
+		t.Fatalf("host = %q, want back to this machine", model.addWorkspaceHostName())
+	}
+	model.selectAddWorkspaceHost(-1)
+	if model.addWorkspaceHostName() != "devbox" {
+		t.Fatalf("host = %q, want the last one", model.addWorkspaceHostName())
+	}
+}
+
+// TestWithNoOtherMachinesTheStripSaysSo: an empty ~/.ssh/config is
+// ordinary, and a row that cannot move should say why rather than ignore
+// the key.
+func TestWithNoOtherMachinesTheStripSaysSo(t *testing.T) {
+	model := addWorkspaceFixture(t)
+	strip := model.renderMachineStrip(60)
+	if !strings.Contains(strip, "ssh/config") {
+		t.Fatalf("strip = %q", strip)
+	}
+	model.selectAddWorkspaceHost(1)
+	if model.addWorkspaceHostName() != "" {
+		t.Fatal("there is nowhere else to go")
+	}
+}
+
+// TestBrowsingFollowsTheChosenMachine: the whole point — the picker runs
+// where the directories are.
+func TestBrowsingFollowsTheChosenMachine(t *testing.T) {
+	model := addWorkspaceFixture(t, "devbox")
+	model.selectAddWorkspaceHost(1)
+
+	choice, ok := model.selectedDirectory()
+	if !ok || choice.kind != directoryYazi || choice.host != "devbox" {
+		t.Fatalf("directory choice = %#v", choice)
+	}
+
+	// The start directory is this machine's and means nothing there, so
+	// it is not sent: that Stormlight starts wherever it lands.
+	spec := yaziPickerSpec(model.addWorkspaceHostName(), "", model.yaziPath)
+	if spec.host != "devbox" {
+		t.Fatalf("picker spec = %#v", spec)
+	}
+	if strings.Contains(strings.Join(spec.args, " "), "--yazi") {
+		t.Fatalf("this machine's yazi means nothing there: %#v", spec.args)
+	}
+}
+
+// TestAMissingLocalYaziDoesNotHideARemoteOne: this machine's PATH says
+// nothing about another machine's.
+func TestAMissingLocalYaziDoesNotHideARemoteOne(t *testing.T) {
+	model := addWorkspaceFixture(t, "devbox")
+	model.yaziPath = ""
+	model.setAddWorkspaceChoices()
+	if _, ok := model.selectedDirectory(); ok &&
+		model.directories[0].kind == directoryYazi {
+		t.Fatal("no yazi here means no browse row here")
+	}
+
+	model.selectAddWorkspaceHost(1)
+	if model.directories[0].kind != directoryYazi {
+		t.Fatalf("browsing another machine should still be offered: %#v", model.directories)
+	}
+	if _, cmd := model.openYazi(); cmd == nil {
+		t.Fatalf("opening the remote picker was refused: %v", model.err)
+	}
+}
+
+// TestATypedRemotePathIsNotCheckedHere: /srv/api need not exist on this
+// machine, and checking would either refuse a good path or pass for the
+// wrong reason.
+func TestATypedRemotePathIsNotCheckedHere(t *testing.T) {
+	model := addWorkspaceFixture(t, "devbox")
+	model.selectAddWorkspaceHost(1)
+
+	updated, cmd := model.submitAddWorkspace("/srv/api")
+	if cmd == nil {
+		t.Fatalf("a remote path was refused: %v", updated.(Model).err)
+	}
+	message, ok := cmd().(workspaceAddedMsg)
+	if !ok || message.err != nil {
+		t.Fatalf("add result = %#v", message)
+	}
+	backend := model.backend.(*recordingBackend)
+	if backend.addedHost != "devbox" || backend.addedPath != "/srv/api" {
+		t.Fatalf("added %q on %q", backend.addedPath, backend.addedHost)
+	}
+
+	// A relative path means "here", and here is the wrong machine.
+	next, cmd := model.submitAddWorkspace("srv/api")
+	if cmd != nil {
+		t.Fatal("a relative remote path must be refused")
+	}
+	if next.(Model).err == nil {
+		t.Fatal("refusing it should say why")
+	}
+}
+
+// TestAWorkspaceRowNamesItsMachine: two checkouts at the same path on
+// different machines are otherwise the same row twice.
+func TestAWorkspaceRowNamesItsMachine(t *testing.T) {
+	remote := workspace.Context{
+		Host: "devbox", ID: "devbox:git:/srv/api/.git", Kind: "git",
+		Name: "api", Root: "/srv/api", ExecutionRoot: "/srv/api",
+	}
+	detail := workspaceDetail(remote, 60)
+	if !strings.Contains(detail, "devbox") {
+		t.Fatalf("subtitle = %q", detail)
+	}
+
+	local := remote
+	local.Host = ""
+	if strings.Contains(workspaceDetail(local, 60), "devbox") {
+		t.Fatalf("a local workspace says nothing about hosts: %q", workspaceDetail(local, 60))
+	}
+}

--- a/internal/ui/model.go
+++ b/internal/ui/model.go
@@ -136,6 +136,11 @@ type Model struct {
 	catalogWorkspaces []workspace.Context
 	workspaceRoots    []workspace.Context
 	groups            []workspaceGroup
+	// hosts are the machines the Add Workspace modal can browse, and
+	// addWorkspaceHost is which of them it is on. Index 0 is always this
+	// machine, named by the empty string.
+	hosts            []string
+	addWorkspaceHost int
 	// dispatchHost is the machine the open dispatch form is aimed at. It
 	// travels with the directory rather than being asked for separately:
 	// a path only means anything alongside the machine it is on.
@@ -299,6 +304,10 @@ type Options struct {
 	Columns ColumnPrefs
 	// Keys rebinds the seam chords; empty lists keep the defaults.
 	Keys KeyBindings
+	// Hosts are the machines to offer when adding a workspace, in the
+	// order they should appear — read from the user's SSH configuration.
+	// This machine is always the first choice and is not in this list.
+	Hosts []string
 }
 
 func NewModelWithOptions(backend Backend, options Options) Model {
@@ -351,6 +360,9 @@ func NewModelWithOptions(backend Backend, options Options) Model {
 		ptyEnabled:         true,
 		ptyManager:         ptyview.NewManager(backend),
 		keys:               fillKeyDefaults(options.Keys),
+		// This machine first, then whatever the user's SSH configuration
+		// names. The empty string is how everything else says "here".
+		hosts: append([]string{""}, options.Hosts...),
 	}
 	for index, info := range model.providers {
 		if info.ID == options.DefaultProvider {

--- a/internal/ui/overlays.go
+++ b/internal/ui/overlays.go
@@ -265,18 +265,27 @@ func taskEditorSpec(binary, cwd, task string) (overlaySpec, error) {
 }
 
 func (m Model) openYazi() (tea.Model, tea.Cmd) {
-	if m.yaziPath == "" {
+	// A missing Yazi here says nothing about another machine, which has
+	// its own PATH and answers for itself.
+	if m.yaziPath == "" && m.addWorkspaceHostName() == "" {
 		m.err = fmt.Errorf("yazi is not installed or not on PATH")
 		return m, nil
 	}
+	host := ""
 	start := strings.TrimSpace(m.pickerStart)
-	if m.mode != modeAddWorkspace {
+	if m.mode == modeAddWorkspace {
+		host = m.addWorkspaceHostName()
+	} else {
 		start = strings.TrimSpace(m.cwdInput.Value())
 	}
-	if !isDirectory(start) {
+	// Only a directory on this machine can be checked, and only this
+	// machine's has a sensible fallback. Over there, an empty start means
+	// "wherever that Stormlight lands", which is the home directory of
+	// the account it runs as.
+	if host == "" && !isDirectory(start) {
 		start = m.initialCwd
 	}
-	return m, m.openOverlay(yaziPickerSpec("", start, m.yaziPath))
+	return m, m.openOverlay(yaziPickerSpec(host, start, m.yaziPath))
 }
 
 // yaziPickerSpec builds the picker overlay.
@@ -295,7 +304,9 @@ func yaziPickerSpec(host, start, localYazi string) overlaySpec {
 	if host == "" && strings.TrimSpace(localYazi) != "" {
 		args = append(args, "--yazi", localYazi)
 	}
-	args = append(args, start)
+	if strings.TrimSpace(start) != "" {
+		args = append(args, start)
+	}
 
 	return overlaySpec{
 		title: "Yazi",

--- a/internal/ui/workspaces.go
+++ b/internal/ui/workspaces.go
@@ -44,6 +44,16 @@ func (m Model) updateAddWorkspace(msg tea.KeyPressMsg) (tea.Model, tea.Cmd) {
 		m.mode = modeNormal
 		m.blurForm()
 		return m, nil
+	case "h", "left":
+		if m.formFocus == dispatchDirectory {
+			m.selectAddWorkspaceHost(-1)
+			return m, nil
+		}
+	case "l", "right":
+		if m.formFocus == dispatchDirectory {
+			m.selectAddWorkspaceHost(1)
+			return m, nil
+		}
 	case "j", "down":
 		if m.formFocus == dispatchDirectory {
 			m.selectDirectory(1)
@@ -375,6 +385,13 @@ func workspaceDetail(value workspace.Context, width int) string {
 	}
 	join := func(pathToken string) string {
 		parts := []string{}
+		// The machine comes first: it is the most significant thing about
+		// a workspace that is not on this one, and two checkouts at the
+		// same path on different machines are otherwise the same row
+		// twice.
+		if value.Host != "" {
+			parts = append(parts, value.Host)
+		}
 		if kind != "" {
 			parts = append(parts, kind)
 		}
@@ -427,13 +444,17 @@ func (m Model) beginAddWorkspace() (tea.Model, tea.Cmd) {
 
 func (m Model) submitAddWorkspace(path string) (tea.Model, tea.Cmd) {
 	path = strings.TrimSpace(path)
-	if !isDirectory(path) {
+	host := m.addWorkspaceHostName()
+	// Only this machine's directories can be checked here; that host
+	// resolves its own, and says so if the path is not there.
+	if host == "" && !isDirectory(path) {
 		m.err = fmt.Errorf("workspace directory is unavailable: %s", path)
 		return m, nil
 	}
+	if host != "" && !filepath.IsAbs(path) {
+		m.err = fmt.Errorf("a path on %s must be absolute: %s", host, path)
+		return m, nil
+	}
 	m.blurForm()
-	// A typed path is this machine's until the modal grows a host
-	// selector (#138); one browsed with the picker already carries the
-	// machine it was browsed on.
-	return m, addWorkspaceCmd(m.backend, "", path)
+	return m, addWorkspaceCmd(m.backend, host, path)
 }

--- a/main.go
+++ b/main.go
@@ -457,6 +457,11 @@ func runDashboard(command *cobra.Command, cfg config.Config, openPath string) er
 		ModeForDir:      cfg.ModeForDir,
 		ProviderForDir:  cfg.ProviderForDir,
 		Columns:         ui.LoadColumnPrefs(),
+		// The machines to offer when adding a workspace: the ones the
+		// user's SSH configuration names, plus any they have configured
+		// here. Naming one is what makes it usable, so this list is
+		// suggestions rather than permission.
+		Hosts: dashboardHosts(cfg),
 	}
 	if openPath != "" {
 		value, err := service.AddWorkspace(context.Background(), "", openPath)
@@ -593,6 +598,19 @@ func fleetHosts(cfg config.Config, catalog *workspace.Catalog) []string {
 	for _, entry := range entries {
 		if entry.Host != "" && !slices.Contains(hosts, entry.Host) {
 			hosts = append(hosts, entry.Host)
+		}
+	}
+	return hosts
+}
+
+// dashboardHosts is every machine worth offering, in a stable order:
+// what ~/.ssh/config names first, then anything configured here that it
+// did not.
+func dashboardHosts(cfg config.Config) []string {
+	hosts := remote.KnownHosts()
+	for _, name := range slices.Sorted(maps.Keys(cfg.Hosts)) {
+		if !slices.Contains(hosts, name) {
+			hosts = append(hosts, name)
 		}
 	}
 	return hosts

--- a/site/docs/architecture.html
+++ b/site/docs/architecture.html
@@ -230,7 +230,9 @@
     <p>Dispatch follows the workspace it resolved: the context already names the machine,
     because resolution happened there. The name is also what qualifies workspace IDs.</p>
     <p>A host is known because something names it, not because it was configured: a
-    workspace on it, a dispatch aimed at it, a name picked out of <code>~/.ssh/config</code>.
+    workspace on it, a dispatch aimed at it, a name picked out of <code>~/.ssh/config</code>
+    in the Add Workspace modal, which offers this machine first and then whatever that file
+    names.
     Members exist at start-up for the machines the catalog says hold a workspace — listing
     names no host, so without that a machine's agents would be invisible until something
     mentioned one — and any other joins the moment it is first named.


### PR DESCRIPTION
The feature: **Add Workspace now asks which machine, reads `~/.ssh/config` for
the options, and browses that machine with Yazi.** Closes #138.

```
  Add workspace

  Machine  devbox  3 of 4 · h/l

  Choose a directory                    1/2
  ▌Browse with Yazi   YAZI   Interactive picker
   Enter a path       PATH   Enter a directory
```

`h`/`l` (or arrows) walk this machine → the hosts in your ssh config. Browsing
runs Yazi *there*, and what comes back is added as a workspace on that machine.

The machine reads as one row rather than a list because it usually has one
answer, and because a directory means nothing until you know which machine it
is on — so it belongs above the directory rows, not beside them.

## What follows the machine

- **A missing Yazi here no longer hides the browse row for somewhere else.**
  This machine's PATH says nothing about another's; that host answers for
  itself.
- **A typed path is checked here only when it is here.** On another machine it
  must be absolute and is left to that host to resolve — a path that happens to
  exist on both would otherwise pass for the wrong reason.
- **The start directory is not sent.** It is a path from this filesystem and
  means nothing there, so the picker starts wherever that Stormlight lands.
- **Workspace subtitles lead with the host.** Two checkouts at the same path on
  different machines were otherwise the same row twice.

## Testing

`go test ./...` and `go vet ./...` green. New coverage: the modal starts on
this machine; the strip walks and wraps; an empty ssh config says so rather
than ignoring the key; browsing follows the chosen machine and drops this
machine's Yazi path; a missing local Yazi still offers a remote browse; a typed
remote path is not checked here but must be absolute; a workspace row names its
machine.

**In the dashboard**, against a real `~/.ssh/config`: the strip walked
`This machine / sandbox / devbox / builder`, and browsing on `devbox` opened
Yazi over the tunnel, returned the chosen directory through the overlay's own
session, and left `{"host":"devbox","path":"/Volumes/repos/stormlight"}` in the
catalog.

**Non-regression**: a local dashboard renders byte-identically to `main`.

## Known gap

Typing a destination that is not in `~/.ssh/config` still needs
`workspace add --host`. The modal offers what the file names; an arbitrary
`user@host` wants a text input the modal does not have yet. Filing separately.