### PR TITLE
A hook that cannot find Stormlight falls back to its name

### DIFF
--- a/internal/provider/hooks.go
+++ b/internal/provider/hooks.go
@@ -40,10 +40,17 @@ const hookTimeoutSeconds = 5
 // The provider passes the payload on stdin, and $STORMLIGHT_BIN is read at
 // hook time rather than baked in so the value comes from the environment
 // the managed process was started with.
+//
+// It falls back to the name on PATH, because an empty variable is not a
+// hypothetical: a daemon older than the field carrying it drops it
+// silently, and `exec ""` fails as `exec: : not found` — an error three
+// layers from anything that explains it. Any machine hosting agents has
+// Stormlight installed by definition, so the fallback is the same binary
+// nine times in ten, and a legible failure the tenth.
 func reportEvent(providerID agent.Provider) hookCommand {
 	return hookCommand{
 		Type:    "command",
-		Command: `exec "$STORMLIGHT_BIN" _provider-event ` + string(providerID),
+		Command: `exec "${STORMLIGHT_BIN:-stormlight}" _provider-event ` + string(providerID),
 		Timeout: hookTimeoutSeconds,
 	}
 }

--- a/internal/provider/hooks_test.go
+++ b/internal/provider/hooks_test.go
@@ -1,0 +1,41 @@
+package provider
+
+import (
+	"os"
+	"os/exec"
+	"strings"
+	"testing"
+
+	"github.com/trentkm/stormlight/internal/agent"
+)
+
+// TestHooksSurviveAnEmptyBinaryVariable: $STORMLIGHT_BIN arrives in the
+// agent's environment, and a daemon older than the field carrying it
+// drops that field without a word. `exec ""` then fails as
+// "exec: : not found" — an error three layers from anything explaining
+// it. Any machine hosting agents has Stormlight on it by definition, so
+// the name is a better last resort than nothing.
+func TestHooksSurviveAnEmptyBinaryVariable(t *testing.T) {
+	command := reportEvent(agent.ProviderClaude).Command
+	if !strings.Contains(command, "${STORMLIGHT_BIN:-stormlight}") {
+		t.Fatalf("hook command = %q", command)
+	}
+
+	// Prove the shell agrees: an unset variable resolves to the fallback,
+	// and a set one still wins.
+	for _, test := range []struct{ env, want string }{
+		{"", "stormlight"},
+		{"/opt/stormlight/bin/stormlight", "/opt/stormlight/bin/stormlight"},
+	} {
+		script := `printf '%s' "${STORMLIGHT_BIN:-stormlight}"`
+		run := exec.Command("/bin/sh", "-c", script)
+		run.Env = append(os.Environ(), "STORMLIGHT_BIN="+test.env)
+		out, err := run.Output()
+		if err != nil {
+			t.Fatal(err)
+		}
+		if string(out) != test.want {
+			t.Fatalf("STORMLIGHT_BIN=%q resolved to %q, want %q", test.env, out, test.want)
+		}
+	}
+}

--- a/internal/provider/provider.go
+++ b/internal/provider/provider.go
@@ -415,7 +415,7 @@ func codexLifecycleArgs(mode agent.PermissionMode) ([]string, error) {
 		Notify: []string{
 			"/bin/sh",
 			"-c",
-			`exec "$STORMLIGHT_BIN" _provider-event codex "$0"`,
+			`exec "${STORMLIGHT_BIN:-stormlight}" _provider-event codex "$0"`,
 		},
 	})
 	if err != nil {


### PR DESCRIPTION
The lifecycle hooks run `exec "$STORMLIGHT_BIN" _provider-event`, reading the
variable at hook time so the value comes from the environment the agent was
started with. When it is empty the shell says:

```
Stop hook error: Failed with non-blocking status code:
/bin/sh: line 0: exec: : not found
```

which is an error three layers from anything that explains it — and the agent
silently stops reporting state from then on.

Empty is not hypothetical: a daemon older than the spawn field carrying that
environment drops the field without a word (#144), so every agent it starts has
no `STORMLIGHT_BIN` at all. Hit while testing remote dispatch against a daemon
three days older than the dashboard.

`${STORMLIGHT_BIN:-stormlight}` falls back to the name on PATH. Any machine
hosting agents has Stormlight installed by definition — it is the bridge, the
resolver and the picker — so nine times in ten the fallback is the same binary
the variable would have named, and the tenth fails somewhere legible.

Both the Claude/Codex hook handlers and Codex's `notify` callback.

### Testing

`go test ./...` green. The new test asserts the fallback is in the command and
that `/bin/sh` agrees about what it resolves to, both unset and set.

Does not close #144 — that field carries more than this one variable, and its
other passenger is the `CLAUDE_CODE_DISABLE_TERMINAL_TITLE` setting whose
absence puts Claude Code's title back in the input box. This makes the loudest
half stop.