### PR TITLE
Adding a workspace asks which machine

### DIFF
--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -210,8 +210,31 @@ qualifies workspace IDs.
 
 A host is known because something names it, not because it was
 configured: a workspace on it, a dispatch aimed at it, a name picked out
-of `~/.ssh/config` in the Add Workspace modal, which offers this machine
-first and then whatever that file names. Members exist at start-up for the machines the
+of `~/.ssh/config` in the Add Workspace modal's Remote tab, which lists
+what that file names and takes a destination it does not.
+
+Two rules keep one machine from looking like two. An agent has one
+identity, so two members reporting the same one are two names for the
+same daemon — a host that resolves back to this machine, say — and the
+first to claim it wins. And an agent's workspace is on the machine the
+agent is on, so the fleet stamps its context: the copy stored at dispatch
+would otherwise group apart from the same workspace reached through a
+host.
+
+Nothing Stormlight sends a host may assume a shell. `ssh host <command>`
+runs it in whatever login shell that account has, which is as likely to
+be fish as sh, so scripts go to `/bin/sh` on stdin — unquoted, unparsed
+by anything else. Every ssh call is bounded by a connect timeout, and a
+host that fails to answer is left alone for a while rather than dialled
+again on the next refresh; a machine that is asleep should cost its own
+absence, not the dashboard's responsiveness.
+
+`stormlight remote setup <host>` reports what a machine is missing and
+can install it. Stormlight itself is copied from this machine when the
+platforms match — the same build, so the two ends cannot disagree about
+the protocol between them — and pointed at the releases when they do not.
+Yazi is offered only through the host's own package manager, and
+described rather than guessed at when there is none. Members exist at start-up for the machines the
 catalog says hold a workspace — listing names no host, so without that a
 machine's agents would be invisible until something mentioned one — and
 any other joins the moment it is first named. `[hosts.<name>]` is where a

--- a/internal/app/service.go
+++ b/internal/app/service.go
@@ -72,12 +72,22 @@ const remoteTranscriptTTL = 2 * time.Second
 
 type resolvedWorkspace struct {
 	value workspace.Context
-	at    time.Time
+	// failure is why it did not resolve, remembered as deliberately as a
+	// success: a host that is asleep costs a connection attempt to
+	// discover, and re-discovering it on every refresh is a dashboard
+	// that spends its whole life waiting on a machine nobody is using.
+	failure error
+	at      time.Time
 }
 
 // workspaceResolveTTL bounds how stale a cached resolution can get; a
 // checkout converted to a worktree (or similar) is noticed within this.
 const workspaceResolveTTL = 10 * time.Second
+
+// unreachableResolveTTL is how long a host that could not answer is left
+// alone. Long enough that a sleeping laptop is not dialled on every
+// refresh, short enough that waking it up shows within the minute.
+const unreachableResolveTTL = 30 * time.Second
 
 func NewService(
 	runtime session.Runtime,
@@ -346,20 +356,37 @@ func (s *Service) resolveCached(
 	s.resolveMu.Lock()
 	cached, ok := s.resolved[entry]
 	s.resolveMu.Unlock()
-	if ok && time.Since(cached.at) < workspaceResolveTTL {
-		return cached.value, nil
+	if ok && time.Since(cached.at) < s.resolveTTL(entry) {
+		return cached.value, cached.failure
 	}
 	value, err := s.workspaces.ResolveOn(ctx, entry.Host, entry.Path)
-	if err != nil {
-		return workspace.Context{}, err
-	}
 	s.resolveMu.Lock()
 	if s.resolved == nil {
 		s.resolved = map[workspace.Entry]resolvedWorkspace{}
 	}
-	s.resolved[entry] = resolvedWorkspace{value: value, at: time.Now()}
+	s.resolved[entry] = resolvedWorkspace{value: value, failure: err, at: time.Now()}
 	s.resolveMu.Unlock()
+	if err != nil {
+		return workspace.Context{}, err
+	}
 	return value, nil
+}
+
+// resolveTTL is how long an answer stands. A directory on this machine
+// changes shape rarely and costs nothing to re-read; a machine that could
+// not be reached costs a connection attempt to ask again, so it is left
+// alone for longer — the same reasoning the fleet applies to its members.
+func (s *Service) resolveTTL(entry workspace.Entry) time.Duration {
+	if entry.Host == "" {
+		return workspaceResolveTTL
+	}
+	s.resolveMu.Lock()
+	cached, ok := s.resolved[entry]
+	s.resolveMu.Unlock()
+	if ok && cached.failure != nil {
+		return unreachableResolveTTL
+	}
+	return workspaceResolveTTL
 }
 
 // applyWorkspaceNames overlays user-chosen display names from the catalog.

--- a/internal/app/transcript_test.go
+++ b/internal/app/transcript_test.go
@@ -14,6 +14,7 @@ import (
 	"github.com/trentkm/stormlight/internal/agent"
 	"github.com/trentkm/stormlight/internal/history"
 	"github.com/trentkm/stormlight/internal/provider"
+	"github.com/trentkm/stormlight/internal/remote"
 	"github.com/trentkm/stormlight/internal/session"
 	"github.com/trentkm/stormlight/internal/workspace"
 )
@@ -173,5 +174,45 @@ func TestAnUnreadableTranscriptFallsBackToTheScreen(t *testing.T) {
 	}
 	if !strings.Contains(plain(rendered), "what the terminal last showed") {
 		t.Fatalf("want the terminal snapshot, got %q", rendered)
+	}
+}
+
+// TestAnUnreachableHostIsNotAskedEveryRefresh: a workspace on a machine
+// that is asleep costs a connection attempt to discover, and the
+// dashboard refreshes on a timer. Asking again every time is a workspace
+// pane that spends its life waiting on a machine nobody is using.
+func TestAnUnreachableHostIsNotAskedEveryRefresh(t *testing.T) {
+	directory := t.TempDir()
+	attempts := filepath.Join(directory, "attempts")
+	ssh := filepath.Join(directory, "ssh")
+	if err := os.WriteFile(ssh, []byte(
+		"#!/bin/sh\necho attempt >> "+attempts+
+			"\necho 'ssh: connect to host devbox port 22: Operation timed out' >&2\nexit 255\n",
+	), 0o755); err != nil {
+		t.Fatal(err)
+	}
+
+	registry := workspace.NewRegistry()
+	registry.AddHost(remote.Host{Name: "devbox", SSHProgram: ssh})
+	service := NewServiceWithCatalog(
+		&readingRuntime{},
+		provider.NewRegistry(),
+		registry,
+		workspace.NewCatalogAt(filepath.Join(directory, "workspaces.json")),
+		history.NewLogAt(filepath.Join(directory, "sessions.jsonl")),
+	)
+
+	entry := workspace.Entry{Host: "devbox", Path: "/srv/api"}
+	for range 4 {
+		if _, err := service.resolveCached(context.Background(), entry); err == nil {
+			t.Fatal("an unreachable host should not resolve")
+		}
+	}
+	content, err := os.ReadFile(attempts)
+	if err != nil {
+		t.Fatalf("the host was never dialled at all: %v", err)
+	}
+	if got := strings.Count(string(content), "attempt"); got != 1 {
+		t.Fatalf("dialled %d times across four refreshes, want 1", got)
 	}
 }

--- a/internal/fleet/fleet.go
+++ b/internal/fleet/fleet.go
@@ -202,7 +202,26 @@ func (f *Runtime) ListAgents(ctx context.Context) ([]agent.Agent, error) {
 			continue
 		}
 		for _, listed := range item.agents {
+			// An agent has one identity. Two members reporting the same
+			// one are two names for the same daemon — a host that
+			// resolves back to this machine, or two aliases for one box —
+			// and the roster must show it once. The first member to
+			// claim it wins, and this machine is always first.
+			if _, taken := owner[listed.ID]; taken {
+				diagnostic.Logger().Debug("host is another name for one already listed",
+					"host", hostName(item.member.host),
+					"agent_id", listed.ID,
+				)
+				continue
+			}
 			listed.Host = item.member.host
+			// The workspace an agent is in is on the machine the agent
+			// is on. Its context was resolved when it was dispatched and
+			// records whatever was true then, so stamping it here is
+			// what keeps one workspace from becoming two rows: the
+			// catalog's copy is qualified with the host, and an agent's
+			// stored copy would otherwise not be.
+			listed.Workspace = listed.Workspace.OnHost(item.member.host)
 			owner[listed.ID] = item.member
 			agents = append(agents, listed)
 		}

--- a/internal/picker/picker.go
+++ b/internal/picker/picker.go
@@ -20,9 +20,9 @@ import (
 // choosing, which is not an error.
 func Choose(binary, start string) (string, error) {
 	if strings.TrimSpace(binary) == "" {
-		resolved, err := exec.LookPath("yazi")
+		resolved, err := findYazi()
 		if err != nil {
-			return "", fmt.Errorf("yazi is not installed or not on PATH")
+			return "", err
 		}
 		binary = resolved
 	}
@@ -67,6 +67,32 @@ func Choose(binary, start string) (string, error) {
 		return "", fmt.Errorf("read Yazi directory: %w", err)
 	}
 	return resolveDirectory(choice, cwd)
+}
+
+// findYazi looks for the chooser the way a person would.
+//
+// A command run over ssh gets a non-interactive shell, whose PATH is
+// often the bare system one — no /opt/homebrew/bin, no ~/.local/bin, none
+// of what a version manager adds. So a plain lookup failing does not mean
+// yazi is absent, and asking a login shell is the difference between
+// "browse that machine" working and appearing to be unsupported.
+func findYazi() (string, error) {
+	if resolved, err := exec.LookPath("yazi"); err == nil {
+		return resolved, nil
+	}
+	shell := os.Getenv("SHELL")
+	if shell == "" {
+		shell = "/bin/sh"
+	}
+	// -l is a login shell: the one that reads the profile the user
+	// actually configures.
+	output, err := exec.Command(shell, "-lc", "command -v yazi").Output()
+	if resolved := strings.TrimSpace(string(output)); err == nil && resolved != "" {
+		return resolved, nil
+	}
+	host, _ := os.Hostname()
+	return "", fmt.Errorf(
+		"yazi is not installed on %s, or not on the PATH its login shell sets", host)
 }
 
 // resolveDirectory reads the two answers Yazi leaves: the file or

--- a/internal/remote/setup.go
+++ b/internal/remote/setup.go
@@ -1,0 +1,251 @@
+package remote
+
+import (
+	"bytes"
+	"context"
+	"fmt"
+	"io"
+	"os"
+	"os/exec"
+	"strings"
+)
+
+// A host needs two things, and only one of them is Stormlight's problem.
+//
+// Stormlight itself is not optional: the bridge, the resolver, and the
+// picker are all that binary, so a host without it cannot be reached at
+// all. Yazi is optional — it is what makes browsing possible, and a host
+// without it can still take a typed path.
+type Requirement struct {
+	Name string
+	// Path is where the host found it; empty means it did not.
+	Path string
+	// Version is what it reports, when it can be asked.
+	Version string
+	// Required says whether the host is unusable without it.
+	Required bool
+}
+
+func (r Requirement) Present() bool { return r.Path != "" }
+
+// Report is what a host says about itself.
+type Report struct {
+	Host string
+	// Platform is `uname -sm`, which is what decides whether this
+	// machine's binary can simply be copied over.
+	Platform   string
+	Home       string
+	Stormlight Requirement
+	Yazi       Requirement
+	// PackageManager is the first recognised one on the host, and the
+	// only thing that makes installing Yazi something Stormlight can
+	// offer rather than describe.
+	PackageManager string
+}
+
+// Ready reports whether the host can host agents at all.
+func (r Report) Ready() bool { return r.Stormlight.Present() }
+
+// probeScript asks every question in one round trip, and asks each one
+// twice: a command run over ssh gets a non-interactive shell whose PATH
+// is often the bare system one, so a login shell is the difference
+// between "not installed" and "not on this particular PATH".
+const probeScript = `
+look() {
+  command -v "$1" 2>/dev/null && return 0
+  [ -n "$SHELL" ] && "$SHELL" -lc "command -v $1" 2>/dev/null && return 0
+  return 1
+}
+printf 'platform=%s\n' "$(uname -sm)"
+printf 'home=%s\n' "$HOME"
+sl=$(look stormlight) && printf 'stormlight=%s\n' "$sl"
+[ -n "$sl" ] && printf 'stormlight_version=%s\n' "$("$sl" --version 2>/dev/null | head -1)"
+yz=$(look yazi) && printf 'yazi=%s\n' "$yz"
+for manager in brew apt-get dnf pacman apk; do
+  if command -v "$manager" >/dev/null 2>&1; then printf 'package_manager=%s\n' "$manager"; break; fi
+done
+`
+
+// Probe asks a host what it has. It is the first thing that touches a
+// machine, so its errors are the ones that have to be legible: an
+// unaccepted host key, a refused login, a name that does not resolve.
+func Probe(ctx context.Context, transport *Transport) (Report, error) {
+	command := transport.ShellCommand(ctx, probeScript)
+	var stdout, stderr bytes.Buffer
+	command.Stdout = &stdout
+	command.Stderr = &stderr
+	if err := command.Run(); err != nil {
+		if message := strings.TrimSpace(stderr.String()); message != "" {
+			return Report{}, fmt.Errorf("%s", Explain(transport.Host().Name, message))
+		}
+		return Report{}, fmt.Errorf("%s: %w", transport.Host().Name, err)
+	}
+
+	report := Report{
+		Host:       transport.Host().Name,
+		Stormlight: Requirement{Name: "stormlight", Required: true},
+		Yazi:       Requirement{Name: "yazi"},
+	}
+	for _, line := range strings.Split(stdout.String(), "\n") {
+		key, value, ok := strings.Cut(strings.TrimSpace(line), "=")
+		if !ok {
+			continue
+		}
+		switch key {
+		case "platform":
+			report.Platform = value
+		case "home":
+			report.Home = value
+		case "stormlight":
+			report.Stormlight.Path = value
+		case "stormlight_version":
+			report.Stormlight.Version = value
+		case "yazi":
+			report.Yazi.Path = value
+		case "package_manager":
+			report.PackageManager = value
+		}
+	}
+	return report, nil
+}
+
+// InstallPath is where Stormlight puts itself on a host that has none.
+// ~/.local/bin is the convention, and the reason `bin` exists in the
+// host's configuration: a non-interactive shell often does not have it on
+// PATH, so the dashboard names the binary outright rather than hoping.
+func (r Report) InstallPath() string {
+	home := r.Home
+	if home == "" {
+		home = "$HOME"
+	}
+	return home + "/.local/bin/stormlight"
+}
+
+// CanCopyBinary reports whether this machine's Stormlight will run on
+// that one. Nothing else here is a matter of taste: a Darwin arm64 binary
+// on a Linux box is not a slow path, it is a file that will not execute.
+func (r Report) CanCopyBinary() bool {
+	local, err := localPlatform()
+	if err != nil {
+		return false
+	}
+	return r.Platform != "" && r.Platform == local
+}
+
+// YaziInstallCommand is how this host would install Yazi, or empty when
+// Stormlight has no business guessing. Package management belongs to the
+// machine's owner; offering to run the one command its own package
+// manager would use is help, and inventing one is damage.
+func (r Report) YaziInstallCommand() string {
+	switch r.PackageManager {
+	case "brew":
+		return "brew install yazi"
+	case "apt-get":
+		return "sudo apt-get install -y yazi"
+	case "dnf":
+		return "sudo dnf install -y yazi"
+	case "pacman":
+		return "sudo pacman -S --noconfirm yazi"
+	case "apk":
+		return "sudo apk add yazi"
+	default:
+		return ""
+	}
+}
+
+// InstallStormlight copies this machine's binary to the host and puts it
+// on the path the bridge will look for.
+//
+// Copying rather than downloading is deliberate where the platforms
+// match: it is the build the dashboard is already running, so the two
+// ends cannot disagree about the protocol between them — which is the one
+// failure this whole exercise exists to avoid.
+func InstallStormlight(
+	ctx context.Context,
+	transport *Transport,
+	report Report,
+	binary string,
+	progress io.Writer,
+) error {
+	if !report.CanCopyBinary() {
+		return fmt.Errorf(
+			"%s is %s and this machine is not; install Stormlight there from its own "+
+				"release (https://github.com/trentkm/stormlight/releases) and set "+
+				"bin = in [hosts.%s]",
+			report.Host, report.Platform, report.Host)
+	}
+	file, err := os.Open(binary)
+	if err != nil {
+		return err
+	}
+	defer file.Close()
+
+	target := report.InstallPath()
+	fmt.Fprintf(progress, "copying this machine's stormlight to %s:%s\n", report.Host, target)
+
+	// Three steps rather than one script, because the middle one needs
+	// stdin for the binary and a script needs stdin for itself.
+	prepare := transport.ShellCommand(ctx, fmt.Sprintf(
+		"set -e\nmkdir -p %q\n", pathDir(target)))
+	prepare.Stdout, prepare.Stderr = progress, progress
+	if err := prepare.Run(); err != nil {
+		return fmt.Errorf("prepare %s on %s: %w", pathDir(target), report.Host, err)
+	}
+
+	// Written beside the target and moved into place, so a half-copied
+	// binary is never the one a hook tries to run.
+	copyIn := transport.PipeCommand(ctx, file, "tee", target+".new")
+	copyIn.Stdout, copyIn.Stderr = io.Discard, progress
+	if err := copyIn.Run(); err != nil {
+		return fmt.Errorf("copy stormlight to %s: %w", report.Host, err)
+	}
+
+	finish := transport.ShellCommand(ctx, fmt.Sprintf(
+		"set -e\nchmod 0755 %[1]q.new\nmv %[1]q.new %[1]q\n%[1]q --version\n", target))
+	finish.Stdout, finish.Stderr = progress, progress
+	if err := finish.Run(); err != nil {
+		return fmt.Errorf("install stormlight on %s: %w", report.Host, err)
+	}
+	return nil
+}
+
+// pathDir is filepath.Dir for a path on another machine, which is always
+// slash-separated whatever this one uses.
+func pathDir(path string) string {
+	if index := strings.LastIndex(path, "/"); index > 0 {
+		return path[:index]
+	}
+	return "."
+}
+
+// InstallYazi runs the host's own package manager.
+func InstallYazi(
+	ctx context.Context,
+	transport *Transport,
+	report Report,
+	progress io.Writer,
+) error {
+	install := report.YaziInstallCommand()
+	if install == "" {
+		return fmt.Errorf(
+			"%s has no package manager Stormlight recognises; install yazi there yourself, "+
+				"or use Enter a path instead of browsing", report.Host)
+	}
+	fmt.Fprintf(progress, "running on %s: %s\n", report.Host, install)
+	// A login shell, because the package manager is usually on the PATH
+	// a profile sets rather than the one ssh hands a bare command.
+	command := transport.ShellCommand(ctx, `"$SHELL" -lc `+shellQuote([]string{install})+"\n")
+	command.Stdout = progress
+	command.Stderr = progress
+	return command.Run()
+}
+
+// localPlatform is this machine's `uname -sm`, asked the same way the
+// host was asked so the two answers are comparable.
+func localPlatform() (string, error) {
+	output, err := exec.Command("uname", "-sm").Output()
+	if err != nil {
+		return "", err
+	}
+	return strings.TrimSpace(string(output)), nil
+}

--- a/internal/remote/setup_test.go
+++ b/internal/remote/setup_test.go
@@ -1,0 +1,146 @@
+package remote
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// fakeSSH stands in for the ssh client: whatever the script prints is
+// what the host said.
+func fakeSSH(t *testing.T, script string) *Transport {
+	t.Helper()
+	path := filepath.Join(t.TempDir(), "ssh")
+	if err := os.WriteFile(path, []byte("#!/bin/sh\n"+script+"\n"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	return NewTransport(Host{Name: "devbox", SSHProgram: path})
+}
+
+func TestProbeReadsWhatAHostHas(t *testing.T) {
+	transport := fakeSSH(t, `cat >/dev/null
+printf 'platform=Linux x86_64\n'
+printf 'home=/home/trent\n'
+printf 'stormlight=/home/trent/.local/bin/stormlight\n'
+printf 'stormlight_version=stormlight version v0.2.2\n'
+printf 'package_manager=apt-get\n'`)
+
+	report, err := Probe(context.Background(), transport)
+	if err != nil {
+		t.Fatalf("Probe: %v", err)
+	}
+	if report.Platform != "Linux x86_64" || report.Home != "/home/trent" {
+		t.Fatalf("report = %+v", report)
+	}
+	if !report.Stormlight.Present() || report.Stormlight.Version == "" {
+		t.Fatalf("stormlight = %+v", report.Stormlight)
+	}
+	// Yazi said nothing, so it is missing — and that is not fatal.
+	if report.Yazi.Present() {
+		t.Fatalf("yazi = %+v", report.Yazi)
+	}
+	if !report.Ready() {
+		t.Fatal("a host with stormlight can hold agents, yazi or not")
+	}
+	if got := report.YaziInstallCommand(); !strings.Contains(got, "apt-get") {
+		t.Fatalf("install command = %q", got)
+	}
+	if got := report.InstallPath(); got != "/home/trent/.local/bin/stormlight" {
+		t.Fatalf("install path = %q", got)
+	}
+}
+
+// TestAHostWithoutStormlightIsNotReady: the bridge, the resolver and the
+// picker are all that binary, so its absence is the one that stops
+// everything.
+func TestAHostWithoutStormlightIsNotReady(t *testing.T) {
+	transport := fakeSSH(t, `cat >/dev/null; printf 'platform=Linux x86_64\n'`)
+	report, err := Probe(context.Background(), transport)
+	if err != nil {
+		t.Fatalf("Probe: %v", err)
+	}
+	if report.Ready() {
+		t.Fatal("a host without stormlight cannot be reached at all")
+	}
+}
+
+// TestProbeExplainsAnUnacceptedHostKey: the first thing anyone does with
+// a new machine, and BatchMode turns "should I trust this?" into a
+// refusal with no way to say yes.
+func TestProbeExplainsAnUnacceptedHostKey(t *testing.T) {
+	transport := fakeSSH(t, `cat >/dev/null
+echo "Host key verification failed." >&2
+exit 255`)
+	_, err := Probe(context.Background(), transport)
+	if err == nil {
+		t.Fatal("an unverified host key must not look like an empty report")
+	}
+	if !strings.Contains(err.Error(), "ssh devbox") {
+		t.Fatalf("the error should say how to fix it: %v", err)
+	}
+}
+
+// TestAForeignPlatformIsNotCopiedTo: a Darwin arm64 binary on a Linux box
+// is not a slow path, it is a file that will not execute.
+func TestAForeignPlatformIsNotCopiedTo(t *testing.T) {
+	local, err := localPlatform()
+	if err != nil {
+		t.Skip("cannot read this machine's platform")
+	}
+	if (Report{Platform: local}).CanCopyBinary() != true {
+		t.Fatal("the same platform should be copyable")
+	}
+	foreign := Report{Host: "devbox", Platform: "Plan9 386"}
+	if foreign.CanCopyBinary() {
+		t.Fatal("a different platform must not be copied to")
+	}
+	err = InstallStormlight(context.Background(), nil, foreign, "", nil)
+	if err == nil || !strings.Contains(err.Error(), "releases") {
+		t.Fatalf("it should point at the releases instead: %v", err)
+	}
+}
+
+// TestYaziIsOnlyOfferedWhereItCanBeInstalled: package management belongs
+// to the machine's owner. Offering the one command its own package
+// manager would use is help; inventing one is damage.
+func TestYaziIsOnlyOfferedWhereItCanBeInstalled(t *testing.T) {
+	for manager, want := range map[string]string{
+		"brew":    "brew install yazi",
+		"pacman":  "pacman -S",
+		"unknown": "",
+	} {
+		got := (Report{PackageManager: manager}).YaziInstallCommand()
+		if want == "" && got != "" {
+			t.Fatalf("%s: offered %q", manager, got)
+		}
+		if want != "" && !strings.Contains(got, want) {
+			t.Fatalf("%s: got %q", manager, got)
+		}
+	}
+	err := InstallYazi(context.Background(), nil, Report{Host: "devbox"}, nil)
+	if err == nil || !strings.Contains(err.Error(), "Enter a path") {
+		t.Fatalf("it should say what still works instead: %v", err)
+	}
+}
+
+// TestScriptsDoNotDependOnTheLoginShell: `ssh host <script>` runs it in
+// whatever shell that account has, which is as likely to be fish as sh —
+// and a POSIX script is not fish. Sending it to /bin/sh on stdin means
+// nothing quotes it and nothing else parses it.
+func TestScriptsDoNotDependOnTheLoginShell(t *testing.T) {
+	transport := NewTransport(Host{Name: "devbox"})
+	command := transport.ShellCommand(context.Background(), "printf hello\n")
+	joined := strings.Join(command.Args, " ")
+	if !strings.Contains(joined, "/bin/sh -s") {
+		t.Fatalf("a script needs a shell it can name: %v", command.Args)
+	}
+	if strings.Contains(joined, "printf hello") {
+		t.Fatalf("the script must not be an argument for a login shell to parse: %v",
+			command.Args)
+	}
+	if command.Stdin == nil {
+		t.Fatal("the script travels on stdin")
+	}
+}

--- a/internal/remote/ssh.go
+++ b/internal/remote/ssh.go
@@ -122,6 +122,36 @@ func (t *Transport) Command(env []string, args ...string) *exec.Cmd {
 	return exec.Command(t.host.sshProgram(), t.sshArgs(false, env, args)...)
 }
 
+// ShellCommand runs a script on the host rather than Stormlight — for
+// the questions asked before Stormlight is known to be there at all, and
+// for putting it there.
+//
+// The script travels on stdin, to a POSIX shell asked for by name. Both
+// halves of that matter. `ssh host <command>` hands the command to the
+// account's *login* shell, which is as likely to be fish as sh, and a
+// POSIX script is not fish — nor does any amount of quoting make it one,
+// since the quoting itself is what fish parses differently. Reading the
+// script from stdin means nothing quotes it at all.
+func (t *Transport) ShellCommand(ctx context.Context, script string) *exec.Cmd {
+	sshArgs := t.sshOptions(false)
+	sshArgs = append(sshArgs, t.host.destination(), "/bin/sh", "-s")
+	command := exec.CommandContext(ctx, t.host.sshProgram(), sshArgs...)
+	command.Stdin = strings.NewReader(script)
+	return command
+}
+
+// PipeCommand runs one command on the host with something of the
+// caller's on its stdin — a file being copied there, most of the time.
+// The arguments are quoted words rather than a script, which every shell
+// agrees about.
+func (t *Transport) PipeCommand(ctx context.Context, stdin io.Reader, args ...string) *exec.Cmd {
+	sshArgs := t.sshOptions(false)
+	sshArgs = append(sshArgs, t.host.destination(), shellQuote(args))
+	command := exec.CommandContext(ctx, t.host.sshProgram(), sshArgs...)
+	command.Stdin = stdin
+	return command
+}
+
 // CommandContext is Command bound to a context, for the calls a caller
 // gives up on: workspace resolution runs on the dashboard's refresh path,
 // where an unreachable host must not hold the frame.
@@ -135,12 +165,17 @@ func (t *Transport) TTYCommand(env []string, args ...string) *exec.Cmd {
 	return exec.Command(t.host.sshProgram(), t.sshArgs(true, env, args)...)
 }
 
-func (t *Transport) sshArgs(tty bool, env, args []string) []string {
+// sshOptions is everything before the destination.
+func (t *Transport) sshOptions(tty bool) []string {
 	// BatchMode is not about scripting convenience. The dashboard owns
 	// the terminal, and ssh prompting for a password or a host key on
 	// /dev/tty would paint over it with something nobody can answer. Fail
 	// with a message instead.
-	sshArgs := []string{"-o", "BatchMode=yes"}
+	// ConnectTimeout bounds every call. Without it a host that is merely
+	// asleep takes ssh's own default to fail — long enough that the
+	// dashboard looks broken rather than patient — and this runs on the
+	// refresh path.
+	sshArgs := []string{"-o", "BatchMode=yes", "-o", "ConnectTimeout=10"}
 	if tty {
 		sshArgs = append(sshArgs, "-t")
 	}
@@ -151,7 +186,11 @@ func (t *Transport) sshArgs(tty bool, env, args []string) []string {
 			"-o", "ControlPersist=60s",
 		)
 	}
-	sshArgs = append(sshArgs, t.host.Options...)
+	return append(sshArgs, t.host.Options...)
+}
+
+func (t *Transport) sshArgs(tty bool, env, args []string) []string {
+	sshArgs := t.sshOptions(tty)
 	sshArgs = append(sshArgs, t.host.destination())
 	remote := make([]string, 0, len(args)+1)
 	remote = append(remote, t.host.bin())
@@ -215,6 +254,25 @@ func Handshake(conn net.Conn) (Hello, error) {
 			hello.Protocol, Protocol, hello.Version, localVersion)
 	}
 	return hello, nil
+}
+
+// Explain turns ssh's own diagnostics into something with a next step.
+// The dashboard runs ssh in BatchMode, which is right — a password prompt
+// would paint over the TUI with something nobody can answer — but it
+// turns "should I trust this host?" into a refusal with no way to say
+// yes. The answer is to say yes once, in a terminal, and ssh remembers.
+func Explain(host string, message string) string {
+	if strings.Contains(message, "Host key verification failed") {
+		return fmt.Sprintf(
+			"%s: its host key is not known yet — run `ssh %s` once to accept it",
+			host, host)
+	}
+	if strings.Contains(message, "Permission denied") {
+		return fmt.Sprintf(
+			"%s: %s (Stormlight cannot answer a password prompt; it needs key-based login)",
+			host, message)
+	}
+	return host + ": " + message
 }
 
 // readHello consumes the greeting line, one byte at a time so that not a

--- a/internal/remote/sshconfig.go
+++ b/internal/remote/sshconfig.go
@@ -4,7 +4,6 @@ import (
 	"bufio"
 	"os"
 	"path/filepath"
-	"slices"
 	"strings"
 )
 
@@ -12,6 +11,39 @@ import (
 // two deep; anything past this is a loop, and following it forever is a
 // dashboard that never opens its own modal.
 const maxIncludeDepth = 8
+
+// ConfigHost is one machine named in the user's SSH configuration.
+type ConfigHost struct {
+	// Name is the alias, and what Stormlight calls the machine.
+	Name string
+	// HostName, User, and Port are what ssh would use for it, when the
+	// configuration says. Empty means ssh's own default — for HostName
+	// that is the alias itself.
+	HostName string
+	User     string
+	Port     string
+}
+
+// Summary is the machine in one phrase, for a list that has to say which
+// `builder` this is. It says nothing when the configuration adds nothing
+// to the name, rather than repeating it back.
+func (h ConfigHost) Summary() string {
+	hostName := h.HostName
+	if hostName == "" {
+		hostName = h.Name
+	}
+	summary := hostName
+	if h.User != "" {
+		summary = h.User + "@" + hostName
+	}
+	if h.Port != "" && h.Port != "22" {
+		summary += ":" + h.Port
+	}
+	if summary == h.Name {
+		return ""
+	}
+	return summary
+}
 
 // KnownHosts reads the host names out of the user's SSH configuration, in
 // the order they appear, as suggestions for a machine to work on.
@@ -25,11 +57,11 @@ const maxIncludeDepth = 8
 // whatever matches them; neither is a machine anyone can connect to, so
 // offering them as choices would be offering something that cannot work.
 // A negated pattern (`!prod`) is exclusion, not a name.
-func KnownHosts() []string {
+func KnownHosts() []ConfigHost {
 	return knownHostsFrom(defaultSSHConfigPath(), 0)
 }
 
-func knownHostsFrom(path string, depth int) []string {
+func knownHostsFrom(path string, depth int) []ConfigHost {
 	if depth > maxIncludeDepth || strings.TrimSpace(path) == "" {
 		return nil
 	}
@@ -40,7 +72,25 @@ func knownHostsFrom(path string, depth int) []string {
 	}
 	defer file.Close()
 
-	var hosts []string
+	var hosts []ConfigHost
+	// Directives belong to the Host block above them, and one block can
+	// name several machines — `Host build ci` configures both.
+	var current []int
+	add := func(host ConfigHost) int {
+		for index, known := range hosts {
+			if known.Name == host.Name {
+				return index
+			}
+		}
+		hosts = append(hosts, host)
+		return len(hosts) - 1
+	}
+	set := func(apply func(*ConfigHost)) {
+		for _, index := range current {
+			apply(&hosts[index])
+		}
+	}
+
 	scanner := bufio.NewScanner(file)
 	for scanner.Scan() {
 		keyword, rest, ok := splitDirective(scanner.Text())
@@ -49,21 +99,24 @@ func knownHostsFrom(path string, depth int) []string {
 		}
 		switch keyword {
 		case "host":
+			current = nil
 			for _, pattern := range strings.Fields(rest) {
 				if isHostPattern(pattern) {
 					continue
 				}
-				if !slices.Contains(hosts, pattern) {
-					hosts = append(hosts, pattern)
-				}
+				current = append(current, add(ConfigHost{Name: pattern}))
 			}
+		case "hostname":
+			set(func(host *ConfigHost) { host.HostName = rest })
+		case "user":
+			set(func(host *ConfigHost) { host.User = rest })
+		case "port":
+			set(func(host *ConfigHost) { host.Port = rest })
 		case "include":
 			for _, included := range strings.Fields(rest) {
 				for _, match := range expandInclude(included) {
 					for _, host := range knownHostsFrom(match, depth+1) {
-						if !slices.Contains(hosts, host) {
-							hosts = append(hosts, host)
-						}
+						add(host)
 					}
 				}
 			}

--- a/internal/remote/sshconfig_test.go
+++ b/internal/remote/sshconfig_test.go
@@ -33,9 +33,40 @@ Host build ci
   HostName builder.internal
 `)
 	hosts := KnownHosts()
-	want := []string{"devbox", "build", "ci"}
-	if !slices.Equal(hosts, want) {
-		t.Fatalf("hosts = %v, want %v (in file order)", hosts, want)
+	if !slices.Equal(names(hosts), []string{"devbox", "build", "ci"}) {
+		t.Fatalf("hosts = %v, want them in file order", names(hosts))
+	}
+	// The details are what tell one `builder` from another in a list.
+	if got := hosts[0].Summary(); got != "trent@10.0.0.4" {
+		t.Fatalf("devbox summary = %q", got)
+	}
+	// One block can name several machines, and they share its settings.
+	if hosts[1].HostName != "builder.internal" || hosts[2].HostName != "builder.internal" {
+		t.Fatalf("a shared Host block should reach both: %+v", hosts[1:])
+	}
+}
+
+func names(hosts []ConfigHost) []string {
+	out := make([]string, 0, len(hosts))
+	for _, host := range hosts {
+		out = append(out, host.Name)
+	}
+	return out
+}
+
+// TestSummarySaysNothingItDoesNotKnow: `Host laptop` with no HostName
+// resolves to "laptop", and echoing the name back as its own detail is
+// noise in a list of names.
+func TestSummarySaysNothingItDoesNotKnow(t *testing.T) {
+	if got := (ConfigHost{Name: "laptop"}).Summary(); got != "" {
+		t.Fatalf("summary = %q, want nothing", got)
+	}
+	if got := (ConfigHost{Name: "b", HostName: "b.internal", Port: "2222"}).Summary(); got != "b.internal:2222" {
+		t.Fatalf("summary = %q", got)
+	}
+	// Port 22 is the default and says nothing.
+	if got := (ConfigHost{Name: "b", HostName: "b.internal", Port: "22"}).Summary(); got != "b.internal" {
+		t.Fatalf("summary = %q", got)
 	}
 }
 
@@ -60,8 +91,8 @@ Host devbox
   HostName 10.0.0.4
 `)
 	hosts := KnownHosts()
-	if !slices.Equal(hosts, []string{"devbox"}) {
-		t.Fatalf("hosts = %v, want only the one real name", hosts)
+	if !slices.Equal(names(hosts), []string{"devbox"}) {
+		t.Fatalf("hosts = %v, want only the one real name", names(hosts))
 	}
 }
 
@@ -85,19 +116,19 @@ Host laptop
 	}
 
 	hosts := KnownHosts()
-	if !slices.Contains(hosts, "devbox") || !slices.Contains(hosts, "laptop") {
-		t.Fatalf("hosts = %v, want both the included and the direct entry", hosts)
+	if !slices.Contains(names(hosts), "devbox") || !slices.Contains(names(hosts), "laptop") {
+		t.Fatalf("hosts = %v, want both the included and the direct entry", names(hosts))
 	}
 }
 
 func TestKnownHostsSurvivesAnIncludeLoop(t *testing.T) {
 	writeSSHConfig(t, "Include config\nHost devbox\n")
-	done := make(chan []string, 1)
+	done := make(chan []ConfigHost, 1)
 	go func() { done <- KnownHosts() }()
 	select {
 	case hosts := <-done:
-		if !slices.Contains(hosts, "devbox") {
-			t.Fatalf("hosts = %v", hosts)
+		if !slices.Contains(names(hosts), "devbox") {
+			t.Fatalf("hosts = %v", names(hosts))
 		}
 	case <-time.After(5 * time.Second):
 		t.Fatal("a self-including config should stop, not spin")
@@ -116,7 +147,7 @@ func TestNoSSHConfigIsNotAFailure(t *testing.T) {
 
 func TestKnownHostsAcceptsEqualsForm(t *testing.T) {
 	writeSSHConfig(t, "Host=devbox\n  HostName=10.0.0.4\n")
-	if hosts := KnownHosts(); !slices.Equal(hosts, []string{"devbox"}) {
-		t.Fatalf("hosts = %v", hosts)
+	if hosts := KnownHosts(); !slices.Equal(names(hosts), []string{"devbox"}) {
+		t.Fatalf("hosts = %v", names(hosts))
 	}
 }

--- a/internal/remote/stdio.go
+++ b/internal/remote/stdio.go
@@ -128,7 +128,7 @@ func (c *stdioConn) exitFailure() error {
 		return nil
 	}
 	if message := c.stderr.String(); message != "" {
-		return fmt.Errorf("%s: %s", c.address, message)
+		return errors.New(Explain(string(c.address), message))
 	}
 	return fmt.Errorf("%s: %w", c.address, c.waitErr)
 }

--- a/internal/ui/dispatch.go
+++ b/internal/ui/dispatch.go
@@ -221,18 +221,33 @@ func (m Model) renderAddWorkspaceAt(width, height int) string {
 	lines := []string{
 		titleStyle().Render("  Add workspace"),
 		"",
-		"  " + m.renderMachineStrip(contentWidth),
+		"  " + m.renderAddWorkspaceTabs(contentWidth),
 		"",
-		"  " + m.renderDispatchSectionTitle(
-			accentStyle(),
-			"Choose a directory",
-			fmt.Sprintf("%d/%d", m.directoryIndex+1, len(m.directories)),
-			contentWidth,
-		),
 	}
+	if m.showingMachines() {
+		lines = append(lines, "  "+m.renderDispatchSectionTitle(
+			accentStyle(),
+			"Machine",
+			fmt.Sprintf("%d/%d", m.machineIndex+1, len(m.machines)),
+			contentWidth,
+		))
+		lines = append(lines, m.renderMachineRows(
+			contentWidth, max(1, min(5, height-8)))...)
+		if choice, ok := m.selectedMachine(); ok && choice.kind == machineTyped {
+			lines = append(lines, "", "  "+m.hostInput.View())
+		}
+		return strings.Join(lines, "\n")
+	}
+
+	lines = append(lines, "  "+m.renderDispatchSectionTitle(
+		accentStyle(),
+		"Choose a directory",
+		fmt.Sprintf("%d/%d", m.directoryIndex+1, len(m.directories)),
+		contentWidth,
+	))
 	lines = append(lines, m.renderDirectoryRows(
 		contentWidth,
-		max(1, min(3, height-8)),
+		max(1, min(3, height-10)),
 	)...)
 	if selected, ok := m.selectedDirectory(); ok &&
 		selected.kind == directoryCustom {
@@ -259,34 +274,62 @@ func (m Model) renderAddWorkspaceAt(width, height int) string {
 	return strings.Join(lines, "\n")
 }
 
-// renderMachineStrip is the machine the modal is adding a workspace on.
-//
-// It reads as one row rather than a list because it usually has one
-// answer — this machine — and because a directory only means anything
-// once you know which machine it is on, so it belongs above the
-// directory rows rather than beside them.
-func (m Model) renderMachineStrip(width int) string {
-	name := "This machine"
-	if host := m.addWorkspaceHostName(); host != "" {
-		name = host
+// renderAddWorkspaceTabs is the modal's first line of navigation: which
+// machine's directories this is about. Local is the common answer, so it
+// leads and the modal opens on it.
+func (m Model) renderAddWorkspaceTabs(width int) string {
+	local := "Local"
+	remote := "Remote"
+	if m.addWorkspaceTab == tabRemote && m.addWorkspaceHost != "" {
+		// A breadcrumb rather than a third tab: the machine is where you
+		// are inside Remote, not somewhere else to go.
+		remote += "  ›  " + m.addWorkspaceHost
 	}
-	hint := "no other machines in ~/.ssh/config"
-	if len(m.hosts) > 1 {
-		hint = fmt.Sprintf("%d of %d · h/l", m.addWorkspaceHost+1, len(m.hosts))
+	render := func(label string, active bool) string {
+		if active {
+			return accentStyle().Render("▏" + label)
+		}
+		return mutedStyle().Render(" " + label)
 	}
-	label := mutedStyle().Copy().Bold(true).Render("Machine")
-	value := accentStyle().Render(name)
-	detail := mutedStyle().Render(hint)
-
-	plain := "Machine  " + name + "  " + hint
-	styled := label + "  " + value + "  " + detail
-	if lipgloss.Width(plain) > width {
-		return label + "  " + value
+	tabs := render(local, m.addWorkspaceTab == tabLocal) + "   " +
+		render(remote, m.addWorkspaceTab == tabRemote)
+	if lipgloss.Width(tabs) > width {
+		return truncate(tabs, width)
 	}
-	return styled
+	return tabs
 }
 
-// The task composer's floor and ceiling. Under three rows a wrapped task
+// renderMachineRows lists the machines the Remote tab can open.
+func (m Model) renderMachineRows(width, maxRows int) []string {
+	if len(m.machines) == 0 {
+		return []string{"    " + mutedStyle().Render("No machines available")}
+	}
+	maxRows = clamp(maxRows, 1, 8)
+	start, end := visibleRange(len(m.machines), m.machineIndex, maxRows)
+	rows := make([]string, 0, end-start)
+	for index := start; index < end; index++ {
+		rows = append(rows, "  "+m.renderMachineRow(
+			m.machines[index], index == m.machineIndex, width))
+	}
+	return rows
+}
+
+func (m Model) renderMachineRow(choice machineChoice, selected bool, width int) string {
+	summary := choice.summary
+	kind := choice.detail
+	if choice.kind == machineTyped {
+		summary = "A machine ~/.ssh/config does not name"
+		kind = "new"
+	}
+	return m.renderDirectoryRow(directoryChoice{
+		kind:          directoryPath,
+		label:         choice.name,
+		workspaceKind: kind,
+		detail:        summary,
+	}, selected, width)
+}
+
+// The task composer's floor and ceiling.// The task composer's floor and ceiling. Under three rows a wrapped task
 // stops being editable — most of what you typed is scrolled out of sight —
 // and past six the box crowds the rest of the form.
 const (
@@ -724,7 +767,10 @@ func (m Model) renderDirectoryRow(
 ) string {
 	kind := strings.ToUpper(choice.workspaceKind)
 	detail := shortPath(choice.path)
-	if choice.host != "" {
+	if choice.detail != "" {
+		detail = choice.detail
+	}
+	if choice.host != "" && choice.detail == "" {
 		// scp's own shorthand, and unambiguous: a bare path here would
 		// read as this machine's.
 		detail = choice.host + ":" + detail
@@ -732,15 +778,21 @@ func (m Model) renderDirectoryRow(
 	switch choice.kind {
 	case directoryYazi:
 		kind = "YAZI"
-		detail = "Interactive picker"
+		if choice.detail == "" {
+			detail = "Interactive picker"
+		}
+	case directorySetup:
+		kind = "SETUP"
 	case directoryCustom:
 		kind = "PATH"
-		detail = "Enter a directory"
-		// A typed path inherits the machine the form is aimed at, so the
-		// row says which one rather than leaving it to be discovered
-		// after the agent starts somewhere else.
-		if m.dispatchHost != "" {
-			detail = m.dispatchHost + ": " + detail
+		if choice.detail == "" {
+			detail = "Enter a directory"
+			// A typed path inherits the machine the form is aimed at, so
+			// the row says which one rather than leaving it to be
+			// discovered after the agent starts somewhere else.
+			if m.dispatchHost != "" {
+				detail = m.dispatchHost + ": " + detail
+			}
 		}
 	}
 	if kind == "" {
@@ -1102,59 +1154,131 @@ func (m *Model) prepareAddWorkspaceChoices(start string) {
 		start = m.initialCwd
 	}
 	m.pickerStart = start
-	m.addWorkspaceHost = 0
+	m.addWorkspaceTab = tabLocal
+	m.addWorkspaceHost = ""
+	m.machineIndex = 0
+	m.formFocus = dispatchDirectory
+	m.hostInput.SetValue("")
+	m.hostInput.Blur()
 	m.setAddWorkspaceChoices()
 	m.cwdInput.SetValue("")
 }
 
-// setAddWorkspaceChoices rebuilds the rows for the machine now selected.
-// Browsing needs a picker on that machine, and this one's Yazi says
-// nothing about whether another has it — so the row is offered and the
-// far side answers.
+// setAddWorkspaceChoices rebuilds the directory rows for the machine the
+// modal is on. Browsing needs a picker over there, and this machine's
+// Yazi says nothing about whether another has one — so the row is
+// offered and the far side answers.
 func (m *Model) setAddWorkspaceChoices() {
+	host := m.addWorkspaceHost
+	where := "Interactive picker"
+	typed := "Enter a directory"
+	if host != "" {
+		where = "Browse " + host
+		typed = "A path on " + host
+	}
 	choices := make([]directoryChoice, 0, 2)
-	if m.yaziPath != "" || m.addWorkspaceHostName() != "" {
+	if m.yaziPath != "" || host != "" {
 		choices = append(choices, directoryChoice{
-			kind:  directoryYazi,
-			host:  m.addWorkspaceHostName(),
-			label: "Browse with Yazi",
+			kind:   directoryYazi,
+			host:   host,
+			label:  "Browse with Yazi",
+			detail: where,
 		})
 	}
 	choices = append(choices, directoryChoice{
-		kind:  directoryCustom,
-		host:  m.addWorkspaceHostName(),
-		label: "Enter a path",
+		kind:   directoryCustom,
+		host:   host,
+		label:  "Enter a path",
+		detail: typed,
 	})
+	if host != "" {
+		// A machine needs Stormlight before it can be reached at all, and
+		// Yazi before it can be browsed. Offering to put them there beats
+		// failing at the first thing that needs them.
+		choices = append(choices, directoryChoice{
+			kind:   directorySetup,
+			host:   host,
+			label:  "Set up this machine",
+			detail: "Check and install what " + host + " needs",
+		})
+	}
 	m.directories = choices
 	m.directoryIndex = 0
 }
 
 // addWorkspaceHostName is the machine the modal is on; empty is this one.
-func (m Model) addWorkspaceHostName() string {
-	if m.addWorkspaceHost <= 0 || m.addWorkspaceHost >= len(m.hosts) {
-		return ""
-	}
-	return m.hosts[m.addWorkspaceHost]
+func (m Model) addWorkspaceHostName() string { return m.addWorkspaceHost }
+
+// showingMachines reports whether the Remote tab is still asking which
+// machine, rather than which directory on one.
+func (m Model) showingMachines() bool {
+	return m.addWorkspaceTab == tabRemote && m.addWorkspaceHost == ""
 }
 
-// selectAddWorkspaceHost moves along the machine strip. It wraps, because
-// the list is short and a dead end at either side is a keypress that
-// silently does nothing.
-func (m *Model) selectAddWorkspaceHost(delta int) {
-	if len(m.hosts) <= 1 {
+// selectMachine moves down the machine list. It stops at the ends rather
+// than wrapping: this is a list, and lists have ends.
+func (m *Model) selectMachine(delta int) {
+	if len(m.machines) == 0 {
 		return
 	}
-	m.addWorkspaceHost = (m.addWorkspaceHost + delta + len(m.hosts)) % len(m.hosts)
-	m.setAddWorkspaceChoices()
-	// The path box was about the machine we just left.
-	m.cwdInput.SetValue("")
-	if m.addWorkspaceHostName() == "" {
-		m.pickerStart = m.initialCwd
-	} else {
-		// Nothing here knows that machine's directories; its own
-		// Stormlight starts the picker wherever it lands.
-		m.pickerStart = ""
+	m.machineIndex = clamp(m.machineIndex+delta, 0, len(m.machines)-1)
+}
+
+func (m Model) selectedMachine() (machineChoice, bool) {
+	if m.machineIndex < 0 || m.machineIndex >= len(m.machines) {
+		return machineChoice{}, false
 	}
+	return m.machines[m.machineIndex], true
+}
+
+// openMachine moves from choosing a machine to choosing a directory on
+// it. The typed row needs a name first, so it focuses the input instead.
+func (m *Model) openMachine() {
+	choice, ok := m.selectedMachine()
+	if !ok {
+		return
+	}
+	if choice.kind == machineTyped {
+		m.formFocus = dispatchCustomPath
+		m.hostInput.Focus()
+		return
+	}
+	m.enterMachine(choice.name)
+}
+
+func (m *Model) enterMachine(host string) {
+	m.addWorkspaceHost = host
+	m.formFocus = dispatchDirectory
+	m.hostInput.Blur()
+	m.cwdInput.SetValue("")
+	// Nothing here knows that machine's directories; its own Stormlight
+	// starts the picker wherever it lands.
+	m.pickerStart = ""
+	m.setAddWorkspaceChoices()
+}
+
+// leaveMachine goes back to the machine list, which is what Esc means
+// inside the Remote tab.
+func (m *Model) leaveMachine() {
+	m.addWorkspaceHost = ""
+	m.formFocus = dispatchDirectory
+	m.hostInput.Blur()
+	m.hostInput.SetValue("")
+	m.setAddWorkspaceChoices()
+}
+
+// switchAddWorkspaceTab moves between Local and Remote, forgetting
+// whichever machine the Remote tab had been opened on.
+func (m *Model) switchAddWorkspaceTab(tab addWorkspaceTab) {
+	m.addWorkspaceTab = tab
+	m.addWorkspaceHost = ""
+	m.machineIndex = 0
+	m.formFocus = dispatchDirectory
+	m.hostInput.Blur()
+	m.hostInput.SetValue("")
+	m.cwdInput.SetValue("")
+	m.pickerStart = m.initialCwd
+	m.setAddWorkspaceChoices()
 }
 
 func (m *Model) selectDirectory(delta int) {

--- a/internal/ui/machine_test.go
+++ b/internal/ui/machine_test.go
@@ -10,61 +10,98 @@ import (
 func addWorkspaceFixture(t *testing.T, hosts ...string) Model {
 	t.Helper()
 	model := flowModelFixture(t, &recordingBackend{})
-	model.hosts = append([]string{""}, hosts...)
+	choices := make([]HostChoice, 0, len(hosts))
+	for _, host := range hosts {
+		choices = append(choices, HostChoice{Name: host, Summary: "trent@" + host})
+	}
+	model.machines = machineChoices(choices)
 	model.yaziPath = "/usr/local/bin/yazi"
 	model.mode = modeAddWorkspace
-	model.formFocus = dispatchDirectory
 	model.prepareAddWorkspaceChoices(t.TempDir())
 	return model
 }
 
-// TestTheModalStartsOnThisMachine: adding a workspace here is the common
-// case and must stay the thing that happens if you press nothing.
-func TestTheModalStartsOnThisMachine(t *testing.T) {
+// TestTheModalOpensOnLocal: adding a workspace here is the common case
+// and must stay the thing that happens if you press nothing.
+func TestTheModalOpensOnLocal(t *testing.T) {
 	model := addWorkspaceFixture(t, "sandbox", "devbox")
-	if model.addWorkspaceHostName() != "" {
-		t.Fatalf("started on %q", model.addWorkspaceHostName())
+	if model.addWorkspaceTab != tabLocal || model.addWorkspaceHostName() != "" {
+		t.Fatalf("opened on tab %v, host %q", model.addWorkspaceTab, model.addWorkspaceHostName())
 	}
-	if !strings.Contains(model.renderMachineStrip(60), "This machine") {
-		t.Fatalf("strip = %q", model.renderMachineStrip(60))
+	if model.showingMachines() {
+		t.Fatal("the Local tab asks for a directory, not a machine")
 	}
 }
 
-func TestTheMachineStripWalksTheSSHConfigHosts(t *testing.T) {
+// TestTheRemoteTabListsTheSSHConfigHosts, and the row for a machine it
+// does not name — most people's configuration names nothing at all.
+func TestTheRemoteTabListsTheSSHConfigHosts(t *testing.T) {
 	model := addWorkspaceFixture(t, "sandbox", "devbox")
+	model.switchAddWorkspaceTab(tabRemote)
 
-	model.selectAddWorkspaceHost(1)
-	if model.addWorkspaceHostName() != "sandbox" {
-		t.Fatalf("host = %q", model.addWorkspaceHostName())
+	if !model.showingMachines() {
+		t.Fatal("the Remote tab asks which machine first")
 	}
-	model.selectAddWorkspaceHost(1)
-	if model.addWorkspaceHostName() != "devbox" {
-		t.Fatalf("host = %q", model.addWorkspaceHostName())
+	if len(model.machines) != 3 {
+		t.Fatalf("machines = %#v", model.machines)
 	}
-	// It wraps: the list is short, and a dead end is a keypress that
-	// silently does nothing.
-	model.selectAddWorkspaceHost(1)
-	if model.addWorkspaceHostName() != "" {
-		t.Fatalf("host = %q, want back to this machine", model.addWorkspaceHostName())
+	if model.machines[0].name != "sandbox" || model.machines[2].kind != machineTyped {
+		t.Fatalf("machines = %#v", model.machines)
 	}
-	model.selectAddWorkspaceHost(-1)
-	if model.addWorkspaceHostName() != "devbox" {
-		t.Fatalf("host = %q, want the last one", model.addWorkspaceHostName())
+	rendered := strings.Join(model.renderMachineRows(70, 5), "\n")
+	// The summary is what tells one `builder` from another.
+	if !strings.Contains(rendered, "trent@sandbox") {
+		t.Fatalf("rows = %q", rendered)
 	}
 }
 
-// TestWithNoOtherMachinesTheStripSaysSo: an empty ~/.ssh/config is
-// ordinary, and a row that cannot move should say why rather than ignore
-// the key.
-func TestWithNoOtherMachinesTheStripSaysSo(t *testing.T) {
+// TestOpeningAMachineDrillsIn: choosing one moves to its directories,
+// with the machine as a breadcrumb rather than a third tab.
+func TestOpeningAMachineDrillsIn(t *testing.T) {
+	model := addWorkspaceFixture(t, "sandbox", "devbox")
+	model.switchAddWorkspaceTab(tabRemote)
+	model.selectMachine(1)
+	model.openMachine()
+
+	if model.addWorkspaceHostName() != "devbox" {
+		t.Fatalf("host = %q", model.addWorkspaceHostName())
+	}
+	if model.showingMachines() {
+		t.Fatal("it should be asking for a directory now")
+	}
+	if !strings.Contains(model.renderAddWorkspaceTabs(70), "devbox") {
+		t.Fatalf("tabs = %q", model.renderAddWorkspaceTabs(70))
+	}
+	// The rows say which machine they act on.
+	choice, ok := model.selectedDirectory()
+	if !ok || choice.host != "devbox" || !strings.Contains(choice.detail, "devbox") {
+		t.Fatalf("directory choice = %#v", choice)
+	}
+
+	// Esc steps back to the list rather than abandoning the modal.
+	model.leaveMachine()
+	if !model.showingMachines() || model.addWorkspaceHostName() != "" {
+		t.Fatal("leaving a machine should return to the machine list")
+	}
+}
+
+// TestNamingAMachineTheConfigDoesNot: a host is known by being named, so
+// the modal takes a destination nobody wrote down.
+func TestNamingAMachineTheConfigDoesNot(t *testing.T) {
 	model := addWorkspaceFixture(t)
-	strip := model.renderMachineStrip(60)
-	if !strings.Contains(strip, "ssh/config") {
-		t.Fatalf("strip = %q", strip)
+	model.switchAddWorkspaceTab(tabRemote)
+	if len(model.machines) != 1 || model.machines[0].kind != machineTyped {
+		t.Fatalf("an empty ssh config still offers the typed row: %#v", model.machines)
 	}
-	model.selectAddWorkspaceHost(1)
-	if model.addWorkspaceHostName() != "" {
-		t.Fatal("there is nowhere else to go")
+
+	model.openMachine()
+	if model.formFocus != dispatchCustomPath {
+		t.Fatal("the typed row should ask for the destination")
+	}
+	model.hostInput.SetValue("trent@newbox")
+	model.enterMachine(strings.TrimSpace(model.hostInput.Value()))
+	if model.addWorkspaceHostName() != "trent@newbox" {
+		t.Fatalf("host = %q", model.addWorkspaceHostName())
 	}
 }
 
@@ -72,7 +109,8 @@ func TestWithNoOtherMachinesTheStripSaysSo(t *testing.T) {
 // where the directories are.
 func TestBrowsingFollowsTheChosenMachine(t *testing.T) {
 	model := addWorkspaceFixture(t, "devbox")
-	model.selectAddWorkspaceHost(1)
+	model.switchAddWorkspaceTab(tabRemote)
+	model.openMachine()
 
 	choice, ok := model.selectedDirectory()
 	if !ok || choice.kind != directoryYazi || choice.host != "devbox" {
@@ -96,12 +134,12 @@ func TestAMissingLocalYaziDoesNotHideARemoteOne(t *testing.T) {
 	model := addWorkspaceFixture(t, "devbox")
 	model.yaziPath = ""
 	model.setAddWorkspaceChoices()
-	if _, ok := model.selectedDirectory(); ok &&
-		model.directories[0].kind == directoryYazi {
+	if model.directories[0].kind == directoryYazi {
 		t.Fatal("no yazi here means no browse row here")
 	}
 
-	model.selectAddWorkspaceHost(1)
+	model.switchAddWorkspaceTab(tabRemote)
+	model.openMachine()
 	if model.directories[0].kind != directoryYazi {
 		t.Fatalf("browsing another machine should still be offered: %#v", model.directories)
 	}
@@ -115,7 +153,8 @@ func TestAMissingLocalYaziDoesNotHideARemoteOne(t *testing.T) {
 // wrong reason.
 func TestATypedRemotePathIsNotCheckedHere(t *testing.T) {
 	model := addWorkspaceFixture(t, "devbox")
-	model.selectAddWorkspaceHost(1)
+	model.switchAddWorkspaceTab(tabRemote)
+	model.openMachine()
 
 	updated, cmd := model.submitAddWorkspace("/srv/api")
 	if cmd == nil {

--- a/internal/ui/model.go
+++ b/internal/ui/model.go
@@ -101,16 +101,47 @@ type workspaceGroup struct {
 	agents  []agent.Agent
 }
 
+// addWorkspaceTab is which half of the Add Workspace modal is showing.
+// Local is the common answer and the one it opens on.
+type addWorkspaceTab int
+
+const (
+	tabLocal addWorkspaceTab = iota
+	tabRemote
+)
+
+// machineChoice is one row of the Remote tab: a machine from the user's
+// SSH configuration, or the row for naming one it does not list.
+type machineChoice struct {
+	kind    machineChoiceKind
+	name    string
+	detail  string
+	summary string
+}
+
+type machineChoiceKind int
+
+const (
+	machineHost machineChoiceKind = iota
+	machineTyped
+)
+
 type directoryChoiceKind int
 
 const (
 	directoryPath directoryChoiceKind = iota
 	directoryYazi
 	directoryCustom
+	// directorySetup is not a directory at all: it is the row that
+	// prepares the machine so the others can work.
+	directorySetup
 )
 
 type directoryChoice struct {
 	kind directoryChoiceKind
+	// detail overrides the row's right-hand column, for rows whose
+	// meaning changes with the machine they act on.
+	detail string
 	// host is the machine the path is on; empty is this one. Two
 	// machines can offer the same path, and they are different choices.
 	host          string
@@ -136,11 +167,13 @@ type Model struct {
 	catalogWorkspaces []workspace.Context
 	workspaceRoots    []workspace.Context
 	groups            []workspaceGroup
-	// hosts are the machines the Add Workspace modal can browse, and
-	// addWorkspaceHost is which of them it is on. Index 0 is always this
-	// machine, named by the empty string.
-	hosts            []string
-	addWorkspaceHost int
+	// The Add Workspace modal: which tab is showing, which machine the
+	// Remote tab has been opened on, and the machines it can offer.
+	addWorkspaceTab  addWorkspaceTab
+	addWorkspaceHost string
+	machines         []machineChoice
+	machineIndex     int
+	hostInput        lineInput
 	// dispatchHost is the machine the open dispatch form is aimed at. It
 	// travels with the directory rather than being asked for separately:
 	// a path only means anything alongside the machine it is on.
@@ -233,6 +266,27 @@ type Model struct {
 	overlayGeneration int
 }
 
+// machineChoices is the Remote tab's rows: what the SSH configuration
+// names, and then the row for a machine it does not. Naming one is what
+// makes it usable, so the typed row is always there — most people's
+// configuration names nothing at all.
+func machineChoices(hosts []HostChoice) []machineChoice {
+	choices := make([]machineChoice, 0, len(hosts)+1)
+	for _, host := range hosts {
+		choices = append(choices, machineChoice{
+			kind:    machineHost,
+			name:    host.Name,
+			detail:  "SSH",
+			summary: host.Summary,
+		})
+	}
+	return append(choices, machineChoice{
+		kind:   machineTyped,
+		name:   "Type a destination…",
+		detail: "SSH",
+	})
+}
+
 type dashboardMsg struct {
 	agents     []agent.Agent
 	workspaces []workspace.Context
@@ -262,6 +316,12 @@ type directoryPickedMsg struct {
 	// is, and the two are one answer.
 	host string
 	path string
+	err  error
+}
+
+// machinePreparedMsg reports the end of a host setup run.
+type machinePreparedMsg struct {
+	host string
 	err  error
 }
 
@@ -306,8 +366,15 @@ type Options struct {
 	Keys KeyBindings
 	// Hosts are the machines to offer when adding a workspace, in the
 	// order they should appear — read from the user's SSH configuration.
-	// This machine is always the first choice and is not in this list.
-	Hosts []string
+	// This machine is not among them; it has its own tab.
+	Hosts []HostChoice
+}
+
+// HostChoice is a machine the Add Workspace modal can offer: the name
+// Stormlight will call it, and what its configuration says it is.
+type HostChoice struct {
+	Name    string
+	Summary string
 }
 
 func NewModelWithOptions(backend Backend, options Options) Model {
@@ -360,9 +427,8 @@ func NewModelWithOptions(backend Backend, options Options) Model {
 		ptyEnabled:         true,
 		ptyManager:         ptyview.NewManager(backend),
 		keys:               fillKeyDefaults(options.Keys),
-		// This machine first, then whatever the user's SSH configuration
-		// names. The empty string is how everything else says "here".
-		hosts: append([]string{""}, options.Hosts...),
+		machines:           machineChoices(options.Hosts),
+		hostInput:          newLineInput("user@host"),
 	}
 	for index, info := range model.providers {
 		if info.ID == options.DefaultProvider {
@@ -597,6 +663,12 @@ func (m Model) Update(message tea.Msg) (tea.Model, tea.Cmd) {
 		m.formFocus = dispatchTask
 		m.focusForm()
 		m.syncTaskComposerSize()
+		return m, nil
+
+	case machinePreparedMsg:
+		if msg.err != nil {
+			m.err = fmt.Errorf("set up %s: %w", msg.host, msg.err)
+		}
 		return m, nil
 
 	case taskEditedMsg:

--- a/internal/ui/overlays.go
+++ b/internal/ui/overlays.go
@@ -288,6 +288,29 @@ func (m Model) openYazi() (tea.Model, tea.Cmd) {
 	return m, m.openOverlay(yaziPickerSpec(host, start, m.yaziPath))
 }
 
+// openSetup runs the host preparation in a popup. It runs *here* rather
+// than there — the whole point is a machine that may not have Stormlight
+// yet — and it gets a real terminal so a package manager asking for a
+// password has somewhere to ask.
+func (m Model) openSetup(host string) (tea.Model, tea.Cmd) {
+	if host == "" {
+		return m, nil
+	}
+	return m, m.openOverlay(overlaySpec{
+		title: "Set up " + host,
+		// Empty host: this machine, which is the one holding the ssh
+		// configuration and the binary to copy.
+		host: "",
+		path: "",
+		args: []string{"remote", "setup", host, "--install", "--yazi", "--wait"},
+		dir:  m.initialCwd,
+		result: func(_ string, runErr error) tea.Msg {
+			return machinePreparedMsg{host: host, err: runErr}
+		},
+		cleanup: func() {},
+	})
+}
+
 // yaziPickerSpec builds the picker overlay.
 //
 // The program is Stormlight itself on the machine being browsed, because

--- a/internal/ui/workspaces.go
+++ b/internal/ui/workspaces.go
@@ -31,6 +31,22 @@ func (m Model) updateAddWorkspace(msg tea.KeyPressMsg) (tea.Model, tea.Cmd) {
 	}
 	m.dispatchPrefix = ""
 
+	// Naming a machine the SSH configuration does not: the row's own
+	// input, which takes everything but the keys that leave it.
+	if m.showingMachines() && m.formFocus == dispatchCustomPath &&
+		key != "esc" && key != "ctrl+c" && key != "ctrl+[" {
+		if key == "enter" {
+			destination := strings.TrimSpace(m.hostInput.Value())
+			if destination == "" {
+				return m, nil
+			}
+			m.enterMachine(destination)
+			return m, nil
+		}
+		m.hostInput = m.hostInput.Update(msg)
+		return m, nil
+	}
+
 	if m.formFocus == dispatchCustomPath &&
 		key != "esc" && key != "ctrl+c" && key != "ctrl+[" {
 		if confirmed := m.handlePathNavKey(msg); confirmed {
@@ -41,25 +57,41 @@ func (m Model) updateAddWorkspace(msg tea.KeyPressMsg) (tea.Model, tea.Cmd) {
 
 	switch key {
 	case "esc", "ctrl+c", "ctrl+[":
+		// Inside a machine, Esc steps back out to the list rather than
+		// abandoning the whole modal.
+		if m.addWorkspaceTab == tabRemote && m.addWorkspaceHost != "" {
+			m.leaveMachine()
+			return m, nil
+		}
+		if m.showingMachines() && m.formFocus == dispatchCustomPath {
+			m.hostInput.Blur()
+			m.formFocus = dispatchDirectory
+			return m, nil
+		}
 		m.mode = modeNormal
 		m.blurForm()
 		return m, nil
-	case "h", "left":
-		if m.formFocus == dispatchDirectory {
-			m.selectAddWorkspaceHost(-1)
-			return m, nil
+	case "tab", "shift+tab", "h", "left", "l", "right":
+		if m.addWorkspaceTab == tabLocal {
+			m.switchAddWorkspaceTab(tabRemote)
+		} else {
+			m.switchAddWorkspaceTab(tabLocal)
 		}
-	case "l", "right":
-		if m.formFocus == dispatchDirectory {
-			m.selectAddWorkspaceHost(1)
-			return m, nil
-		}
+		return m, nil
 	case "j", "down":
+		if m.showingMachines() {
+			m.selectMachine(1)
+			return m, nil
+		}
 		if m.formFocus == dispatchDirectory {
 			m.selectDirectory(1)
 			return m, nil
 		}
 	case "k", "up":
+		if m.showingMachines() {
+			m.selectMachine(-1)
+			return m, nil
+		}
 		if m.formFocus == dispatchDirectory {
 			m.selectDirectory(-1)
 			return m, nil
@@ -80,11 +112,17 @@ func (m Model) updateAddWorkspace(msg tea.KeyPressMsg) (tea.Model, tea.Cmd) {
 			return m, nil
 		}
 	case "enter":
+		if m.showingMachines() {
+			m.openMachine()
+			return m, nil
+		}
 		selected, ok := m.selectedDirectory()
 		if !ok {
 			return m, nil
 		}
 		switch selected.kind {
+		case directorySetup:
+			return m.openSetup(selected.host)
 		case directoryYazi:
 			return m.openYazi()
 		case directoryCustom:
@@ -146,6 +184,15 @@ func (m Model) renderWorkspaceRow(
 		nameNeed,
 	)
 	suffix := chipsPlain(chips)
+	// A workspace on another machine is marked in the column itself, not
+	// only in the subtitle: compact rows have no subtitle, and which
+	// machine a workspace is on is the one thing about it not worth
+	// guessing at. The marker rides with the counts rather than the name
+	// so that a remote workspace is not also a truncated one.
+	remote := group.context.Host != ""
+	if remote {
+		suffix = remoteMarker + " " + suffix
+	}
 	// Nothing marks this column. A selected-but-unfocused workspace is
 	// already named by the row that stays at full strength while its
 	// neighbours dim, and by the connector arc pointing out of it — an arrow
@@ -199,10 +246,14 @@ func (m Model) renderWorkspaceRow(
 	case stats.Working > 0:
 		renderedName = shimmerText(name, m.shimmerPhaseOrRest(), nil)
 	}
+	styledSuffix := chipsStyled(chips)
+	if remote {
+		styledSuffix = mutedStyle().Render(remoteMarker+" ") + styledSuffix
+	}
 	top := gutter +
 		renderedName +
 		strings.Repeat(" ", gap) +
-		chipsStyled(chips)
+		styledSuffix
 	bottom := mutedStyle().Render(" " + bottomContent)
 	if !m.expandedRows() {
 		return top
@@ -373,6 +424,11 @@ func renderSelectedWorkspaceRow(
 // tokens — resolver kind, home-relative root, and the component when it
 // adds information — indented under the name rather than justified across
 // the row.
+// remoteMarker prefixes a workspace that lives on another machine. It is
+// the same geometric vocabulary as the status glyphs rather than a Nerd
+// Font icon, which not every terminal Stormlight runs in would have.
+const remoteMarker = "⇢"
+
 func workspaceDetail(value workspace.Context, width int) string {
 	width = max(1, width)
 	kind := strings.ToLower(strings.TrimSpace(value.Kind))

--- a/internal/windrun/overlay.go
+++ b/internal/windrun/overlay.go
@@ -2,6 +2,7 @@ package windrun
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"os"
 	"strings"
@@ -16,6 +17,12 @@ import (
 // no agent document, so the roster already ignores them; the marker makes
 // them legible in `windrunner ls` and debugging.
 const overlayMetadataKey = "stormlight_overlay"
+
+// OverlayErrorKey is where an overlay program leaves the reason it could
+// not answer. The program's own stderr goes to a popup that closes with
+// it, so without this the dashboard can only report the exit status —
+// "exited with status 1" for a machine that simply has no yazi.
+const OverlayErrorKey = "stormlight_overlay_error"
 
 // OverlayResultKey is where an overlay program leaves its answer: its own
 // session's metadata, which the daemon stores without reading and the
@@ -99,6 +106,9 @@ func (o *overlay) Result(_ context.Context) (string, error) {
 	info, err := o.client.Info(o.id)
 	if err != nil {
 		return "", err
+	}
+	if reason := info.Metadata[OverlayErrorKey]; reason != "" {
+		return "", errors.New(reason)
 	}
 	return info.Metadata[OverlayResultKey], nil
 }

--- a/internal/workspace/remote.go
+++ b/internal/workspace/remote.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"strings"
 
@@ -136,7 +137,7 @@ func (r remoteResolver) run(ctx context.Context, args ...string) ([]byte, error)
 		// problems this is: no stormlight there, no such directory, a
 		// key that is not accepted.
 		if message := strings.TrimSpace(stderr.String()); message != "" {
-			return nil, fmt.Errorf("%s: %s", r.Name(), message)
+			return nil, errors.New(remote.Explain(r.host, message))
 		}
 		return nil, fmt.Errorf("%s: %w", r.Name(), err)
 	}

--- a/main.go
+++ b/main.go
@@ -117,6 +117,7 @@ func newRootCommand() *cobra.Command {
 		newDeleteCommand(cfg),
 		newMarkCommand(cfg),
 		newWorkspaceCommand(cfg),
+		newRemoteCommand(cfg),
 		newEventCommand(cfg),
 		newProviderEventCommand(cfg),
 		newLogsCommand(&logFile),
@@ -276,6 +277,10 @@ func newPickCommand() *cobra.Command {
 			}
 			chosen, err := picker.Choose(yaziPath, start)
 			if err != nil {
+				// The popup closes with this process, taking its stderr
+				// with it, so the reason goes where the dashboard can
+				// still read it.
+				_ = recordPickFailure(err)
 				return err
 			}
 			return recordPick(chosen)
@@ -286,6 +291,13 @@ func newPickCommand() *cobra.Command {
 	return command
 }
 
+// recordPickFailure records why there is no answer, so the dashboard can
+// say "yazi is not installed on devbox" rather than "exited with status
+// 1".
+func recordPickFailure(reason error) error {
+	return writeOverlayMetadata(windrun.OverlayErrorKey, reason.Error())
+}
+
 // recordPick writes the answer into this process's own session. Quitting
 // without choosing records nothing, which is how the dashboard tells a
 // cancelled picker from one that chose.
@@ -293,11 +305,17 @@ func recordPick(chosen string) error {
 	if strings.TrimSpace(chosen) == "" {
 		return nil
 	}
+	return writeOverlayMetadata(windrun.OverlayResultKey, chosen)
+}
+
+// writeOverlayMetadata leaves a value in this process's own session, for
+// whoever is holding the other end of it.
+func writeOverlayMetadata(key, value string) error {
 	sessionID := os.Getenv("WINDRUNNER_SESSION")
 	if sessionID == "" {
-		// Run by hand rather than as an overlay: say the answer instead
-		// of filing it.
-		fmt.Println(chosen)
+		// Run by hand rather than as an overlay: say it instead of
+		// filing it.
+		fmt.Println(value)
 		return nil
 	}
 	c, err := wrclient.Dial(windrun.SocketPath())
@@ -313,7 +331,7 @@ func recordPick(chosen string) error {
 	if metadata == nil {
 		metadata = map[string]string{}
 	}
-	metadata[windrun.OverlayResultKey] = chosen
+	metadata[key] = value
 	return c.SetMetadata(sessionID, metadata)
 }
 
@@ -606,14 +624,27 @@ func fleetHosts(cfg config.Config, catalog *workspace.Catalog) []string {
 // dashboardHosts is every machine worth offering, in a stable order:
 // what ~/.ssh/config names first, then anything configured here that it
 // did not.
-func dashboardHosts(cfg config.Config) []string {
-	hosts := remote.KnownHosts()
-	for _, name := range slices.Sorted(maps.Keys(cfg.Hosts)) {
-		if !slices.Contains(hosts, name) {
-			hosts = append(hosts, name)
-		}
+func dashboardHosts(cfg config.Config) []ui.HostChoice {
+	var choices []ui.HostChoice
+	named := map[string]bool{}
+	for _, host := range remote.KnownHosts() {
+		named[host.Name] = true
+		choices = append(choices, ui.HostChoice{
+			Name:    host.Name,
+			Summary: host.Summary(),
+		})
 	}
-	return hosts
+	for _, name := range slices.Sorted(maps.Keys(cfg.Hosts)) {
+		if named[name] {
+			continue
+		}
+		summary := cfg.Hosts[name].Destination
+		if summary == name {
+			summary = ""
+		}
+		choices = append(choices, ui.HostChoice{Name: name, Summary: summary})
+	}
+	return choices
 }
 
 func remoteMember(cfg config.Config, name string) fleet.Member {
@@ -771,6 +802,133 @@ func newListCommand(cfg config.Config) *cobra.Command {
 	}
 	command.Flags().BoolVar(&asJSON, "json", false, "emit JSON")
 	return command
+}
+
+// newRemoteCommand groups what a machine needs before it can hold
+// agents. Reaching a host is one binary and one optional tool, and the
+// difference between "it does not work" and "it needs yazi" is worth a
+// command rather than a guess.
+func newRemoteCommand(cfg config.Config) *cobra.Command {
+	command := &cobra.Command{
+		Use:   "remote",
+		Short: "Inspect and prepare machines Stormlight can reach",
+	}
+	command.AddCommand(newRemoteListCommand(cfg), newRemoteSetupCommand(cfg))
+	return command
+}
+
+func newRemoteListCommand(cfg config.Config) *cobra.Command {
+	return &cobra.Command{
+		Use:   "list",
+		Short: "List the machines this dashboard would offer",
+		Args:  cobra.NoArgs,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			hosts := dashboardHosts(cfg)
+			if len(hosts) == 0 {
+				fmt.Fprintln(cmd.OutOrStdout(),
+					"No machines in ~/.ssh/config or [hosts.*]. Any name works anyway.")
+				return nil
+			}
+			for _, host := range hosts {
+				fmt.Fprintf(cmd.OutOrStdout(), "%s\t%s\n", host.Name, host.Summary)
+			}
+			return nil
+		},
+	}
+}
+
+func newRemoteSetupCommand(cfg config.Config) *cobra.Command {
+	var install bool
+	var withYazi bool
+	var wait bool
+	command := &cobra.Command{
+		Use:   "setup <host>",
+		Short: "Report what a machine is missing, and optionally install it",
+		Args:  cobra.ExactArgs(1),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			host := remoteHostFrom(args[0], cfg.Hosts[args[0]])
+			transport := remote.NewTransport(host)
+			out := cmd.OutOrStdout()
+
+			report, err := remote.Probe(cmd.Context(), transport)
+			if err != nil {
+				return err
+			}
+			writeRemoteReport(out, report)
+			if !install {
+				if !report.Ready() || !report.Yazi.Present() {
+					fmt.Fprintf(out, "\nRun with --install to fix this.\n")
+				}
+				holdOpen(out, wait)
+				return nil
+			}
+
+			if !report.Stormlight.Present() {
+				binary, err := selfpath.Resolve()
+				if err != nil {
+					return err
+				}
+				if err := remote.InstallStormlight(
+					cmd.Context(), transport, report, binary, out); err != nil {
+					return err
+				}
+			}
+			if withYazi && !report.Yazi.Present() {
+				if err := remote.InstallYazi(cmd.Context(), transport, report, out); err != nil {
+					return err
+				}
+			}
+			fresh, err := remote.Probe(cmd.Context(), transport)
+			if err != nil {
+				return err
+			}
+			fmt.Fprintln(out)
+			writeRemoteReport(out, fresh)
+			holdOpen(out, wait)
+			return nil
+		},
+	}
+	command.Flags().BoolVar(&install, "install", false,
+		"install what is missing rather than only reporting it")
+	command.Flags().BoolVar(&withYazi, "yazi", false,
+		"also install yazi, using the host's own package manager")
+	command.Flags().BoolVar(&wait, "wait", false,
+		"hold the terminal open at the end, for a popup nobody else closes")
+	return command
+}
+
+// holdOpen keeps a popup up long enough to be read. The overlay closes
+// when its program exits, and a report that scrolls past in a tenth of a
+// second is a report nobody has seen.
+func holdOpen(out io.Writer, wait bool) {
+	if !wait {
+		return
+	}
+	fmt.Fprintf(out, "\nPress any key to close.\n")
+	var one [1]byte
+	_, _ = os.Stdin.Read(one[:])
+}
+
+func writeRemoteReport(out io.Writer, report remote.Report) {
+	fmt.Fprintf(out, "%s\t%s\n", report.Host, report.Platform)
+	line := func(requirement remote.Requirement, note string) {
+		state := "missing"
+		detail := note
+		if requirement.Present() {
+			state = "ok"
+			detail = requirement.Path
+			if requirement.Version != "" {
+				detail += "  " + requirement.Version
+			}
+		}
+		fmt.Fprintf(out, "  %-11s %-8s %s\n", requirement.Name, state, detail)
+	}
+	line(report.Stormlight, "required — the bridge, the resolver and the picker are all this binary")
+	yaziNote := "optional — browsing needs it; a typed path does not"
+	if !report.Yazi.Present() && report.YaziInstallCommand() != "" {
+		yaziNote = "optional — " + report.YaziInstallCommand()
+	}
+	line(report.Yazi, yaziNote)
 }
 
 func newWorkspaceCommand(cfg config.Config) *cobra.Command {

--- a/site/docs/architecture.html
+++ b/site/docs/architecture.html
@@ -231,8 +231,23 @@
     because resolution happened there. The name is also what qualifies workspace IDs.</p>
     <p>A host is known because something names it, not because it was configured: a
     workspace on it, a dispatch aimed at it, a name picked out of <code>~/.ssh/config</code>
-    in the Add Workspace modal, which offers this machine first and then whatever that file
-    names.
+    in the Add Workspace modal's Remote tab, which lists what that file names and takes a
+    destination it does not.</p>
+    <p>Two rules keep one machine from looking like two. An agent has one identity, so two
+    members reporting the same one are two names for the same daemon — a host that resolves
+    back to this machine, say — and the first to claim it wins. And an agent's workspace is
+    on the machine the agent is on, so the fleet stamps its context: the copy stored at
+    dispatch would otherwise group apart from the same workspace reached through a host.</p>
+    <p>Nothing Stormlight sends a host may assume a shell. <code>ssh host &lt;command&gt;</code>
+    runs it in whatever login shell that account has, which is as likely to be fish as sh, so
+    scripts go to <code>/bin/sh</code> on stdin — unquoted, unparsed by anything else. Every
+    ssh call is bounded by a connect timeout, and a host that fails to answer is left alone
+    for a while rather than dialled again on the next refresh.</p>
+    <p><code>stormlight remote setup &lt;host&gt;</code> reports what a machine is missing
+    and can install it. Stormlight itself is copied from this machine when the platforms
+    match — the same build, so the two ends cannot disagree about the protocol between them —
+    and pointed at the releases when they do not. Yazi is offered only through the host's own
+    package manager, and described rather than guessed at when there is none.
     Members exist at start-up for the machines the catalog says hold a workspace — listing
     names no host, so without that a machine's agents would be invisible until something
     mentioned one — and any other joins the moment it is first named.


### PR DESCRIPTION
Closes #138. The Add Workspace modal in the shape from the mock: a Local/Remote
tab strip, the Remote tab listing what `~/.ssh/config` names, Enter to drill
into one.

```
   Local   ▏Remote                                    Tab switches
  Machine                                        1/4
  ▌sandbox              SSH    trent@localhost         Enter opens
   devbox               SSH    trent@10.0.0.4
   builder              SSH    trent@builder.example.internal:2222
   Type a destination…  NEW    A machine ~/.ssh/config does not name
```

Hosts carry what the config says they are, because "which `builder` is this" is
the question a list of bare names cannot answer. Choosing one drills in, with
the machine as a breadcrumb rather than a third tab, and `Esc` steps back to the
list rather than abandoning the modal. Typing a destination works because a host
is known by being named (#139).

### Setting a machine up

Inside a machine there is a third row. A host needs Stormlight before it can be
reached at all — the bridge, the resolver and the picker are all that binary —
and Yazi before it can be browsed.

`stormlight remote setup <host>` reports what is missing and installs it, and
the row runs it in a popup with a real terminal, so a package manager asking for
a password has somewhere to ask. Stormlight is copied from this machine when the
platforms match — that is the build the dashboard is already running, so the two
ends cannot disagree about the protocol between them — and pointed at the
releases when they do not. Yazi only through the host's own package manager,
described rather than guessed at when there is none.

Also `stormlight remote list`.

### Three things found by running it

**Nothing sent to a host may assume a shell.** `ssh host <command>` runs it in
whatever login shell that account has, and a POSIX script is not fish — nor does
quoting help, because the quoting is what fish parses differently. Scripts go to
`/bin/sh` on stdin now, where nothing quotes them and nothing else parses them.
Caught on a machine whose shell is fish; it would have worked for almost
everyone and failed bafflingly for the rest.

**Yazi was reported missing on a machine that had it.** A command run over ssh
gets a non-interactive shell whose PATH is often the bare system one, so
`/opt/homebrew/bin` is not on it. Asking a login shell is the difference between
browsing that machine and being told it is unsupported.

**One daemon reached by two names listed everything twice.** An agent has one
identity, so the first member to claim it wins. And an agent's workspace is on
the machine the agent is on, so the fleet stamps its context — the copy stored
at dispatch would otherwise group apart from the same workspace reached through
a host, which is the duplicate *workspace* half of the same report.

### An unreachable host no longer stalls the pane

Every ssh call is bounded by a connect timeout, and a resolution that failed is
remembered as deliberately as one that succeeded. A machine that is asleep costs
a connection attempt to discover and the dashboard refreshes on a timer; before
this, a catalogued workspace on a sleeping laptop meant a permanently
half-empty workspace pane.

### Marking remote workspaces

`⇢` beside the counts rather than the name, so a remote workspace is not also a
truncated one. A geometric glyph like the existing status marks, not a Nerd Font
icon — not every terminal Stormlight runs in has patched fonts.

### Testing

`go test ./...` and `go vet ./...` green. New coverage: the modal opens on
Local; the Remote tab lists hosts with summaries and always offers the typed
row; opening a machine drills in and `Esc` returns; browsing follows the chosen
machine; a missing local Yazi does not hide a remote browse; a typed remote path
is not checked here; probe parsing, readiness, an unaccepted host key explained,
foreign platforms refused, Yazi offered only where installable, scripts not
depending on the login shell; an unreachable host dialled once across four
refreshes.

**Against a real machine over real ssh**: the tab walked this machine's own
`~/.ssh/config`, browsing `sandbox` opened Yazi there and returned the directory
through the overlay's session, and the installer copied 25MB to a scratch path,
moved it into place, and read the version back.

**Non-regression**: a local dashboard renders byte-identically to `main`.

### Known, filed separately

#144 — a daemon older than a spawn field drops it silently, which surfaces as an
empty `$STORMLIGHT_BIN` in hooks and Claude Code's title leaking into the input
box. Not caused by this PR; found while testing it.