### PR TITLE
Setting up a host fetches the build that host can run

### DIFF
--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -232,7 +232,14 @@ absence, not the dashboard's responsiveness.
 `stormlight remote setup <host>` reports what a machine is missing and
 can install it. Stormlight itself is copied from this machine when the
 platforms match — the same build, so the two ends cannot disagree about
-the protocol between them — and pointed at the releases when they do not.
+the protocol between them — and otherwise fetched as that platform's
+published archive, checked against the release's own checksums here
+rather than there: the machine being prepared is precisely the one with
+no Stormlight to check anything with. A development build has no
+published archive and says so instead of guessing at a version. The
+installed path is recorded as that host's `bin`, because a
+non-interactive SSH shell frequently has no `~/.local/bin` on its PATH
+and would not find what was just put there.
 Yazi is offered only through the host's own package manager, and
 described rather than guessed at when there is none. Members exist at start-up for the machines the
 catalog says hold a workspace — listing names no host, so without that a

--- a/internal/remote/install.go
+++ b/internal/remote/install.go
@@ -1,0 +1,167 @@
+package remote
+
+import (
+	"archive/tar"
+	"compress/gzip"
+	"context"
+	"crypto/sha256"
+	"encoding/hex"
+	"fmt"
+	"io"
+	"net/http"
+	"os"
+	"strings"
+	"time"
+)
+
+// releaseHost is where published builds live. A host being prepared from
+// this machine gets the archive for its own platform, fetched here and
+// checked here, rather than a URL handed to it to trust on its own.
+const releaseHost = "https://github.com/trentkm/stormlight/releases/download"
+
+// downloadTimeout bounds fetching one archive. They are tens of
+// megabytes; a minute is generous and a stall is not a thing to wait out
+// inside a popup.
+const downloadTimeout = 60 * time.Second
+
+// Target is a platform in the naming published builds use.
+type Target struct {
+	OS   string
+	Arch string
+}
+
+func (t Target) String() string { return t.OS + "/" + t.Arch }
+
+// TargetFor reads `uname -sm` the way Go names the same platform.
+//
+// The two vocabularies disagree in exactly the places that matter:
+// `aarch64` and `arm64` are one machine with two names, as are `x86_64`
+// and `amd64`, and picking the wrong one downloads a binary that will
+// not run.
+func TargetFor(platform string) (Target, bool) {
+	fields := strings.Fields(platform)
+	if len(fields) != 2 {
+		return Target{}, false
+	}
+	var target Target
+	switch strings.ToLower(fields[0]) {
+	case "darwin":
+		target.OS = "darwin"
+	case "linux":
+		target.OS = "linux"
+	default:
+		return Target{}, false
+	}
+	switch strings.ToLower(fields[1]) {
+	case "arm64", "aarch64":
+		target.Arch = "arm64"
+	case "x86_64", "amd64":
+		target.Arch = "amd64"
+	default:
+		return Target{}, false
+	}
+	return target, true
+}
+
+// releaseBinary fetches the published build for a platform and returns
+// the executable inside it, having checked the archive against the
+// release's own checksums.
+//
+// Checked here rather than there: the machine being prepared is the one
+// that cannot yet be trusted to check anything, since the whole reason
+// for this is that it has no Stormlight on it.
+func releaseBinary(ctx context.Context, version string, target Target) ([]byte, error) {
+	number := strings.TrimPrefix(version, "v")
+	if number == "" || number == "dev" {
+		return nil, fmt.Errorf(
+			"this is a development build (%s), so there is no published archive to "+
+				"install on a %s host — build one for that platform and copy it there, "+
+				"or install a release on it and set bin = in its [hosts.*] entry",
+			version, target)
+	}
+	archive := fmt.Sprintf("stormlight_%s_%s_%s.tar.gz", number, target.OS, target.Arch)
+	base := fmt.Sprintf("%s/v%s", releaseHost, number)
+
+	sums, err := fetch(ctx, base+"/checksums.txt")
+	if err != nil {
+		return nil, fmt.Errorf("read the release checksums: %w", err)
+	}
+	want, ok := checksumFor(sums, archive)
+	if !ok {
+		return nil, fmt.Errorf(
+			"release v%s publishes nothing for %s", number, target)
+	}
+
+	payload, err := fetch(ctx, base+"/"+archive)
+	if err != nil {
+		return nil, fmt.Errorf("download %s: %w", archive, err)
+	}
+	sum := sha256.Sum256(payload)
+	if got := hex.EncodeToString(sum[:]); got != want {
+		return nil, fmt.Errorf(
+			"%s does not match the checksum the release published "+
+				"(got %s, want %s) — refusing to install it", archive, got, want)
+	}
+	return binaryFromArchive(payload)
+}
+
+func fetch(ctx context.Context, url string) ([]byte, error) {
+	ctx, cancel := context.WithTimeout(ctx, downloadTimeout)
+	defer cancel()
+	request, err := http.NewRequestWithContext(ctx, http.MethodGet, url, nil)
+	if err != nil {
+		return nil, err
+	}
+	response, err := http.DefaultClient.Do(request)
+	if err != nil {
+		return nil, err
+	}
+	defer response.Body.Close()
+	if response.StatusCode != http.StatusOK {
+		return nil, fmt.Errorf("%s: %s", url, response.Status)
+	}
+	return io.ReadAll(response.Body)
+}
+
+// checksumFor reads goreleaser's checksums.txt: one "<sum>  <file>" per
+// line.
+func checksumFor(sums []byte, archive string) (string, bool) {
+	for _, line := range strings.Split(string(sums), "\n") {
+		fields := strings.Fields(line)
+		if len(fields) == 2 && fields[1] == archive {
+			return fields[0], true
+		}
+	}
+	return "", false
+}
+
+// binaryFromArchive pulls the executable out of a release tarball, which
+// also carries the licence and the readme.
+func binaryFromArchive(payload []byte) ([]byte, error) {
+	uncompressed, err := gzip.NewReader(strings.NewReader(string(payload)))
+	if err != nil {
+		return nil, err
+	}
+	defer uncompressed.Close()
+	archive := tar.NewReader(uncompressed)
+	for {
+		header, err := archive.Next()
+		if err == io.EOF {
+			break
+		}
+		if err != nil {
+			return nil, err
+		}
+		if header.Typeflag != tar.TypeReg || header.Name != "stormlight" {
+			continue
+		}
+		return io.ReadAll(archive)
+	}
+	return nil, fmt.Errorf("the release archive holds no stormlight binary")
+}
+
+// localBinary is this machine's own executable, for a host that runs the
+// same platform.
+func localBinary(path string) ([]byte, error) {
+	return os.ReadFile(path)
+}

--- a/internal/remote/setup.go
+++ b/internal/remote/setup.go
@@ -5,7 +5,6 @@ import (
 	"context"
 	"fmt"
 	"io"
-	"os"
 	"os/exec"
 	"strings"
 )
@@ -132,6 +131,9 @@ func (r Report) CanCopyBinary() bool {
 	return r.Platform != "" && r.Platform == local
 }
 
+// Target is the host's platform in the naming published builds use.
+func (r Report) Target() (Target, bool) { return TargetFor(r.Platform) }
+
 // YaziInstallCommand is how this host would install Yazi, or empty when
 // Stormlight has no business guessing. Package management belongs to the
 // machine's owner; offering to run the one command its own package
@@ -153,35 +155,32 @@ func (r Report) YaziInstallCommand() string {
 	}
 }
 
-// InstallStormlight copies this machine's binary to the host and puts it
-// on the path the bridge will look for.
+// InstallStormlight puts a Stormlight the host can run at the path the
+// bridge will look for, and reports where it went.
 //
-// Copying rather than downloading is deliberate where the platforms
-// match: it is the build the dashboard is already running, so the two
-// ends cannot disagree about the protocol between them — which is the one
-// failure this whole exercise exists to avoid.
+// Where the platforms match it copies this machine's own binary, which is
+// deliberate: it is the build the dashboard is already running, so the
+// two ends cannot disagree about the protocol between them — the one
+// failure this whole exercise exists to avoid. Where they do not — a Mac
+// preparing a Linux box, which is the ordinary case rather than the
+// exotic one — it fetches that platform's published archive, checks it
+// against the release's own checksums here, and sends the binary from
+// inside it.
 func InstallStormlight(
 	ctx context.Context,
 	transport *Transport,
 	report Report,
 	binary string,
 	progress io.Writer,
-) error {
-	if !report.CanCopyBinary() {
-		return fmt.Errorf(
-			"%s is %s and this machine is not; install Stormlight there from its own "+
-				"release (https://github.com/trentkm/stormlight/releases) and set "+
-				"bin = in [hosts.%s]",
-			report.Host, report.Platform, report.Host)
-	}
-	file, err := os.Open(binary)
+) (string, error) {
+	payload, err := binaryFor(ctx, report, binary, progress)
 	if err != nil {
-		return err
+		return "", err
 	}
-	defer file.Close()
+	file := bytes.NewReader(payload)
 
 	target := report.InstallPath()
-	fmt.Fprintf(progress, "copying this machine's stormlight to %s:%s\n", report.Host, target)
+	fmt.Fprintf(progress, "installing to %s:%s\n", report.Host, target)
 
 	// Three steps rather than one script, because the middle one needs
 	// stdin for the binary and a script needs stdin for itself.
@@ -189,7 +188,7 @@ func InstallStormlight(
 		"set -e\nmkdir -p %q\n", pathDir(target)))
 	prepare.Stdout, prepare.Stderr = progress, progress
 	if err := prepare.Run(); err != nil {
-		return fmt.Errorf("prepare %s on %s: %w", pathDir(target), report.Host, err)
+		return "", fmt.Errorf("prepare %s on %s: %w", pathDir(target), report.Host, err)
 	}
 
 	// Written beside the target and moved into place, so a half-copied
@@ -197,16 +196,40 @@ func InstallStormlight(
 	copyIn := transport.PipeCommand(ctx, file, "tee", target+".new")
 	copyIn.Stdout, copyIn.Stderr = io.Discard, progress
 	if err := copyIn.Run(); err != nil {
-		return fmt.Errorf("copy stormlight to %s: %w", report.Host, err)
+		return "", fmt.Errorf("copy stormlight to %s: %w", report.Host, err)
 	}
 
 	finish := transport.ShellCommand(ctx, fmt.Sprintf(
 		"set -e\nchmod 0755 %[1]q.new\nmv %[1]q.new %[1]q\n%[1]q --version\n", target))
 	finish.Stdout, finish.Stderr = progress, progress
 	if err := finish.Run(); err != nil {
-		return fmt.Errorf("install stormlight on %s: %w", report.Host, err)
+		return "", fmt.Errorf("install stormlight on %s: %w", report.Host, err)
 	}
-	return nil
+	return target, nil
+}
+
+// binaryFor is the executable to send: this machine's when the host runs
+// the same platform, and that platform's published build otherwise.
+func binaryFor(
+	ctx context.Context,
+	report Report,
+	binary string,
+	progress io.Writer,
+) ([]byte, error) {
+	if report.CanCopyBinary() {
+		fmt.Fprintf(progress, "%s runs %s, same as here — sending this build\n",
+			report.Host, report.Platform)
+		return localBinary(binary)
+	}
+	target, ok := report.Target()
+	if !ok {
+		return nil, fmt.Errorf(
+			"%s reports %q, which is not a platform Stormlight publishes for",
+			report.Host, report.Platform)
+	}
+	fmt.Fprintf(progress, "%s runs %s — fetching the %s build of %s\n",
+		report.Host, report.Platform, target, localVersion)
+	return releaseBinary(ctx, localVersion, target)
 }
 
 // pathDir is filepath.Dir for a path on another machine, which is always

--- a/internal/remote/setup_test.go
+++ b/internal/remote/setup_test.go
@@ -82,23 +82,77 @@ exit 255`)
 	}
 }
 
-// TestAForeignPlatformIsNotCopiedTo: a Darwin arm64 binary on a Linux box
-// is not a slow path, it is a file that will not execute.
-func TestAForeignPlatformIsNotCopiedTo(t *testing.T) {
+// TestAForeignPlatformGetsItsOwnBuild: a Darwin arm64 binary on a Linux
+// box is not a slow path, it is a file that will not execute — so the
+// host's own published build is fetched instead. macOS preparing a Linux
+// machine is the ordinary case, not the exotic one.
+func TestAForeignPlatformGetsItsOwnBuild(t *testing.T) {
 	local, err := localPlatform()
 	if err != nil {
 		t.Skip("cannot read this machine's platform")
 	}
-	if (Report{Platform: local}).CanCopyBinary() != true {
+	if !(Report{Platform: local}).CanCopyBinary() {
 		t.Fatal("the same platform should be copyable")
 	}
-	foreign := Report{Host: "devbox", Platform: "Plan9 386"}
+	foreign := Report{Host: "devbox", Platform: "Linux aarch64"}
 	if foreign.CanCopyBinary() {
 		t.Fatal("a different platform must not be copied to")
 	}
-	err = InstallStormlight(context.Background(), nil, foreign, "", nil)
-	if err == nil || !strings.Contains(err.Error(), "releases") {
-		t.Fatalf("it should point at the releases instead: %v", err)
+	target, ok := foreign.Target()
+	if !ok || target.OS != "linux" || target.Arch != "arm64" {
+		t.Fatalf("target = %+v, ok = %v", target, ok)
+	}
+}
+
+// TestPlatformNamesAreTranslated: uname and Go name the same machines
+// differently, and picking the wrong one downloads a binary that will not
+// run.
+func TestPlatformNamesAreTranslated(t *testing.T) {
+	for platform, want := range map[string]Target{
+		"Linux aarch64": {OS: "linux", Arch: "arm64"},
+		"Linux x86_64":  {OS: "linux", Arch: "amd64"},
+		"Darwin arm64":  {OS: "darwin", Arch: "arm64"},
+		"Darwin x86_64": {OS: "darwin", Arch: "amd64"},
+	} {
+		got, ok := TargetFor(platform)
+		if !ok || got != want {
+			t.Fatalf("%s → %+v (%v), want %+v", platform, got, ok, want)
+		}
+	}
+	for _, unknown := range []string{"Plan9 386", "Linux", "", "FreeBSD amd64"} {
+		if _, ok := TargetFor(unknown); ok {
+			t.Fatalf("%q is not a platform Stormlight publishes for", unknown)
+		}
+	}
+}
+
+// TestADevelopmentBuildSaysSoRatherThanGuessing: there is no published
+// archive for a build that was never published, and inventing a version
+// to download would install something other than what is running here.
+func TestADevelopmentBuildSaysSoRatherThanGuessing(t *testing.T) {
+	_, err := releaseBinary(
+		context.Background(), "dev", Target{OS: "linux", Arch: "arm64"})
+	if err == nil {
+		t.Fatal("a development build has no release to install from")
+	}
+	for _, want := range []string{"development build", "bin ="} {
+		if !strings.Contains(err.Error(), want) {
+			t.Fatalf("it should say what to do instead: %v", err)
+		}
+	}
+}
+
+// TestAChecksumMismatchRefuses: the machine being prepared is the one
+// that cannot check anything yet, which is why this side checks.
+func TestAChecksumMismatchRefuses(t *testing.T) {
+	sums := []byte("abc123  stormlight_1.0.0_linux_arm64.tar.gz\n" +
+		"def456  stormlight_1.0.0_darwin_arm64.tar.gz\n")
+	got, ok := checksumFor(sums, "stormlight_1.0.0_linux_arm64.tar.gz")
+	if !ok || got != "abc123" {
+		t.Fatalf("checksum = %q, %v", got, ok)
+	}
+	if _, ok := checksumFor(sums, "stormlight_1.0.0_windows_arm64.tar.gz"); ok {
+		t.Fatal("a file the release never published has no checksum")
 	}
 }
 

--- a/main.go
+++ b/main.go
@@ -3,8 +3,10 @@ package main
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"io"
+	"io/fs"
 	"maps"
 	"net"
 	"os"
@@ -876,42 +878,16 @@ func newRemoteSetupCommand(cfg config.Config) *cobra.Command {
 			transport := remote.NewTransport(host)
 			out := cmd.OutOrStdout()
 
-			report, err := remote.Probe(cmd.Context(), transport)
+			// Every failure from here is one the person who asked has to
+			// read, and in a popup this process is the only thing holding
+			// the window open. So it reports, waits, and only then
+			// returns the error.
+			err := setUpHost(cmd.Context(), transport, args[0], out, install, withYazi)
 			if err != nil {
-				return err
+				fmt.Fprintf(out, "\n%v\n", err)
 			}
-			writeRemoteReport(out, report)
-			if !install {
-				if !report.Ready() || !report.Yazi.Present() {
-					fmt.Fprintf(out, "\nRun with --install to fix this.\n")
-				}
-				holdOpen(out, wait)
-				return nil
-			}
-
-			if !report.Stormlight.Present() {
-				binary, err := selfpath.Resolve()
-				if err != nil {
-					return err
-				}
-				if err := remote.InstallStormlight(
-					cmd.Context(), transport, report, binary, out); err != nil {
-					return err
-				}
-			}
-			if withYazi && !report.Yazi.Present() {
-				if err := remote.InstallYazi(cmd.Context(), transport, report, out); err != nil {
-					return err
-				}
-			}
-			fresh, err := remote.Probe(cmd.Context(), transport)
-			if err != nil {
-				return err
-			}
-			fmt.Fprintln(out)
-			writeRemoteReport(out, fresh)
 			holdOpen(out, wait)
-			return nil
+			return err
 		},
 	}
 	command.Flags().BoolVar(&install, "install", false,
@@ -921,6 +897,101 @@ func newRemoteSetupCommand(cfg config.Config) *cobra.Command {
 	command.Flags().BoolVar(&wait, "wait", false,
 		"hold the terminal open at the end, for a popup nobody else closes")
 	return command
+}
+
+// setUpHost reports what a machine has and, when asked, gives it what it
+// is missing.
+func setUpHost(
+	ctx context.Context,
+	transport *remote.Transport,
+	host string,
+	out io.Writer,
+	install, withYazi bool,
+) error {
+	report, err := remote.Probe(ctx, transport)
+	if err != nil {
+		return err
+	}
+	writeRemoteReport(out, report)
+	if !install {
+		if !report.Ready() || !report.Yazi.Present() {
+			fmt.Fprintf(out, "\nRun with --install to fix this.\n")
+		}
+		return nil
+	}
+
+	if !report.Stormlight.Present() {
+		binary, err := selfpath.Resolve()
+		if err != nil {
+			return err
+		}
+		installed, err := remote.InstallStormlight(ctx, transport, report, binary, out)
+		if err != nil {
+			return err
+		}
+		// A non-interactive SSH shell often has no ~/.local/bin on its
+		// PATH, so the bridge would look for a binary by name and not
+		// find the one just put there. Naming it outright is what
+		// [hosts.*] is for.
+		recordHostBinary(out, host, installed)
+	}
+	if withYazi && !report.Yazi.Present() {
+		if err := remote.InstallYazi(ctx, transport, report, out); err != nil {
+			return err
+		}
+	}
+	fresh, err := remote.Probe(ctx, transport)
+	if err != nil {
+		return err
+	}
+	fmt.Fprintln(out)
+	writeRemoteReport(out, fresh)
+	return nil
+}
+
+// recordHostBinary writes the installed path into the host's
+// configuration, so the next connection finds it whatever that machine's
+// non-interactive PATH happens to hold.
+//
+// It only appends a section that is not there. Rewriting the file would
+// mean parsing and re-emitting it, which costs the comments and the
+// ordering someone put there by hand — so an existing entry is left alone
+// and the line to change is printed instead.
+func recordHostBinary(out io.Writer, host, installed string) {
+	path := config.Path()
+	if path == "" {
+		return
+	}
+	existing, err := os.ReadFile(path)
+	if err != nil && !errors.Is(err, fs.ErrNotExist) {
+		fmt.Fprintf(out, "\nSet bin = %q in [hosts.%s]: %v\n", installed, host, err)
+		return
+	}
+	section := fmt.Sprintf("[hosts.%s]", host)
+	if strings.Contains(string(existing), section) {
+		fmt.Fprintf(out, "\n%s already exists — set bin = %q in it if the bridge "+
+			"cannot find stormlight.\n", section, installed)
+		return
+	}
+	entry := fmt.Sprintf("\n%s\nbin = %q\n", section, installed)
+	if err := appendConfig(path, entry); err != nil {
+		fmt.Fprintf(out, "\nAdd this to %s:\n%s\n", path, entry)
+		return
+	}
+	fmt.Fprintf(out, "\nRecorded bin = %q in %s\n", installed, path)
+}
+
+func appendConfig(path, entry string) error {
+	if err := os.MkdirAll(filepath.Dir(path), 0o700); err != nil {
+		return err
+	}
+	file, err := os.OpenFile(path, os.O_APPEND|os.O_CREATE|os.O_WRONLY, 0o600)
+	if err != nil {
+		return err
+	}
+	defer file.Close()
+	_, err = file.WriteString(entry)
+	return err
 }
 
 // holdOpen keeps a popup up long enough to be read. The overlay closes

--- a/main_test.go
+++ b/main_test.go
@@ -3,6 +3,9 @@ package main
 import (
 	"bytes"
 	"encoding/json"
+	"os"
+	"path/filepath"
+	"strings"
 	"testing"
 
 	"github.com/trentkm/stormlight/internal/agent"
@@ -181,4 +184,58 @@ func TestResolveCommandReportsEveryCheckout(t *testing.T) {
 	if len(values) == 0 {
 		t.Fatal("a workspace always has at least the checkout it was resolved from")
 	}
+}
+
+// TestTheInstalledPathIsRecorded: a non-interactive SSH shell often has
+// no ~/.local/bin on its PATH, so the bridge would look for stormlight by
+// name and miss the one just installed. Naming it outright is what
+// [hosts.*] is for.
+func TestTheInstalledPathIsRecorded(t *testing.T) {
+	directory := t.TempDir()
+	t.Setenv("XDG_CONFIG_HOME", directory)
+	path := filepath.Join(directory, "stormlight", "config.toml")
+	if err := os.MkdirAll(filepath.Dir(path), 0o700); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(path, []byte("[defaults]\nprovider = \"claude\"\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	var out bytes.Buffer
+	recordHostBinary(&out, "devbox", "/home/trent/.local/bin/stormlight")
+
+	content, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !strings.Contains(string(content), "[hosts.devbox]") ||
+		!strings.Contains(string(content), "/home/trent/.local/bin/stormlight") {
+		t.Fatalf("config = %s", content)
+	}
+	// What was already there is untouched: appending costs nothing, and
+	// re-emitting the file would cost the comments and ordering someone
+	// put there by hand.
+	if !strings.Contains(string(content), "[defaults]") {
+		t.Fatalf("existing configuration was lost: %s", content)
+	}
+
+	// A host already configured is left alone and the change is described
+	// instead, because appending a second [hosts.devbox] is not valid TOML.
+	out.Reset()
+	recordHostBinary(&out, "devbox", "/elsewhere/stormlight")
+	if strings.Count(string(mustRead(t, path)), "[hosts.devbox]") != 1 {
+		t.Fatalf("config = %s", mustRead(t, path))
+	}
+	if !strings.Contains(out.String(), "already exists") {
+		t.Fatalf("it should say what to change: %q", out.String())
+	}
+}
+
+func mustRead(t *testing.T, path string) []byte {
+	t.Helper()
+	content, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	return content
 }

--- a/site/docs/architecture.html
+++ b/site/docs/architecture.html
@@ -246,7 +246,12 @@
     <p><code>stormlight remote setup &lt;host&gt;</code> reports what a machine is missing
     and can install it. Stormlight itself is copied from this machine when the platforms
     match — the same build, so the two ends cannot disagree about the protocol between them —
-    and pointed at the releases when they do not. Yazi is offered only through the host's own
+    and otherwise fetched as that platform's published archive, checked against the release's
+    own checksums here rather than there: the machine being prepared is precisely the one
+    with no Stormlight to check anything with. A development build has no published archive
+    and says so instead of guessing at a version. The installed path is recorded as that
+    host's <code>bin</code>, because a non-interactive SSH shell frequently has no
+    <code>~/.local/bin</code> on its PATH and would not find what was just put there. Yazi is offered only through the host's own
     package manager, and described rather than guessed at when there is none.
     Members exist at start-up for the machines the catalog says hold a workspace — listing
     names no host, so without that a machine's agents would be invisible until something


### PR DESCRIPTION
Fixes #149.

Preparing a Linux machine from a Mac is the ordinary case, and it was the one
case setup refused. It only ever copied this machine's own binary, so anything
else got an error pointing at the releases page — and the popup carrying that
error closed before it could be read.

## The host's own build

A host whose platform differs now gets that platform's published archive,
fetched here and verified here against the checksums the release published. Here
rather than there on purpose: the machine being prepared is precisely the one
with no Stormlight on it to check anything with.

Where platforms match it still copies the running binary — the two ends then
cannot disagree about the protocol between them, which is the failure this
exercise exists to avoid.

`uname` and Go disagree about names in exactly the places that matter:
`aarch64`/`arm64` and `x86_64`/`amd64` are one machine each, and picking the
wrong one downloads a binary that will not run. Translated and tested.

A development build has no published archive, and guessing a version would
install something other than what is running here. It says so, and says what to
do instead.

## The other two from the report

**Failures stay visible.** Setup prints the error before returning, so `--wait`
holds the popup open on failure rather than only on success. That is how #149
was hard to read in the first place.

**The installed path is recorded** as that host's `bin`. A non-interactive SSH
shell frequently has no `~/.local/bin` on its PATH, so the bridge would look for
`stormlight` by name and miss what was just installed. The entry is appended
only when the host has none — rewriting the file would cost the comments and
ordering someone put there by hand, so an existing entry is described rather
than replaced.

## Testing

`go test ./...` and `go vet ./...` green. New coverage: platform names
translated both ways and unknown ones refused; a foreign platform resolves to
its own target rather than being refused; a development build explains itself;
checksum lookup finds the right line and misses a file the release never
published; the installed path is appended to config without disturbing what was
there, and an existing host entry is left alone.

**Against the real release**: the v0.11.0 `linux/arm64` archive downloads,
matches its published checksum, and yields a genuine ELF binary.

## Not covered

The install itself onto a genuinely foreign host — I have no Linux machine to
reach. The path up to and including "correct binary in hand, verified" is
exercised; the `tee`/`chmod`/`mv` after it is the same code that already works
same-platform.