### PR TITLE
Errors get a card of their own, not a corner of the hint row

### DIFF
--- a/internal/ui/alert.go
+++ b/internal/ui/alert.go
@@ -85,6 +85,17 @@ func (m *Model) raisePolled(err error) {
 	m.raiseFailure(err, true)
 }
 
+// complain is a form objecting to what is in it — an empty name, a path
+// that is not there. Only these belong to the surface they were raised in,
+// and only these are swept when it closes. A failure that merely *arrived*
+// while a form happened to be open belongs to nothing on screen: an ssh
+// setup that failed in the background is not answered by cancelling the
+// dispatch form that was open at the time.
+func (m *Model) complain(err error) {
+	m.raiseFailure(err, false)
+	m.alert.raisedIn = m.mode
+}
+
 func (m *Model) raiseFailure(err error, polled bool) {
 	if err == nil {
 		return
@@ -99,7 +110,7 @@ func (m *Model) raiseFailure(err error, polled bool) {
 		// dismissal that lasts 700ms is not a dismissal.
 		return
 	}
-	m.alert = alert{err: err, raisedIn: m.mode, polled: polled, at: alertClock()}
+	m.alert = alert{err: err, polled: polled, at: alertClock()}
 	// Every failure leaves its full text behind, so `e` can still reach
 	// the last one after the card has gone. This is not what an open
 	// detail view is reading — that took its own copy — because a poll
@@ -113,16 +124,25 @@ func (m *Model) raiseFailure(err error, polled bool) {
 // and a package-scope name that ordinary parameters shadow is a trap.
 var alertClock = time.Now
 
-// dismissAlert takes the card down. Dismissing a self-repeating failure
-// also hushes it: the poll would otherwise raise the identical message on
-// the very next tick, and the Esc the card advertised would do nothing
-// that lasts.
+// dismissAlert is the reader answering the card — Esc, or opening it to
+// read. Answering a self-repeating failure also hushes it: the poll would
+// otherwise raise the identical message on the very next tick, and an Esc
+// undone in 700ms is not a dismissal.
+//
+// This is the only way a card ends that counts as read. Everything else
+// clears it with clearAlert, because hushing a message nobody saw is how
+// a dashboard goes quiet about a daemon that is still down.
 func (m *Model) dismissAlert() {
 	if m.alert.polled {
 		m.hushedPoll = m.alert.message()
 	}
-	m.alert = alert{}
+	m.clearAlert()
 }
+
+// clearAlert takes the card down without counting it as read: a card that
+// timed out unread inside the portal, or a stale form complaint dropped
+// when the form reopens.
+func (m *Model) clearAlert() { m.alert = alert{} }
 
 // resolvePolled is the refresh reporting that it worked. A card raised by
 // a failing poll is the one kind that answers itself: the daemon came back,
@@ -159,7 +179,9 @@ func (m *Model) ageAlert(now time.Time) {
 		return
 	}
 	if now.After(m.alert.expires) {
-		m.dismissAlert()
+		// Timing out is the one ending where the reader provably did not
+		// read it, so it must not hush anything.
+		m.clearAlert()
 	}
 }
 
@@ -306,6 +328,25 @@ func (m Model) alertCardKeys(clipped bool) string {
 		label = "e read it all"
 	}
 	return mutedStyle().Render(label+"  ·  Esc dismiss") + " "
+}
+
+// inputStripRows is the rows at the foot of the body that belong to an
+// input rather than to content: the composer, the search line. The card
+// floats above them instead of over them — covering the box someone is
+// typing into is worse than covering anything else on screen.
+func (m Model) inputStripRows(width int) int {
+	switch m.mode {
+	case modeCompose:
+		interactionWidth := width
+		if width >= 72 {
+			_, _, interactionWidth = m.paneWidths(width)
+		}
+		// The composer is its input between two rules.
+		return composerHeight(m.sendInput.Value(), max(1, interactionWidth)) + 2
+	case modeSearch:
+		return 1
+	}
+	return 0
 }
 
 // alertRows is how many rows the card will take, which is how much of the

--- a/internal/ui/alert.go
+++ b/internal/ui/alert.go
@@ -1,0 +1,270 @@
+package ui
+
+// The failure surface: the card an error gets to itself, and the detail
+// view behind it.
+
+import (
+	"strings"
+	"time"
+
+	tea "charm.land/bubbletea/v2"
+	"charm.land/lipgloss/v2"
+	"github.com/charmbracelet/x/ansi"
+)
+
+// An error used to live in a third of the hint row — twenty-eight columns
+// at the widest, its newlines flattened to spaces — and the next keystroke
+// wiped it. Anything a failure had to say past "ssh: connect to host thai"
+// was unreadable by construction, and the reader rarely got even that far.
+//
+// The alert is the correction. The message floats in its own card over the
+// foot of the body, wrapped rather than cut, and it waits there until it is
+// dismissed, superseded, or answered — the hint row keeps its own line.
+type alert struct {
+	err error
+	// expires bounds the card's life in the two places the dashboard
+	// cannot take an Esc on its behalf: inside the portal, where the
+	// keyboard belongs to the agent, and under a floating program. Zero
+	// means the card waits for a human, which is the usual case.
+	expires time.Time
+}
+
+// alertDetail is the whole message, opened over the card with `e`. It is a
+// snapshot rather than a view onto the live alert: reading is what dismisses
+// the card, so by the time this is on screen the alert itself is gone.
+type alertDetail struct {
+	text   string
+	offset int
+}
+
+const (
+	// alertLinger is how long a card lives where nothing can dismiss it.
+	alertLinger = 12 * time.Second
+	// alertCardLines is how much of a message the card carries before the
+	// rest becomes one keystroke away rather than lost.
+	alertCardLines = 3
+	alertCardWidth = 76
+)
+
+func (a alert) active() bool { return a.err != nil }
+
+func (a alert) message() string {
+	if a.err == nil {
+		return ""
+	}
+	return strings.TrimSpace(a.err.Error())
+}
+
+// raise puts an error on screen. A failure repeating itself — a refresh
+// against a daemon that is still down, arriving every tick — is the same
+// card, not a new one, so its clock is not restarted and it can still age
+// out where nothing can dismiss it.
+func (m *Model) raise(err error) {
+	if err == nil {
+		m.alert = alert{}
+		return
+	}
+	if m.alert.active() && m.alert.message() == strings.TrimSpace(err.Error()) {
+		return
+	}
+	m.alert = alert{err: err}
+}
+
+func (m *Model) dismissAlert() { m.alert = alert{} }
+
+// keyboardHeldElsewhere reports that the dashboard's own keys are not
+// available: the portal has the keyboard, or a floating program does. Esc
+// belongs to them there, so a card raised in that state cannot be dismissed
+// by hand and gets a clock instead.
+func (m Model) keyboardHeldElsewhere() bool {
+	return m.overlay != nil || m.terminalFocused()
+}
+
+// ageAlert runs on the poll tick. Leaving the portal hands the card back to
+// the human and stops its clock; entering it starts one.
+func (m *Model) ageAlert(now time.Time) {
+	if !m.alert.active() {
+		return
+	}
+	if !m.keyboardHeldElsewhere() {
+		m.alert.expires = time.Time{}
+		return
+	}
+	if m.alert.expires.IsZero() {
+		m.alert.expires = now.Add(alertLinger)
+		return
+	}
+	if now.After(m.alert.expires) {
+		m.dismissAlert()
+	}
+}
+
+// alertDetailReachable reports whether `e` opens the full text from here.
+// It needs the dashboard's own keyboard and a mode that is not spending
+// letters on an input.
+func (m Model) alertDetailReachable() bool {
+	return m.alert.active() && m.mode == modeNormal && !m.keyboardHeldElsewhere()
+}
+
+// openAlertDetail hands the whole message to the reader and clears the card:
+// reading it is what an alert was waiting for.
+func (m Model) openAlertDetail() (tea.Model, tea.Cmd) {
+	if !m.alert.active() {
+		return m, nil
+	}
+	m.alertDetail = alertDetail{text: m.alert.message()}
+	m.dismissAlert()
+	m.mode = modeAlert
+	return m, nil
+}
+
+func (m Model) updateAlertDetail(msg tea.KeyPressMsg) (tea.Model, tea.Cmd) {
+	textWidth, window := m.alertDetailWindow()
+	lines := wrapMessage(m.alertDetail.text, textWidth)
+	last := max(0, len(lines)-window)
+	switch msg.String() {
+	case "esc", "ctrl+c", "ctrl+[", "q", "e", "enter":
+		m.mode = modeNormal
+		return m, nil
+	case "y":
+		// The reason to copy an error is to paste it somewhere that can
+		// answer it: an issue, a search, a shell.
+		return m, copyToClipboardCmd(m.alertDetail.text)
+	case "j", "down":
+		m.alertDetail.offset = clamp(m.alertDetail.offset+1, 0, last)
+	case "k", "up":
+		m.alertDetail.offset = clamp(m.alertDetail.offset-1, 0, last)
+	case "ctrl+d", "pgdown":
+		m.alertDetail.offset = clamp(m.alertDetail.offset+window, 0, last)
+	case "ctrl+u", "pgup":
+		m.alertDetail.offset = clamp(m.alertDetail.offset-window, 0, last)
+	case "g", "home":
+		m.alertDetail.offset = 0
+	case "G", "end":
+		m.alertDetail.offset = last
+	}
+	return m, nil
+}
+
+// wrapMessage lays a message out at width, keeping the line breaks the
+// error itself chose and folding what overruns them. Errors arrive with
+// structure — an ssh failure is several lines of it — and flattening that
+// to one line was half of what made them unreadable.
+func wrapMessage(message string, width int) []string {
+	if width <= 0 || strings.TrimSpace(message) == "" {
+		return nil
+	}
+	message = strings.ReplaceAll(message, "\t", "    ")
+	var lines []string
+	for _, paragraph := range strings.Split(message, "\n") {
+		paragraph = strings.TrimRight(paragraph, " ")
+		if paragraph == "" {
+			lines = append(lines, "")
+			continue
+		}
+		lines = append(lines,
+			strings.Split(ansi.Wrap(paragraph, width, "-"), "\n")...)
+	}
+	return lines
+}
+
+// renderAlertCard draws the floating card, or nothing when no error stands.
+//
+// It floats rather than taking rows of its own on purpose: the Spanreed is
+// a real terminal sized 1:1 to its pane, and a card that changed the body's
+// height would reflow every agent's screen each time something failed.
+func (m Model) renderAlertCard(width, height int) string {
+	if !m.alert.active() || width < 16 || height < 3 {
+		return ""
+	}
+	cardWidth := clamp(width-4, 16, alertCardWidth)
+	textWidth := max(4, cardWidth-6)
+	budget := clamp(height-3, 1, alertCardLines)
+
+	lines := wrapMessage(m.alert.message(), textWidth)
+	clipped := len(lines) > budget
+	if clipped {
+		lines = lines[:budget]
+	}
+
+	body := make([]string, 0, len(lines)+1)
+	for index, line := range lines {
+		marker := "  "
+		if index == 0 {
+			marker = errorStyle().Bold(true).Render("! ")
+		}
+		body = append(body, " "+marker+line)
+	}
+	if keys := m.alertCardKeys(clipped); keys != "" {
+		body = append(body, alignRight(keys, cardWidth-2))
+	}
+	return lipgloss.NewStyle().
+		Width(cardWidth).
+		BorderStyle(lipgloss.RoundedBorder()).
+		BorderForeground(colorFailed()).
+		Render(strings.Join(body, "\n"))
+}
+
+// alertCardKeys names what the reader can do about the card from where they
+// are. Under the portal or a floating program that is nothing — the card is
+// on a clock there, because Esc belongs to the program.
+func (m Model) alertCardKeys(clipped bool) string {
+	if m.keyboardHeldElsewhere() {
+		return ""
+	}
+	keys := []string{}
+	if m.alertDetailReachable() {
+		label := "e detail"
+		if clipped {
+			label = "e read it all"
+		}
+		keys = append(keys, label)
+	}
+	keys = append(keys, "Esc dismiss")
+	return mutedStyle().Render(strings.Join(keys, "  ·  ")) + " "
+}
+
+func alignRight(content string, width int) string {
+	if pad := width - lipgloss.Width(content); pad > 0 {
+		return strings.Repeat(" ", pad) + content
+	}
+	return content
+}
+
+// alertDetailDimensions sizes the detail modal to the message: tall enough
+// to hold it outright when the body has the room, scrolling when it does not.
+func (m Model) alertDetailDimensions(width, height int) (int, int) {
+	lines := wrapMessage(m.alertDetail.text, min(width, alertCardWidth)-6)
+	return modalDimensions(width, height, alertCardWidth, len(lines)+6)
+}
+
+// alertDetailWindow is the text area inside the modal: how wide a line may
+// be and how many of them are on screen at once.
+func (m Model) alertDetailWindow() (int, int) {
+	width, height := m.alertDetailDimensions(m.bodyDimensions())
+	return max(4, width-6), max(1, height-6)
+}
+
+func (m Model) renderAlertModal(width, height int) string {
+	modalWidth, modalHeight := m.alertDetailDimensions(width, height)
+	textWidth := max(4, modalWidth-6)
+	window := max(1, modalHeight-6)
+
+	lines := wrapMessage(m.alertDetail.text, textWidth)
+	offset := clamp(m.alertDetail.offset, 0, max(0, len(lines)-window))
+	visible := lines[offset:min(len(lines), offset+window)]
+
+	out := []string{"  " + errorStyle().Bold(true).Render("Error"), ""}
+	for _, line := range visible {
+		out = append(out, "  "+line)
+	}
+	for len(out) < window+2 {
+		out = append(out, "")
+	}
+	keys := "y copy  ·  Esc close"
+	if len(lines) > window {
+		keys = "j/k scroll  ·  " + keys
+	}
+	out = append(out, "", "  "+mutedStyle().Render(keys))
+	return renderModal(strings.Join(out, "\n"), modalWidth, modalHeight)
+}

--- a/internal/ui/alert.go
+++ b/internal/ui/alert.go
@@ -189,8 +189,20 @@ func (m *Model) clearAlert() {
 // wipe this whole surface exists to remove, wearing a different hat.
 func (m *Model) clearComplaint(surface mode) {
 	if m.alert.active() && m.alert.raisedIn == surface {
-		m.clearAlert()
+		m.retract()
 	}
+}
+
+// retract takes a complaint back entirely: the card and the recall slot
+// both. A form's objection is spent when the form closes, and `e` offering
+// "task cannot be empty" from an hour ago — a form long gone, about a
+// field that no longer exists — presents a retracted complaint as an
+// outstanding failure.
+func (m *Model) retract() {
+	if m.alert.message() == m.lastFailure.text {
+		m.lastFailure = alertDetail{}
+	}
+	m.clearAlert()
 }
 
 // refitForms re-sizes the persistent widgets whose room the card changes.
@@ -381,7 +393,10 @@ func (m Model) renderAlertCard(width, height int) string {
 	}
 	cardWidth := clamp(width-4, 16, alertCardWidth)
 	textWidth := max(4, cardWidth-6)
-	budget := clamp(height-3, 1, alertCardLines)
+	// Minus the lift as well: a card sized against the whole body can grow
+	// past the rows reserved for the composer, clamp to the top, and cover
+	// the box it is meant to stay off.
+	budget := clamp(height-3-m.inputStripRows(), 1, alertCardLines)
 
 	lines := wrapMessage(m.alert.message(), textWidth)
 	clipped := len(lines) > budget
@@ -463,6 +478,21 @@ func (m Model) inputStripRows() int {
 	return 1
 }
 
+// alertCoversRow reports that the card is drawn over this screen row. The
+// real terminal cursor sits at the agent's own cell and the card is
+// composited over the grid without it knowing — an agent's prompt sits on
+// its last output line, which is exactly where the card lands, so without
+// this the cursor blinks inside the error box for the card's whole life.
+func (m Model) alertCoversRow(row int) bool {
+	width, height := m.bodyDimensions()
+	rows := m.alertRows(width, height)
+	if rows == 0 {
+		return false
+	}
+	top := bodyTop + max(0, height-rows-m.inputStripRows())
+	return row >= top && row < top+rows
+}
+
 // alertRows is how many rows the card will take, which is how much of the
 // body a modal has to leave alone.
 func (m Model) alertRows(width, height int) int {
@@ -505,17 +535,52 @@ func (m Model) alertDetailDimensions(width, height int) (int, int) {
 	return modalDimensions(width, height, alertCardWidth, len(lines)+6)
 }
 
+// detailLayout is how the detail view divides its modal: the text area,
+// and whether there is room for the title and the blank rows that separate
+// it. It is computed in one place and read by the render, the scroll clamp
+// and the footer hints — three readers disagreeing about the window is what
+// once put the tail of a message out of reach of every scroll key.
+type detailLayout struct {
+	textWidth int
+	window    int
+	title     bool
+	spaced    bool
+}
+
+// alertDetailLayout hands out the modal's rows in order of what the reader
+// cannot do without: the keys that close the view, then the title that
+// names it, then breathing room, and the message takes what is left.
+// Sizing the message first and letting the remainder truncate is how the
+// keys fell off the bottom while the footer went on advertising them.
+func (m Model) alertDetailLayout(width, height int) detailLayout {
+	modalWidth, modalHeight := m.alertDetailDimensions(width, height)
+	layout := detailLayout{textWidth: max(4, modalWidth-6)}
+	layout.window = max(1, max(1, modalHeight-2)-1)
+	if layout.window > 1 {
+		layout.title = true
+		layout.window--
+	}
+	if layout.window > 2 {
+		layout.spaced = true
+		layout.window -= 2
+	}
+	return layout
+}
+
+// alertDetailLayoutHere is that layout for the region the view is actually
+// drawn in — card and all. Measuring against the whole body while the view
+// is rendered into less than that puts the tail of a long message out of
+// reach: the state believes it is already at the bottom.
+func (m Model) alertDetailLayoutHere() detailLayout {
+	bodyWidth, bodyHeight := m.bodyDimensions()
+	return m.alertDetailLayout(bodyWidth, m.modalRegion(bodyWidth, bodyHeight))
+}
+
 // alertDetailWindow is the text area inside the modal: how wide a line may
 // be and how many of them are on screen at once.
 func (m Model) alertDetailWindow() (int, int) {
-	// Measured in the region the modal is drawn in, card and all. Sizing
-	// this from the whole body while the view is rendered into less than
-	// that puts the tail of a long message out of reach of every scroll
-	// key: the state believes it is already at the bottom.
-	bodyWidth, bodyHeight := m.bodyDimensions()
-	width, height := m.alertDetailDimensions(
-		bodyWidth, m.modalRegion(bodyWidth, bodyHeight))
-	return max(4, width-6), max(1, height-6)
+	layout := m.alertDetailLayoutHere()
+	return layout.textWidth, layout.window
 }
 
 // modalRegion is the room a modal has. A form makes way for the card: it
@@ -531,7 +596,13 @@ func (m Model) modalRegion(width, height int) int {
 	// above the floor, so reserving only its own height leaves the two
 	// overlapping by exactly that lift on the terminals where the modal
 	// fills its region.
-	reserved := m.alertRows(width, height) + m.inputStripRows()
+	// Never more than half the body: the card exists so that a failure
+	// reflows nothing, and a form squeezed down to its own border is a
+	// worse outcome than a card overlapping its foot.
+	reserved := min(
+		m.alertRows(width, height)+m.inputStripRows(),
+		max(0, height/2),
+	)
 	if m.mode == modeDispatch && m.formFocus == dispatchName &&
 		!m.dispatchNameVisibleIn(max(1, height-reserved)) {
 		// Shrinking here would take away the row the reader is typing
@@ -549,35 +620,45 @@ func (m Model) modalRegion(width, height int) int {
 // it is drawn in, which is the only condition under which the scroll keys
 // do anything.
 func (m Model) alertDetailScrolls() bool {
-	textWidth, window := m.alertDetailWindow()
-	return len(wrapMessage(m.alertDetail.text, textWidth)) > window
+	layout := m.alertDetailLayoutHere()
+	return len(wrapMessage(m.alertDetail.text, layout.textWidth)) > layout.window
 }
 
 func (m Model) renderAlertModal(width, height int) string {
 	modalWidth, modalHeight := m.alertDetailDimensions(width, height)
-	textWidth := max(4, modalWidth-6)
-	window := max(1, modalHeight-6)
+	layout := m.alertDetailLayout(width, height)
 
-	lines := wrapMessage(m.alertDetail.text, textWidth)
-	offset := clamp(m.alertDetail.offset, 0, max(0, len(lines)-window))
-	visible := lines[offset:min(len(lines), offset+window)]
+	lines := wrapMessage(m.alertDetail.text, layout.textWidth)
+	offset := clamp(m.alertDetail.offset, 0, max(0, len(lines)-layout.window))
+	visible := lines[offset:min(len(lines), offset+layout.window)]
 
-	title := "  " + errorStyle().Bold(true).Render("Error")
-	if age := alertAgeLabel(m.alertDetail.at); age != "" {
-		title += mutedStyle().Render(age)
+	var out []string
+	if layout.title {
+		title := "  " + errorStyle().Bold(true).Render("Error")
+		if age := alertAgeLabel(m.alertDetail.at); age != "" {
+			title += mutedStyle().Render(age)
+		}
+		out = append(out, title)
+		if layout.spaced {
+			out = append(out, "")
+		}
 	}
-	out := []string{title, ""}
 	for _, line := range visible {
 		out = append(out, "  "+line)
 	}
-	for len(out) < window+2 {
+	// Pad the text area to its full window so the keys sit on the modal's
+	// last row rather than riding up under a short message.
+	for index := len(visible); index < layout.window; index++ {
+		out = append(out, "")
+	}
+	if layout.spaced {
 		out = append(out, "")
 	}
 	keys := "y copy  ·  Esc close"
-	if len(lines) > window {
+	if len(lines) > layout.window {
 		keys = "j/k scroll  ·  " + keys
 	}
-	out = append(out, "", "  "+mutedStyle().Render(keys))
+	out = append(out, "  "+mutedStyle().Render(keys))
 	return renderModal(strings.Join(out, "\n"), modalWidth, modalHeight)
 }
 

--- a/internal/ui/alert.go
+++ b/internal/ui/alert.go
@@ -476,6 +476,10 @@ func (m Model) alertRows(width, height int) int {
 // escapeAnswersAlert reports that Esc would reach the card rather than
 // undoing something in front of it. It mirrors updateNormal's own order.
 func (m Model) escapeAnswersAlert() bool {
+	if m.normalPrefix != "" {
+		// A half-typed chord takes Esc first, to cancel itself.
+		return false
+	}
 	if m.selectionActive {
 		return false
 	}
@@ -523,7 +527,22 @@ func (m Model) modalRegion(width, height int) int {
 	if m.mode.isReading() {
 		return height
 	}
-	return max(1, height-m.alertRows(width, height))
+	// F2 of the region's own arithmetic: the card is drawn inputStripRows
+	// above the floor, so reserving only its own height leaves the two
+	// overlapping by exactly that lift on the terminals where the modal
+	// fills its region.
+	reserved := m.alertRows(width, height) + m.inputStripRows()
+	if m.mode == modeDispatch && m.formFocus == dispatchName &&
+		!m.dispatchNameVisibleIn(max(1, height-reserved)) {
+		// Shrinking here would take away the row the reader is typing
+		// into, and a failure that arrived on its own in the background
+		// is the last thing that should move somebody's cursor. The card
+		// overlaps the form's foot for the moment instead; that is
+		// recoverable, and losing the next few keystrokes into the task
+		// body is not.
+		return height
+	}
+	return max(1, height-reserved)
 }
 
 // alertDetailScrolls reports that the open message is longer than the room

--- a/internal/ui/alert.go
+++ b/internal/ui/alert.go
@@ -121,6 +121,13 @@ func (m *Model) raiseFailure(err error, polled bool) {
 		}
 		return
 	}
+	if polled && message == m.heldBack && m.keyboardHeldElsewhere() {
+		// It timed out here once and nothing here can answer it, so
+		// raising it again every tick would only cover the agent's
+		// terminal on a loop. The moment the reader is back somewhere
+		// they can act on it, this stops applying and it returns.
+		return
+	}
 	if polled && message == m.hushedPoll {
 		// The reader already dealt with this one. The poll will keep
 		// reporting it every tick until the daemon comes back, and a
@@ -165,6 +172,16 @@ func (m *Model) clearAlert() {
 	m.refitForms()
 }
 
+// clearComplaint drops the objection this surface raised last time it was
+// open, and nothing else. Opening a form is not reading the failure that
+// happened to be on screen — clearing everything here was the keystroke
+// wipe this whole surface exists to remove, wearing a different hat.
+func (m *Model) clearComplaint(surface mode) {
+	if m.alert.active() && m.alert.raisedIn == surface {
+		m.clearAlert()
+	}
+}
+
 // refitForms re-sizes the persistent widgets whose room the card changes.
 // The dispatch form's task composer is sized once and kept; a card
 // appearing under it shortens the modal, and a textarea that believes it
@@ -182,7 +199,11 @@ func (m *Model) refitForms() {
 // is news again.
 func (m *Model) resolvePolled() {
 	if m.alert.polled {
-		m.alert = alert{}
+		// Through clearAlert, not by hand: the card's rows come back to
+		// the modal and whatever was sized for the shorter one has to
+		// hear about it. clearAlert does not hush, so recovery still
+		// counts as unread.
+		m.clearAlert()
 	}
 	m.hushedPoll = ""
 }
@@ -198,11 +219,17 @@ func (m Model) keyboardHeldElsewhere() bool {
 // ageAlert runs on the poll tick. Leaving the portal hands the card back to
 // the human and stops its clock; entering it starts one.
 func (m *Model) ageAlert(now time.Time) {
-	if !m.alert.active() {
+	if !m.keyboardHeldElsewhere() {
+		// Back where a card can be answered. Anything held back because
+		// it could not be is fair to raise again, and a card already
+		// standing stops counting down.
+		m.heldBack = ""
+		if m.alert.active() {
+			m.alert.expires = time.Time{}
+		}
 		return
 	}
-	if !m.keyboardHeldElsewhere() {
-		m.alert.expires = time.Time{}
+	if !m.alert.active() {
 		return
 	}
 	if m.alert.expires.IsZero() {
@@ -210,8 +237,15 @@ func (m *Model) ageAlert(now time.Time) {
 		return
 	}
 	if now.After(m.alert.expires) {
-		// Timing out is the one ending where the reader provably did not
-		// read it, so it must not hush anything.
+		if m.alert.polled {
+			// Still failing, and no key here can answer it: raising it
+			// again on the next tick would cover the agent's terminal
+			// every twelve seconds forever. Hold it until the reader is
+			// back on the dashboard, where it can be read and dismissed.
+			m.heldBack = m.alert.message()
+		}
+		// Timing out is not reading, so nothing is hushed: leaving the
+		// portal raises it again.
 		m.clearAlert()
 	}
 }
@@ -377,7 +411,7 @@ func (m Model) alertCardKeys(clipped bool) string {
 // input rather than to content: the composer, the search line. The card
 // floats above them instead of over them — covering the box someone is
 // typing into is worse than covering anything else on screen.
-func (m Model) inputStripRows(width int) int {
+func (m Model) inputStripRows() int {
 	switch m.mode {
 	case modeCompose:
 		// Measured where renderInteraction lays it out, not at the pane's
@@ -447,6 +481,14 @@ func (m Model) alertDetailWindow() (int, int) {
 // failure card has claimed at its foot.
 func (m Model) modalRegion(width, height int) int {
 	return max(1, height-m.alertRows(width, height))
+}
+
+// alertDetailScrolls reports that the open message is longer than the room
+// it is drawn in, which is the only condition under which the scroll keys
+// do anything.
+func (m Model) alertDetailScrolls() bool {
+	textWidth, window := m.alertDetailWindow()
+	return len(wrapMessage(m.alertDetail.text, textWidth)) > window
 }
 
 func (m Model) renderAlertModal(width, height int) string {

--- a/internal/ui/alert.go
+++ b/internal/ui/alert.go
@@ -48,8 +48,12 @@ type alert struct {
 // belongs to the form, so the only way those messages are ever readable in
 // full is for `e` to still find the last one after its card is gone.
 type alertDetail struct {
-	text   string
-	at     time.Time
+	text string
+	at   time.Time
+	// polled remembers that this came from the self-repeating poll, so
+	// reading it can hush it even when its card timed out first and took
+	// the flag with it.
+	polled bool
 	offset int
 }
 
@@ -92,8 +96,15 @@ func (m *Model) raisePolled(err error) {
 // setup that failed in the background is not answered by cancelling the
 // dispatch form that was open at the time.
 func (m *Model) complain(err error) {
+	standing := m.alert.message()
 	m.raiseFailure(err, false)
-	m.alert.raisedIn = m.mode
+	if m.alert.message() != standing {
+		// Only stamp a card this actually raised. A repeat of the same
+		// objection is already stamped, and a card that was standing for
+		// another reason is not the form's to claim — or to take with it
+		// when it closes.
+		m.alert.raisedIn = m.mode
+	}
 }
 
 func (m *Model) raiseFailure(err error, polled bool) {
@@ -102,6 +113,12 @@ func (m *Model) raiseFailure(err error, polled bool) {
 	}
 	message := strings.TrimSpace(err.Error())
 	if m.alert.active() && m.alert.message() == message {
+		if polled {
+			// The same text arriving from the poll makes this the poll's
+			// card too, and a card that never learns it is polled never
+			// clears itself when the daemon comes back.
+			m.alert.polled = true
+		}
 		return
 	}
 	if polled && message == m.hushedPoll {
@@ -111,12 +128,13 @@ func (m *Model) raiseFailure(err error, polled bool) {
 		return
 	}
 	m.alert = alert{err: err, polled: polled, at: alertClock()}
+	m.refitForms()
 	// Every failure leaves its full text behind, so `e` can still reach
 	// the last one after the card has gone. This is not what an open
 	// detail view is reading — that took its own copy — because a poll
 	// failing every tick would otherwise swap the message out from under
 	// someone in the middle of reading it.
-	m.lastFailure = alertDetail{text: message, at: m.alert.at}
+	m.lastFailure = alertDetail{text: message, at: m.alert.at, polled: polled}
 }
 
 // alertClock is when a failure says it arrived; tests replace it to hold
@@ -142,7 +160,20 @@ func (m *Model) dismissAlert() {
 // clearAlert takes the card down without counting it as read: a card that
 // timed out unread inside the portal, or a stale form complaint dropped
 // when the form reopens.
-func (m *Model) clearAlert() { m.alert = alert{} }
+func (m *Model) clearAlert() {
+	m.alert = alert{}
+	m.refitForms()
+}
+
+// refitForms re-sizes the persistent widgets whose room the card changes.
+// The dispatch form's task composer is sized once and kept; a card
+// appearing under it shortens the modal, and a textarea that believes it
+// is taller than the box it is drawn into scrolls and stays scrolled.
+func (m *Model) refitForms() {
+	if m.mode == modeDispatch {
+		m.syncTaskComposerSize()
+	}
+}
 
 // resolvePolled is the refresh reporting that it worked. A card raised by
 // a failing poll is the one kind that answers itself: the daemon came back,
@@ -210,6 +241,12 @@ func (m Model) openAlertDetail() (tea.Model, tea.Cmd) {
 	// A copy, taken once: what is on screen must not change under the
 	// reader because a background poll failed again while they read.
 	m.alertDetail = m.lastFailure
+	if m.lastFailure.polled {
+		// Reading it is answering it. Without this the next tick raises
+		// the identical card over the view opened to read it — and, by
+		// shortening the region, resizes that view mid-read.
+		m.hushedPoll = m.lastFailure.text
+	}
 	m.dismissAlert()
 	m.mode = modeAlert
 	return m, nil
@@ -327,6 +364,12 @@ func (m Model) alertCardKeys(clipped bool) string {
 	if clipped {
 		label = "e read it all"
 	}
+	if !m.escapeAnswersAlert() {
+		// Esc is spoken for — a live selection or search takes it first,
+		// and a card promising a key that does something else is the kind
+		// of small lie that costs trust in every other hint.
+		return mutedStyle().Render(label) + " "
+	}
 	return mutedStyle().Render(label+"  ·  Esc dismiss") + " "
 }
 
@@ -337,12 +380,12 @@ func (m Model) alertCardKeys(clipped bool) string {
 func (m Model) inputStripRows(width int) int {
 	switch m.mode {
 	case modeCompose:
-		interactionWidth := width
-		if width >= 72 {
-			_, _, interactionWidth = m.paneWidths(width)
-		}
+		// Measured where renderInteraction lays it out, not at the pane's
+		// full width — three columns of difference is a wrapped line, and
+		// a lift one row short covers the rule it exists to clear.
+		composerWidth, _ := m.interactionDimensions()
 		// The composer is its input between two rules.
-		return composerHeight(m.sendInput.Value(), max(1, interactionWidth)) + 2
+		return composerHeight(m.sendInput.Value(), max(1, composerWidth)) + 2
 	case modeSearch:
 		return 1
 	}
@@ -357,6 +400,15 @@ func (m Model) alertRows(width, height int) int {
 		return 0
 	}
 	return strings.Count(card, "\n") + 1
+}
+
+// escapeAnswersAlert reports that Esc would reach the card rather than
+// undoing something in front of it. It mirrors updateNormal's own order.
+func (m Model) escapeAnswersAlert() bool {
+	if m.selectionActive {
+		return false
+	}
+	return !(m.activePane == paneInteraction && m.search.query != "")
 }
 
 func alignRight(content string, width int) string {

--- a/internal/ui/alert.go
+++ b/internal/ui/alert.go
@@ -187,9 +187,17 @@ func (m *Model) clearComplaint(surface mode) {
 // appearing under it shortens the modal, and a textarea that believes it
 // is taller than the box it is drawn into scrolls and stays scrolled.
 func (m *Model) refitForms() {
-	if m.mode == modeDispatch {
-		m.syncTaskComposerSize()
+	if m.mode != modeDispatch {
+		return
 	}
+	// A shrink can drop the optional name row out of the form, and a card
+	// appearing under it shrinks it exactly like a smaller terminal does.
+	// Typing must not keep landing in a field that is no longer drawn.
+	if m.formFocus == dispatchName && !m.dispatchNameVisible() {
+		m.formFocus = dispatchTask
+		m.focusForm()
+	}
+	m.syncTaskComposerSize()
 }
 
 // resolvePolled is the refresh reporting that it worked. A card raised by
@@ -206,6 +214,7 @@ func (m *Model) resolvePolled() {
 		m.clearAlert()
 	}
 	m.hushedPoll = ""
+	m.heldBack = ""
 }
 
 // keyboardHeldElsewhere reports that the dashboard's own keys are not
@@ -345,6 +354,13 @@ func (m Model) renderAlertCard(width, height int) string {
 	// Three rows is a card with nothing in it: two borders and the keys.
 	// Rendering one anyway is how a card loses its bottom edge.
 	if !m.alert.active() || width < 16 || height < 4 {
+		return ""
+	}
+	if m.mode.isReading() {
+		// Help, info, history and the detail view are read end to end and
+		// close on any key. Shrinking them to make room truncates their
+		// last lines, and drawing over them is worse; the card waits the
+		// few seconds they are open and comes back after.
 		return ""
 	}
 	cardWidth := clamp(width-4, 16, alertCardWidth)

--- a/internal/ui/alert.go
+++ b/internal/ui/alert.go
@@ -93,24 +93,47 @@ func (m *Model) raiseFailure(err error, polled bool) {
 	if m.alert.active() && m.alert.message() == message {
 		return
 	}
-	m.alert = alert{err: err, raisedIn: m.mode, polled: polled, at: now()}
+	if polled && message == m.hushedPoll {
+		// The reader already dealt with this one. The poll will keep
+		// reporting it every tick until the daemon comes back, and a
+		// dismissal that lasts 700ms is not a dismissal.
+		return
+	}
+	m.alert = alert{err: err, raisedIn: m.mode, polled: polled, at: alertClock()}
 	// Every failure leaves its full text behind, so `e` can still reach
-	// the last one after the card has gone.
-	m.alertDetail = alertDetail{text: message, at: m.alert.at}
+	// the last one after the card has gone. This is not what an open
+	// detail view is reading — that took its own copy — because a poll
+	// failing every tick would otherwise swap the message out from under
+	// someone in the middle of reading it.
+	m.lastFailure = alertDetail{text: message, at: m.alert.at}
 }
 
-// now is the clock the alert reads; tests replace it to keep ages fixed.
-var now = time.Now
+// alertClock is when a failure says it arrived; tests replace it to hold
+// an age still. It is not named `now` because `ageAlert` takes a `now`,
+// and a package-scope name that ordinary parameters shadow is a trap.
+var alertClock = time.Now
 
-func (m *Model) dismissAlert() { m.alert = alert{} }
+// dismissAlert takes the card down. Dismissing a self-repeating failure
+// also hushes it: the poll would otherwise raise the identical message on
+// the very next tick, and the Esc the card advertised would do nothing
+// that lasts.
+func (m *Model) dismissAlert() {
+	if m.alert.polled {
+		m.hushedPoll = m.alert.message()
+	}
+	m.alert = alert{}
+}
 
 // resolvePolled is the refresh reporting that it worked. A card raised by
 // a failing poll is the one kind that answers itself: the daemon came back,
 // so the complaint is no longer true and should not sit there insisting.
+// The recovery also lifts the hush — if the failure returns after this, it
+// is news again.
 func (m *Model) resolvePolled() {
 	if m.alert.polled {
-		m.dismissAlert()
+		m.alert = alert{}
 	}
+	m.hushedPoll = ""
 }
 
 // keyboardHeldElsewhere reports that the dashboard's own keys are not
@@ -150,7 +173,7 @@ func (m Model) alertDetailReachable() bool {
 // readableFailure reports that there is a last failure for `e` to open —
 // the standing card's, or the one whose card has already gone.
 func (m Model) readableFailure() bool {
-	return strings.TrimSpace(m.alertDetail.text) != ""
+	return strings.TrimSpace(m.lastFailure.text) != ""
 }
 
 // openAlertDetail hands the last failure to the reader in full and clears
@@ -159,10 +182,12 @@ func (m Model) readableFailure() bool {
 // the ones raised inside the portal, where no key is ours — are exactly
 // the ones whose card is gone by the time the reader can act.
 func (m Model) openAlertDetail() (tea.Model, tea.Cmd) {
-	if strings.TrimSpace(m.alertDetail.text) == "" {
+	if !m.readableFailure() {
 		return m, nil
 	}
-	m.alertDetail.offset = 0
+	// A copy, taken once: what is on screen must not change under the
+	// reader because a background poll failed again while they read.
+	m.alertDetail = m.lastFailure
 	m.dismissAlert()
 	m.mode = modeAlert
 	return m, nil
@@ -251,7 +276,10 @@ func (m Model) renderAlertCard(width, height int) string {
 		}
 		body = append(body, " "+marker+line)
 	}
-	if keys := m.alertCardKeys(clipped); keys != "" {
+	if keys := m.alertCardKeys(clipped); keys != "" &&
+		lipgloss.Width(keys) <= cardWidth-2 {
+		// Only if it fits on one row. Wrapped, it would cost the card the
+		// row its frame was budgeted, and the bottom border with it.
 		body = append(body, alignRight(keys, cardWidth-2))
 	}
 	return lipgloss.NewStyle().
@@ -312,8 +340,20 @@ func (m Model) alertDetailDimensions(width, height int) (int, int) {
 // alertDetailWindow is the text area inside the modal: how wide a line may
 // be and how many of them are on screen at once.
 func (m Model) alertDetailWindow() (int, int) {
-	width, height := m.alertDetailDimensions(m.bodyDimensions())
+	// Measured in the region the modal is drawn in, card and all. Sizing
+	// this from the whole body while the view is rendered into less than
+	// that puts the tail of a long message out of reach of every scroll
+	// key: the state believes it is already at the bottom.
+	bodyWidth, bodyHeight := m.bodyDimensions()
+	width, height := m.alertDetailDimensions(
+		bodyWidth, m.modalRegion(bodyWidth, bodyHeight))
 	return max(4, width-6), max(1, height-6)
+}
+
+// modalRegion is the room a modal has: the body, less whatever rows the
+// failure card has claimed at its foot.
+func (m Model) modalRegion(width, height int) int {
+	return max(1, height-m.alertRows(width, height))
 }
 
 func (m Model) renderAlertModal(width, height int) string {

--- a/internal/ui/alert.go
+++ b/internal/ui/alert.go
@@ -22,6 +22,19 @@ import (
 // dismissed, superseded, or answered — the hint row keeps its own line.
 type alert struct {
 	err error
+	// raisedIn is the surface the complaint belongs to. A form's
+	// objection to a name or a path is spent the moment the form closes;
+	// a failure raised on the dashboard belongs to nothing that closes,
+	// so it outlives every overlay opened over it.
+	raisedIn mode
+	// polled marks a card the background refresh raised rather than
+	// anything the human did. It is the one failure that reports itself
+	// on a timer, so the next refresh that succeeds answers it and the
+	// card clears itself when the daemon comes back.
+	polled bool
+	// at is when the failure arrived, which the detail view says out
+	// loud: a message recalled later has to place itself in time.
+	at time.Time
 	// expires bounds the card's life in the two places the dashboard
 	// cannot take an Esc on its behalf: inside the portal, where the
 	// keyboard belongs to the agent, and under a floating program. Zero
@@ -29,11 +42,14 @@ type alert struct {
 	expires time.Time
 }
 
-// alertDetail is the whole message, opened over the card with `e`. It is a
-// snapshot rather than a view onto the live alert: reading is what dismisses
-// the card, so by the time this is on screen the alert itself is gone.
+// alertDetail is the whole of the last failure, opened with `e`. It is a
+// snapshot rather than a view onto the live alert, and it outlives the
+// card: inside the portal no key can open anything, and under a form `e`
+// belongs to the form, so the only way those messages are ever readable in
+// full is for `e` to still find the last one after its card is gone.
 type alertDetail struct {
 	text   string
+	at     time.Time
 	offset int
 }
 
@@ -60,17 +76,42 @@ func (a alert) message() string {
 // card, not a new one, so its clock is not restarted and it can still age
 // out where nothing can dismiss it.
 func (m *Model) raise(err error) {
-	if err == nil {
-		m.alert = alert{}
-		return
-	}
-	if m.alert.active() && m.alert.message() == strings.TrimSpace(err.Error()) {
-		return
-	}
-	m.alert = alert{err: err}
+	m.raiseFailure(err, false)
 }
 
+// raisePolled is the refresh's way in: the same card, marked as the one
+// thing that will report its own recovery.
+func (m *Model) raisePolled(err error) {
+	m.raiseFailure(err, true)
+}
+
+func (m *Model) raiseFailure(err error, polled bool) {
+	if err == nil {
+		return
+	}
+	message := strings.TrimSpace(err.Error())
+	if m.alert.active() && m.alert.message() == message {
+		return
+	}
+	m.alert = alert{err: err, raisedIn: m.mode, polled: polled, at: now()}
+	// Every failure leaves its full text behind, so `e` can still reach
+	// the last one after the card has gone.
+	m.alertDetail = alertDetail{text: message, at: m.alert.at}
+}
+
+// now is the clock the alert reads; tests replace it to keep ages fixed.
+var now = time.Now
+
 func (m *Model) dismissAlert() { m.alert = alert{} }
+
+// resolvePolled is the refresh reporting that it worked. A card raised by
+// a failing poll is the one kind that answers itself: the daemon came back,
+// so the complaint is no longer true and should not sit there insisting.
+func (m *Model) resolvePolled() {
+	if m.alert.polled {
+		m.dismissAlert()
+	}
+}
 
 // keyboardHeldElsewhere reports that the dashboard's own keys are not
 // available: the portal has the keyboard, or a floating program does. Esc
@@ -103,16 +144,25 @@ func (m *Model) ageAlert(now time.Time) {
 // It needs the dashboard's own keyboard and a mode that is not spending
 // letters on an input.
 func (m Model) alertDetailReachable() bool {
-	return m.alert.active() && m.mode == modeNormal && !m.keyboardHeldElsewhere()
+	return m.mode == modeNormal && !m.keyboardHeldElsewhere()
 }
 
-// openAlertDetail hands the whole message to the reader and clears the card:
-// reading it is what an alert was waiting for.
+// readableFailure reports that there is a last failure for `e` to open —
+// the standing card's, or the one whose card has already gone.
+func (m Model) readableFailure() bool {
+	return strings.TrimSpace(m.alertDetail.text) != ""
+}
+
+// openAlertDetail hands the last failure to the reader in full and clears
+// the card: reading it is what an alert was waiting for. It opens whether
+// or not a card is still standing, because the messages hardest to read —
+// the ones raised inside the portal, where no key is ours — are exactly
+// the ones whose card is gone by the time the reader can act.
 func (m Model) openAlertDetail() (tea.Model, tea.Cmd) {
-	if !m.alert.active() {
+	if strings.TrimSpace(m.alertDetail.text) == "" {
 		return m, nil
 	}
-	m.alertDetail = alertDetail{text: m.alert.message()}
+	m.alertDetail.offset = 0
 	m.dismissAlert()
 	m.mode = modeAlert
 	return m, nil
@@ -174,7 +224,9 @@ func wrapMessage(message string, width int) []string {
 // a real terminal sized 1:1 to its pane, and a card that changed the body's
 // height would reflow every agent's screen each time something failed.
 func (m Model) renderAlertCard(width, height int) string {
-	if !m.alert.active() || width < 16 || height < 3 {
+	// Three rows is a card with nothing in it: two borders and the keys.
+	// Rendering one anyway is how a card loses its bottom edge.
+	if !m.alert.active() || width < 16 || height < 4 {
 		return ""
 	}
 	cardWidth := clamp(width-4, 16, alertCardWidth)
@@ -185,6 +237,10 @@ func (m Model) renderAlertCard(width, height int) string {
 	clipped := len(lines) > budget
 	if clipped {
 		lines = lines[:budget]
+		// The ellipsis is the card admitting there is more, which it owes
+		// the reader whether or not it can offer a key for the rest.
+		last := len(lines) - 1
+		lines[last] = ansi.Truncate(lines[last], max(1, textWidth-1), "") + "…"
 	}
 
 	body := make([]string, 0, len(lines)+1)
@@ -209,19 +265,29 @@ func (m Model) renderAlertCard(width, height int) string {
 // are. Under the portal or a floating program that is nothing — the card is
 // on a clock there, because Esc belongs to the program.
 func (m Model) alertCardKeys(clipped bool) string {
-	if m.keyboardHeldElsewhere() {
+	if !m.alertDetailReachable() {
+		// Under the portal, a floating program, or a form, every key the
+		// card might name belongs to something else: Esc cancels the form
+		// rather than the card, and `e` edits a path. It claims nothing,
+		// and the message stays readable afterwards through `e` on the
+		// dashboard.
 		return ""
 	}
-	keys := []string{}
-	if m.alertDetailReachable() {
-		label := "e detail"
-		if clipped {
-			label = "e read it all"
-		}
-		keys = append(keys, label)
+	label := "e detail"
+	if clipped {
+		label = "e read it all"
 	}
-	keys = append(keys, "Esc dismiss")
-	return mutedStyle().Render(strings.Join(keys, "  ·  ")) + " "
+	return mutedStyle().Render(label+"  ·  Esc dismiss") + " "
+}
+
+// alertRows is how many rows the card will take, which is how much of the
+// body a modal has to leave alone.
+func (m Model) alertRows(width, height int) int {
+	card := m.renderAlertCard(width, height)
+	if card == "" {
+		return 0
+	}
+	return strings.Count(card, "\n") + 1
 }
 
 func alignRight(content string, width int) string {
@@ -234,7 +300,12 @@ func alignRight(content string, width int) string {
 // alertDetailDimensions sizes the detail modal to the message: tall enough
 // to hold it outright when the body has the room, scrolling when it does not.
 func (m Model) alertDetailDimensions(width, height int) (int, int) {
-	lines := wrapMessage(m.alertDetail.text, min(width, alertCardWidth)-6)
+	// Two passes, because the modal's width decides how many lines the
+	// message takes and the line count decides its height. Measuring at
+	// the preferred width instead would size the modal short of its own
+	// text on every terminal narrow enough to be margined.
+	modalWidth, _ := modalDimensions(width, height, alertCardWidth, 1)
+	lines := wrapMessage(m.alertDetail.text, max(4, modalWidth-6))
 	return modalDimensions(width, height, alertCardWidth, len(lines)+6)
 }
 
@@ -254,7 +325,11 @@ func (m Model) renderAlertModal(width, height int) string {
 	offset := clamp(m.alertDetail.offset, 0, max(0, len(lines)-window))
 	visible := lines[offset:min(len(lines), offset+window)]
 
-	out := []string{"  " + errorStyle().Bold(true).Render("Error"), ""}
+	title := "  " + errorStyle().Bold(true).Render("Error")
+	if age := alertAgeLabel(m.alertDetail.at); age != "" {
+		title += mutedStyle().Render(age)
+	}
+	out := []string{title, ""}
 	for _, line := range visible {
 		out = append(out, "  "+line)
 	}
@@ -267,4 +342,17 @@ func (m Model) renderAlertModal(width, height int) string {
 	}
 	out = append(out, "", "  "+mutedStyle().Render(keys))
 	return renderModal(strings.Join(out, "\n"), modalWidth, modalHeight)
+}
+
+// alertAgeLabel places a recalled message in time. A failure still on
+// screen needs no stamp; one read minutes later does, because `e` reaches
+// the last failure whether or not its card is still up.
+func alertAgeLabel(at time.Time) string {
+	if at.IsZero() {
+		return ""
+	}
+	if age := timeAgo(at); age != "" && age != "now" {
+		return " · " + age + " ago"
+	}
+	return ""
 }

--- a/internal/ui/alert.go
+++ b/internal/ui/alert.go
@@ -18,8 +18,17 @@ import (
 // was unreadable by construction, and the reader rarely got even that far.
 //
 // The alert is the correction. The message floats in its own card over the
-// foot of the body, wrapped rather than cut, and it waits there until it is
-// dismissed, superseded, or answered — the hint row keeps its own line.
+// foot of the body, wrapped rather than cut, and the hint row keeps its own
+// line. A card ends in one of five ways, and only the first counts as read:
+//
+//   - dismissed, by Esc or by opening it with `e`
+//   - superseded, by a different failure
+//   - answered, when the poll that raised it succeeds (see polled)
+//   - swept, when the form that raised it closes (see raisedIn)
+//   - timed out, where no key of ours can reach it (see expires)
+//
+// The distinction matters because only a card that was read may silence a
+// failure that repeats. Everything else leaves it free to speak again.
 type alert struct {
 	err error
 	// raisedIn is the surface the complaint belongs to. A form's
@@ -208,6 +217,11 @@ func (m *Model) refitForms() {
 // The recovery also lifts the hush — if the failure returns after this, it
 // is news again.
 func (m *Model) resolvePolled() {
+	// The recall slot stops being the poll's the moment the poll works.
+	// Otherwise reading it later — the whole point of recall — arms a
+	// hush against a failure that is not happening, and the next time it
+	// does happen the dashboard says nothing at all.
+	m.lastFailure.polled = false
 	if m.alert.polled {
 		// Through clearAlert, not by hand: the card's rows come back to
 		// the modal and whatever was sized for the shorter one has to
@@ -353,10 +367,17 @@ func wrapMessage(message string, width int) []string {
 // a real terminal sized 1:1 to its pane, and a card that changed the body's
 // height would reflow every agent's screen each time something failed.
 func (m Model) renderAlertCard(width, height int) string {
-	// Three rows is a card with nothing in it: two borders and the keys.
-	// Rendering one anyway is how a card loses its bottom edge.
-	if !m.alert.active() || width < 16 || height < 4 {
+	if !m.alert.active() || width < 8 || height < 1 {
 		return ""
+	}
+	// Three rows is a card with nothing in it: two borders and the keys,
+	// and rendering a frame into fewer is how it loses its bottom edge.
+	// A terminal that small still gets the message, just without the
+	// frame — the old footer row managed that much, and going quiet
+	// because the screen is small is the one thing this must never do.
+	if width < 16 || height < 4 {
+		return errorStyle().Render(
+			truncate("! "+m.alert.message(), width))
 	}
 	cardWidth := clamp(width-4, 16, alertCardWidth)
 	textWidth := max(4, cardWidth-6)

--- a/internal/ui/alert.go
+++ b/internal/ui/alert.go
@@ -116,8 +116,10 @@ func (m *Model) raiseFailure(err error, polled bool) {
 		if polled {
 			// The same text arriving from the poll makes this the poll's
 			// card too, and a card that never learns it is polled never
-			// clears itself when the daemon comes back.
+			// clears itself when the daemon comes back. The recall slot
+			// is the same failure and learns it at the same moment.
 			m.alert.polled = true
+			m.lastFailure.polled = true
 		}
 		return
 	}
@@ -356,13 +358,6 @@ func (m Model) renderAlertCard(width, height int) string {
 	if !m.alert.active() || width < 16 || height < 4 {
 		return ""
 	}
-	if m.mode.isReading() {
-		// Help, info, history and the detail view are read end to end and
-		// close on any key. Shrinking them to make room truncates their
-		// last lines, and drawing over them is worse; the card waits the
-		// few seconds they are open and comes back after.
-		return ""
-	}
 	cardWidth := clamp(width-4, 16, alertCardWidth)
 	textWidth := max(4, cardWidth-6)
 	budget := clamp(height-3, 1, alertCardLines)
@@ -428,18 +423,23 @@ func (m Model) alertCardKeys(clipped bool) string {
 // floats above them instead of over them — covering the box someone is
 // typing into is worse than covering anything else on screen.
 func (m Model) inputStripRows() int {
-	switch m.mode {
-	case modeCompose:
+	if m.mode == modeCompose {
 		// Measured where renderInteraction lays it out, not at the pane's
 		// full width — three columns of difference is a wrapped line, and
 		// a lift one row short covers the rule it exists to clear.
 		composerWidth, _ := m.interactionDimensions()
 		// The composer is its input between two rules.
 		return composerHeight(m.sendInput.Value(), max(1, composerWidth)) + 2
-	case modeSearch:
-		return 1
 	}
-	return 0
+	if m.ptyEnabled {
+		// The portal is the pane; the card floats over the terminal and
+		// ages out rather than reserving anything.
+		return 0
+	}
+	// The transcript's foot row is never empty: the reply and search
+	// affordances, the amber band telling the reader an agent is waiting
+	// on them, or the search readout answering which match of how many.
+	return 1
 }
 
 // alertRows is how many rows the card will take, which is how much of the
@@ -493,9 +493,15 @@ func (m Model) alertDetailWindow() (int, int) {
 	return max(4, width-6), max(1, height-6)
 }
 
-// modalRegion is the room a modal has: the body, less whatever rows the
-// failure card has claimed at its foot.
+// modalRegion is the room a modal has. A form makes way for the card: it
+// is being typed into, and a card over the field is intolerable. An
+// overlay that is only read does not — it is sized to its own content, so
+// shrinking it silently cuts its last lines off, and it closes on any key.
+// The card floats over that instead, which loses nothing either way.
 func (m Model) modalRegion(width, height int) int {
+	if m.mode.isReading() {
+		return height
+	}
 	return max(1, height-m.alertRows(width, height))
 }
 

--- a/internal/ui/alert_test.go
+++ b/internal/ui/alert_test.go
@@ -1365,3 +1365,74 @@ func TestAnAutoClosedComposerTakesItsComplaintWithIt(t *testing.T) {
 		t.Fatalf("the composer's objection outlived the composer: %v", model.alert.err)
 	}
 }
+
+// A failure that arrived on its own must never move the field the reader
+// is typing into. Their next keystrokes would land in the task body.
+func TestABackgroundFailureNeverMovesTheCursor(t *testing.T) {
+	for height := 21; height <= 26; height++ {
+		model := alertModel(t)
+		model.width = 100
+		model.height = height
+		updated, _ := model.beginDispatch(false)
+		model = updated.(Model)
+		if !model.dispatchNameVisible() {
+			continue
+		}
+		model.formFocus = dispatchName
+		model.focusForm()
+		model.nameInput.SetValue("ap")
+
+		updated, _ = model.Update(dashboardMsg{err: errors.New(sshFailure)})
+		model = updated.(Model)
+		if model.formFocus != dispatchName {
+			t.Fatalf("at height %d a background failure moved focus to %v",
+				height, model.formFocus)
+		}
+		if !model.dispatchNameVisible() {
+			t.Fatalf("at height %d the focused name row stopped being drawn", height)
+		}
+
+		// And the next keystroke still goes where the reader is looking.
+		updated, _ = model.Update(runeKey("i"))
+		model = updated.(Model)
+		if got := strings.TrimSpace(model.nameInput.Value()); got != "api" {
+			t.Fatalf("at height %d the keystroke landed elsewhere: name=%q task=%q",
+				height, got, model.taskInput.Value())
+		}
+	}
+}
+
+// The card is drawn a lift above the body's floor, so the room a modal is
+// given has to account for both or they overlap by exactly that lift.
+func TestModalAndCardDoNotOverlapWithAFootRow(t *testing.T) {
+	for _, size := range [][2]int{{80, 18}, {80, 19}, {90, 20}, {100, 22}} {
+		model := alertModel(t)
+		model.ptyEnabled = false
+		model.width, model.height = size[0], size[1]
+		model.mode = modeDispatch
+		model.raise(errors.New(sshFailure))
+
+		width, height := model.bodyDimensions()
+		_, modalBottom := frameSpan(model.renderModeBody(width, height), 1)
+		cardTop, _ := frameSpan(model.renderBody(), 0)
+		if modalBottom < 0 || cardTop < 0 {
+			continue
+		}
+		if cardTop <= modalBottom {
+			t.Fatalf("%dx%d: card starts at row %d, modal ends at %d",
+				size[0], size[1], cardTop, modalBottom)
+		}
+	}
+}
+
+// A half-typed chord takes Esc first, so the card must not claim it.
+func TestCardYieldsEscapeToAPendingChord(t *testing.T) {
+	model := alertModel(t)
+	model.raise(errors.New("interrupt failed"))
+	model.normalPrefix = ","
+
+	card := ansi.Strip(model.renderAlertCard(model.bodyDimensions()))
+	if strings.Contains(card, "Esc dismiss") {
+		t.Fatalf("the card claimed Esc while a chord was pending:\n%s", card)
+	}
+}

--- a/internal/ui/alert_test.go
+++ b/internal/ui/alert_test.go
@@ -1436,3 +1436,105 @@ func TestCardYieldsEscapeToAPendingChord(t *testing.T) {
 		t.Fatalf("the card claimed Esc while a chord was pending:\n%s", card)
 	}
 }
+
+// A form's objection is spent when the form closes. Recall must not offer
+// it back later as though it were an outstanding failure.
+func TestARetractedComplaintIsNotRecallable(t *testing.T) {
+	model := alertModel(t)
+	updated, _ := model.beginDispatch(false)
+	model = updated.(Model)
+	model.formFocus = dispatchTask
+	model.taskInput.SetValue("")
+	updated, _ = model.submitDispatch()
+	model = updated.(Model)
+	if model.alert.raisedIn != modeDispatch {
+		t.Fatalf("the form's objection was tagged %v", model.alert.raisedIn)
+	}
+
+	updated, _ = model.Update(tea.KeyPressMsg{Code: tea.KeyEscape})
+	model = updated.(Model)
+	if model.alert.active() {
+		t.Fatalf("the sweep left the card up")
+	}
+
+	updated, _ = model.Update(runeKey("e"))
+	if next := updated.(Model); next.mode == modeAlert {
+		t.Fatalf("a retracted complaint came back through recall: %q",
+			next.alertDetail.text)
+	}
+}
+
+// A reservation that collapses the form it makes room for has defeated
+// itself: the card floats precisely so a failure reflows nothing.
+func TestAShortTerminalKeepsAUsableForm(t *testing.T) {
+	for _, height := range []int{10, 12, 14, 16} {
+		model := alertModel(t)
+		model.width = 100
+		model.height = height
+		model.mode = modeDispatch
+		model.raise(errors.New(sshFailure))
+
+		width, bodyHeight := model.bodyDimensions()
+		region := model.modalRegion(width, bodyHeight)
+		if region < bodyHeight/2 {
+			t.Fatalf("at height %d the form was left %d rows of %d",
+				height, region, bodyHeight)
+		}
+	}
+}
+
+// The card must not grow past the rows reserved for the composer.
+func TestTheCardNeverOutgrowsItsLift(t *testing.T) {
+	model := alertModel(t)
+	model.ptyEnabled = false
+	model.width = 100
+	model.height = 10
+	model.mode = modeCompose
+	model.raise(errors.New(sshFailure))
+
+	width, height := model.bodyDimensions()
+	rows := model.alertRows(width, height)
+	if rows+model.inputStripRows() > height {
+		t.Fatalf("card %d rows + lift %d exceeds the body's %d",
+			rows, model.inputStripRows(), height)
+	}
+}
+
+// The detail view keeps its own key row, which the footer advertises.
+func TestTheDetailViewKeepsItsKeysOnAShortTerminal(t *testing.T) {
+	for _, height := range []int{9, 11, 13} {
+		model := alertModel(t)
+		model.width = 100
+		model.height = height
+		model.raise(errors.New(strings.Repeat("a line of failure output. ", 20)))
+		updated, _ := model.Update(runeKey("e"))
+		model = updated.(Model)
+
+		view := ansi.Strip(model.renderAlertModal(model.bodyDimensions()))
+		if !strings.Contains(view, "Esc close") {
+			t.Fatalf("at height %d the detail view dropped its keys:\n%s", height, view)
+		}
+	}
+}
+
+// The real terminal cursor must not blink inside the card drawn over it.
+func TestTheCursorDoesNotBlinkInsideTheCard(t *testing.T) {
+	model := alertModel(t)
+	model.ptyEnabled = true
+	model.activePane = paneInteraction
+	width, height := model.bodyDimensions()
+	model.raise(errors.New(sshFailure))
+	rows := model.alertRows(width, height)
+	if rows == 0 {
+		t.Fatalf("no card to cover anything")
+	}
+
+	// A grid row the card is drawn over, and one above it.
+	covered := max(0, height-rows-model.inputStripRows()) + bodyTop - ptyGridTop
+	if got := model.gridCursorAt(4, covered); got != nil {
+		t.Fatalf("the cursor was placed inside the card at %v", got)
+	}
+	if got := model.gridCursorAt(4, covered-1); got == nil {
+		t.Fatalf("the cursor was withheld from a row the card does not cover")
+	}
+}

--- a/internal/ui/alert_test.go
+++ b/internal/ui/alert_test.go
@@ -1151,24 +1151,53 @@ func TestACardNeverLeavesFocusOnAnUndrawnField(t *testing.T) {
 	}
 }
 
-// Read-only overlays are sized to their own content and close on any key;
-// taking rows out of them truncates their last lines.
-func TestReadingOverlaysKeepTheirLastLines(t *testing.T) {
+// Read-only overlays are sized to their own content, so taking rows out of
+// them cuts their last lines off. They keep their full height and the card
+// floats over them instead — a failure must never be invisible, which is
+// the whole point of the surface.
+func TestReadingOverlaysKeepTheirLastLinesAndStillShowFailures(t *testing.T) {
+	// 120x44: tall enough that the help draws its final entry, so
+	// shrinking by the card's rows is visible as content loss rather than
+	// as a border that moves.
 	model := alertModel(t)
 	model.width = 120
 	model.height = 44
 	width, height := model.bodyDimensions()
-	bare := model.renderHelpModal(width, height)
+	if !strings.Contains(
+		ansi.Strip(model.renderHelpModal(width, height)), "quit the dashboard",
+	) {
+		t.Skip("this terminal is too short for the help's last entry")
+	}
 
 	model.raise(errors.New(sshFailure))
 	model.mode = modeHelp
-	if got := model.renderModeBody(width, height); !strings.Contains(
-		ansi.Strip(got), strings.TrimSpace(ansi.Strip(lastLine(bare))),
+	if got := ansi.Strip(model.renderModeBody(width, height)); !strings.Contains(
+		got, "quit the dashboard",
 	) {
-		t.Fatalf("the help lost its last line to the card:\n%s", ansi.Strip(got))
+		t.Fatalf("the help lost its last entry to the card:\n%s", got)
 	}
-	if card := model.renderAlertCard(width, height); card != "" {
-		t.Fatalf("the card drew over a reading overlay:\n%s", card)
+	if model.renderAlertCard(width, height) == "" {
+		t.Fatalf("the failure was invisible while the help was open")
+	}
+}
+
+// A failure raised while a reading overlay is open is exactly the case the
+// card must not swallow: nothing else on screen will mention it.
+func TestAFailureRaisedUnderAReadingOverlayIsVisible(t *testing.T) {
+	for _, surface := range []mode{modeHelp, modeInfo, modeHistory, modeAlert} {
+		model := alertModel(t)
+		model.mode = surface
+		model.raise(errors.New("session history is unreadable"))
+
+		width, height := model.bodyDimensions()
+		if !strings.Contains(
+			ansi.Strip(model.renderBody()), "session history is unreadable",
+		) {
+			t.Fatalf("mode %v swallowed the failure raised under it", surface)
+		}
+		if model.renderAlertCard(width, height) == "" {
+			t.Fatalf("mode %v drew no card", surface)
+		}
 	}
 }
 
@@ -1205,5 +1234,45 @@ func TestRecoveryLiftsTheHoldBackToo(t *testing.T) {
 	updated, _ = model.Update(down())
 	if next := updated.(Model); !next.alert.active() {
 		t.Fatalf("a failure that returned after a recovery stayed held back")
+	}
+}
+
+// An unreadable shelf is not an empty one. Saying "nothing here yet" when
+// the read failed is the screen telling the reader something untrue.
+func TestHistoryDoesNotClaimAnEmptyShelfWhenItCouldNotRead(t *testing.T) {
+	model := alertModel(t)
+	model.mode = modeHistory
+	model.historyLoading = true
+
+	updated, _ := model.Update(historyMsg{err: errors.New("state directory is unreadable")})
+	model = updated.(Model)
+
+	view := ansi.Strip(model.renderHistoryModal(model.bodyDimensions()))
+	if strings.Contains(view, "No past sessions recorded yet") {
+		t.Fatalf("the modal claimed an empty shelf after a failed read:\n%s", view)
+	}
+	if !strings.Contains(view, "state directory is unreadable") {
+		t.Fatalf("the modal does not say why it is empty:\n%s", view)
+	}
+}
+
+// The transcript's foot row always says something — the reply affordances,
+// the amber band, the search readout — and the card must stay off it.
+func TestCardStaysOffTheTranscriptsFootRow(t *testing.T) {
+	model := alertModel(t)
+	model.ptyEnabled = false
+	if got := model.inputStripRows(); got < 1 {
+		t.Fatalf("the transcript's foot row was not reserved: %d", got)
+	}
+
+	model.search.query = "needle"
+	if got := model.inputStripRows(); got < 1 {
+		t.Fatalf("the search readout was not reserved: %d", got)
+	}
+
+	model.ptyEnabled = true
+	model.mode = modeNormal
+	if got := model.inputStripRows(); got != 0 {
+		t.Fatalf("the portal reserved %d rows; it has no foot row", got)
 	}
 }

--- a/internal/ui/alert_test.go
+++ b/internal/ui/alert_test.go
@@ -618,3 +618,148 @@ func TestNarrowCardDropsItsKeysRatherThanItsFrame(t *testing.T) {
 		t.Fatalf("the card rendered %d rows into a body of %d:\n%s", rows, height, card)
 	}
 }
+
+// Timing out is the one ending where the reader provably did not read it.
+// Hushing there is how a dashboard goes quiet about a daemon still down.
+func TestTimingOutDoesNotHushAFailure(t *testing.T) {
+	model := alertModel(t)
+	model.ptyEnabled = true
+	model.activePane = paneInteraction
+	updated, _ := model.Update(dashboardMsg{err: errors.New("daemon is not listening")})
+	model = updated.(Model)
+
+	moment := time.Now()
+	model.ageAlert(moment)
+	model.ageAlert(moment.Add(alertLinger + time.Second))
+	if model.alert.active() {
+		t.Fatalf("the card should have timed out inside the portal")
+	}
+
+	model.activePane = paneAgents
+	updated, _ = model.Update(dashboardMsg{err: errors.New("daemon is not listening")})
+	if next := updated.(Model); !next.alert.active() {
+		t.Fatalf("a failure nobody read was silenced by its own timeout")
+	}
+}
+
+// Opening a form drops its stale complaint, which must not silence a
+// self-repeating failure the reader never answered.
+func TestOpeningAFormDoesNotHushAPolledFailure(t *testing.T) {
+	model := alertModel(t)
+	updated, _ := model.Update(dashboardMsg{err: errors.New("daemon is not listening")})
+	model = updated.(Model)
+
+	updated, _ = model.Update(runeKey("n"))
+	model = updated.(Model)
+	updated, _ = model.Update(tea.KeyPressMsg{Code: tea.KeyEscape})
+	model = updated.(Model)
+
+	updated, _ = model.Update(dashboardMsg{err: errors.New("daemon is not listening")})
+	if next := updated.(Model); !next.alert.active() {
+		t.Fatalf("opening a form silenced a failure the reader never answered")
+	}
+}
+
+// Asking again is asking to be told: a hushed failure that is still
+// failing has to answer an explicit refresh, or the retry looks like
+// success.
+func TestExplicitRefreshBreaksTheHush(t *testing.T) {
+	model := alertModel(t)
+	down := func() dashboardMsg {
+		return dashboardMsg{err: errors.New("daemon is not listening")}
+	}
+	updated, _ := model.Update(down())
+	model = updated.(Model)
+	updated, _ = model.Update(tea.KeyPressMsg{Code: tea.KeyEscape})
+	model = updated.(Model)
+
+	updated, _ = model.Update(runeKey("r"))
+	model = updated.(Model)
+	updated, _ = model.Update(down())
+	if next := updated.(Model); !next.alert.active() {
+		t.Fatalf("an explicit refresh that failed again said nothing")
+	}
+}
+
+// A failure that merely arrived while a form was open belongs to nothing
+// on screen; cancelling that form is not an answer to it.
+func TestCancellingAFormKeepsAnUnrelatedFailure(t *testing.T) {
+	model := alertModel(t)
+	updated, _ := model.Update(runeKey("n"))
+	model = updated.(Model)
+	if !model.mode.isForm() {
+		t.Fatalf("n did not open a form: mode = %v", model.mode)
+	}
+
+	// An ssh setup started earlier finishes badly while the form is open.
+	updated, _ = model.Update(machinePreparedMsg{
+		host: "thaidex", err: errors.New("ssh: could not resolve hostname"),
+	})
+	model = updated.(Model)
+	if !model.alert.active() {
+		t.Fatalf("the setup failure raised nothing")
+	}
+
+	updated, _ = model.Update(tea.KeyPressMsg{Code: tea.KeyEscape})
+	if next := updated.(Model); !next.alert.active() {
+		t.Fatalf("cancelling the form discarded a failure it did not raise")
+	}
+}
+
+// Esc keeps meaning what it meant: drop the selection, clear the search,
+// and only then answer the card.
+func TestEscapeAnswersTheCardLast(t *testing.T) {
+	model := alertModel(t)
+	// The transcript's own selection, so the keyboard is the dashboard's
+	// rather than the agent's.
+	model.ptyEnabled = false
+	model.activePane = paneInteraction
+	model.selectionActive = true
+	model.raise(errors.New("interrupt failed"))
+
+	updated, _ := model.Update(tea.KeyPressMsg{Code: tea.KeyEscape})
+	model = updated.(Model)
+	if model.selectionActive {
+		t.Fatalf("Esc did not drop the selection")
+	}
+	if !model.alert.active() {
+		t.Fatalf("Esc answered the card while a selection was still up")
+	}
+
+	updated, _ = model.Update(tea.KeyPressMsg{Code: tea.KeyEscape})
+	if next := updated.(Model); next.alert.active() {
+		t.Fatalf("the next Esc did not answer the card")
+	}
+}
+
+// The card floats above the box someone is typing into, never over it.
+func TestCardStaysOffTheComposer(t *testing.T) {
+	model := alertModel(t)
+	model.mode = modeCompose
+	model.sendInput.SetValue("a reply in progress")
+	model.raise(errors.New(sshFailure))
+
+	width, height := model.bodyDimensions()
+	lift := model.inputStripRows(width)
+	if lift < 3 {
+		t.Fatalf("the composer strip measured %d rows", lift)
+	}
+	_, cardBottom := frameSpan(model.renderBody(), 0)
+	if cardBottom < 0 {
+		t.Fatalf("no card rendered")
+	}
+	if cardBottom > height-1-lift {
+		t.Fatalf("the card reaches row %d, into the composer's last %d rows of %d",
+			cardBottom, lift, height)
+	}
+}
+
+// With no card there is nothing to composite, and the body must go out
+// exactly as the mode drew it.
+func TestBodyIsUntouchedWithoutACard(t *testing.T) {
+	model := alertModel(t)
+	width, height := model.bodyDimensions()
+	if got, want := model.renderBody(), model.renderModeBody(width, height); got != want {
+		t.Fatalf("an empty card still rewrote the body:\n%q\n\n%q", got, want)
+	}
+}

--- a/internal/ui/alert_test.go
+++ b/internal/ui/alert_test.go
@@ -1,0 +1,246 @@
+package ui
+
+import (
+	"errors"
+	"strings"
+	"testing"
+	"time"
+
+	tea "charm.land/bubbletea/v2"
+	"github.com/charmbracelet/x/ansi"
+)
+
+const sshFailure = "set up thaidex: ssh: connect to host thaidex port 22: " +
+	"Connection refused\nkex_exchange_identification: read: " +
+	"Connection reset by peer"
+
+func alertModel(t *testing.T) Model {
+	t.Helper()
+	model := NewModel(stubBackend{})
+	model.ready = true
+	model.width = 100
+	model.height = 30
+	return model
+}
+
+func TestAlertCardShowsWholeMessageWhenItFits(t *testing.T) {
+	model := alertModel(t)
+	model.raise(errors.New("workspace directory is unavailable: /Volumes/repos/gone"))
+
+	card := ansi.Strip(model.renderAlertCard(model.bodyDimensions()))
+	if !strings.Contains(card, "/Volumes/repos/gone") {
+		t.Fatalf("the path the message is about was cut:\n%s", card)
+	}
+	if strings.Contains(card, "…") {
+		t.Fatalf("a message this short should not be elided:\n%s", card)
+	}
+}
+
+func TestAlertCardWrapsRatherThanTruncates(t *testing.T) {
+	model := alertModel(t)
+	model.raise(errors.New(sshFailure))
+
+	card := ansi.Strip(model.renderAlertCard(model.bodyDimensions()))
+	if !strings.Contains(unwrapped(card), unwrapped(sshFailure)) {
+		t.Fatalf("the message did not survive the card whole:\n%s", card)
+	}
+	if !strings.Contains(card, "Esc dismiss") {
+		t.Fatalf("the card does not say how to dismiss it:\n%s", card)
+	}
+}
+
+// unwrapped reads a rendered block back as running text: the card's frame
+// and the line breaks it introduced are layout, not message.
+func unwrapped(value string) string {
+	value = strings.Map(func(r rune) rune {
+		if strings.ContainsRune("│╭╮╰╯─!", r) {
+			return -1
+		}
+		return r
+	}, ansi.Strip(value))
+	return strings.Join(strings.Fields(value), " ")
+}
+
+func TestAlertCardOffersTheRestWhenItRunsOut(t *testing.T) {
+	model := alertModel(t)
+	model.raise(errors.New(strings.Repeat("stderr says something long. ", 30)))
+
+	card := ansi.Strip(model.renderAlertCard(model.bodyDimensions()))
+	if lines := strings.Count(card, "\n") + 1; lines > alertCardLines+3 {
+		t.Fatalf("the card grew past its budget (%d lines):\n%s", lines, card)
+	}
+	if !strings.Contains(card, "e read it all") {
+		t.Fatalf("a clipped card must offer the rest:\n%s", card)
+	}
+}
+
+// The Spanreed is a real terminal sized 1:1 to its pane. A card that took
+// rows of its own would resize every agent's screen each time something
+// failed, so it floats instead.
+func TestAlertCardDoesNotResizeTheBody(t *testing.T) {
+	model := alertModel(t)
+	width, height := model.bodyDimensions()
+
+	model.raise(errors.New(sshFailure))
+	alertWidth, alertHeight := model.bodyDimensions()
+	if alertWidth != width || alertHeight != height {
+		t.Fatalf("body geometry moved under the card: %dx%d, want %dx%d",
+			alertWidth, alertHeight, width, height)
+	}
+
+	body := strings.Split(model.renderBody(), "\n")
+	if len(body) != height {
+		t.Fatalf("body rendered %d rows, want %d", len(body), height)
+	}
+	if !strings.Contains(
+		ansi.Strip(strings.Join(body, "\n")), "kex_exchange_identification") {
+		t.Fatalf("the card never made it onto the body:\n%s", strings.Join(body, "\n"))
+	}
+}
+
+func TestAlertDetailOpensTheWholeMessageAndClosesTheCard(t *testing.T) {
+	model := alertModel(t)
+	model.raise(errors.New(sshFailure))
+
+	updated, _ := model.Update(runeKey("e"))
+	model = updated.(Model)
+	if model.mode != modeAlert {
+		t.Fatalf("mode = %v, want modeAlert", model.mode)
+	}
+	if model.alert.active() {
+		t.Fatalf("reading the message left the card standing")
+	}
+
+	view := ansi.Strip(model.renderAlertModal(model.bodyDimensions()))
+	if !strings.Contains(view, "kex_exchange_identification") ||
+		!strings.Contains(view, "y copy") {
+		t.Fatalf("detail view is missing the message or its keys:\n%s", view)
+	}
+
+	updated, _ = model.Update(tea.KeyPressMsg{Code: tea.KeyEscape})
+	if next := updated.(Model); next.mode != modeNormal {
+		t.Fatalf("Esc left the detail view open: mode = %v", next.mode)
+	}
+}
+
+func TestAlertDetailScrollsAndCopies(t *testing.T) {
+	model := alertModel(t)
+	model.height = 14
+	model.raise(errors.New(strings.Repeat("a line of failure output. ", 60)))
+
+	updated, _ := model.Update(runeKey("e"))
+	model = updated.(Model)
+
+	updated, _ = model.Update(runeKey("j"))
+	if next := updated.(Model); next.alertDetail.offset != 1 {
+		t.Fatalf("offset = %d, want 1", next.alertDetail.offset)
+	}
+	model = updated.(Model)
+
+	updated, cmd := model.Update(runeKey("y"))
+	if cmd == nil {
+		t.Fatalf("y did not copy the message")
+	}
+	if next := updated.(Model); next.mode != modeAlert {
+		t.Fatalf("copying closed the detail view: mode = %v", next.mode)
+	}
+}
+
+// A refresh against a daemon that is down fails every tick. That is one
+// failure repeating, not a new one each time, so its clock keeps running.
+func TestRepeatedFailureIsTheSameCard(t *testing.T) {
+	model := alertModel(t)
+	model.raise(errors.New("daemon is not listening"))
+	model.alert.expires = time.Now().Add(time.Second)
+
+	model.raise(errors.New("daemon is not listening"))
+	if model.alert.expires.IsZero() {
+		t.Fatalf("an identical failure restarted the card's clock")
+	}
+
+	model.raise(errors.New("something else went wrong"))
+	if !model.alert.expires.IsZero() {
+		t.Fatalf("a different failure kept the old card's clock")
+	}
+}
+
+// Inside the portal Esc belongs to the agent, so the card cannot be
+// dismissed by hand there and ages out instead.
+func TestAlertAgesOutOnlyWhereItCannotBeDismissed(t *testing.T) {
+	model := alertModel(t)
+	model.ptyEnabled = true
+	model.activePane = paneInteraction
+	model.raise(errors.New("interrupt failed"))
+
+	now := time.Now()
+	model.ageAlert(now)
+	if model.alert.expires.IsZero() {
+		t.Fatalf("the portal did not start the card's clock")
+	}
+	model.ageAlert(now.Add(alertLinger + time.Second))
+	if model.alert.active() {
+		t.Fatalf("the card outlived its linger inside the portal")
+	}
+
+	model.raise(errors.New("interrupt failed"))
+	model.activePane = paneAgents
+	model.ageAlert(now.Add(alertLinger + time.Second))
+	if !model.alert.active() {
+		t.Fatalf("a dismissible card aged out anyway")
+	}
+	if !model.alert.expires.IsZero() {
+		t.Fatalf("leaving the portal left the clock running")
+	}
+}
+
+// A form's complaint has nothing left to say once the form is gone.
+func TestLeavingAModeClearsItsComplaint(t *testing.T) {
+	model := alertModel(t)
+	model.mode = modeRename
+	model.renameInput = newLineInput("New name")
+
+	updated, _ := model.Update(tea.KeyPressMsg{Code: tea.KeyEnter})
+	model = updated.(Model)
+	if model.alert.message() != "name cannot be empty" {
+		t.Fatalf("rename accepted an empty name: %v", model.alert.err)
+	}
+
+	updated, _ = model.Update(tea.KeyPressMsg{Code: tea.KeyEscape})
+	model = updated.(Model)
+	if model.mode != modeNormal {
+		t.Fatalf("Esc did not leave the rename form: mode = %v", model.mode)
+	}
+	if model.alert.active() {
+		t.Fatalf("the form's complaint outlived the form: %v", model.alert.err)
+	}
+}
+
+func TestWrapMessageKeepsTheLinesTheErrorChose(t *testing.T) {
+	lines := wrapMessage("first line\nsecond line that is long enough to fold", 20)
+	if len(lines) < 3 || lines[0] != "first line" {
+		t.Fatalf("wrap lost the error's own structure: %#v", lines)
+	}
+	for _, line := range lines {
+		if ansi.StringWidth(line) > 20 {
+			t.Fatalf("line %q overruns the width", line)
+		}
+	}
+}
+
+// A small terminal still gets the message, and the card still fits inside
+// the frame rather than pushing it around.
+func TestAlertCardFitsASmallTerminal(t *testing.T) {
+	model := alertModel(t)
+	model.width = 54
+	model.height = 14
+	model.raise(errors.New(sshFailure))
+
+	assertViewFitsPane(t, model, model.width, model.height)
+	view := ansi.Strip(model.View().Content)
+	if !strings.Contains(view, "connect to host") {
+		t.Fatalf("the message never reached a narrow screen:\n%s", view)
+	}
+	if !strings.Contains(view, "e read it all") {
+		t.Fatalf("a card clipped by a small screen must offer the rest:\n%s", view)
+	}
+}

--- a/internal/ui/alert_test.go
+++ b/internal/ui/alert_test.go
@@ -2,6 +2,7 @@ package ui
 
 import (
 	"errors"
+	"fmt"
 	"strings"
 	"testing"
 	"time"
@@ -446,5 +447,174 @@ func TestFooterNamesTheDetailViewsOwnKeys(t *testing.T) {
 	}
 	if strings.Contains(footer, "n new") || strings.Contains(footer, "q quit") {
 		t.Fatalf("footer advertises keys the detail view does not answer: %q", footer)
+	}
+}
+
+// A message read minutes after its card is gone has to place itself in
+// time; one still on screen does not.
+func TestRecalledFailureCarriesItsAge(t *testing.T) {
+	moment := time.Now()
+	alertClock = func() time.Time { return moment.Add(-7 * time.Minute) }
+	t.Cleanup(func() { alertClock = time.Now })
+
+	model := alertModel(t)
+	model.raise(errors.New("interrupt failed"))
+	updated, _ := model.Update(runeKey("e"))
+	model = updated.(Model)
+
+	view := ansi.Strip(model.renderAlertModal(model.bodyDimensions()))
+	if !strings.Contains(view, "7m ago") {
+		t.Fatalf("a recalled failure did not say when it happened:\n%s", view)
+	}
+
+	alertClock = time.Now
+	fresh := alertModel(t)
+	fresh.raise(errors.New("interrupt failed"))
+	updated, _ = fresh.Update(runeKey("e"))
+	view = ansi.Strip(updated.(Model).renderAlertModal(fresh.bodyDimensions()))
+	if strings.Contains(view, "ago") {
+		t.Fatalf("a failure that just happened stamped itself anyway:\n%s", view)
+	}
+}
+
+// The poll fires every 700ms. A failure arriving while someone is reading
+// another one must not swap the text out from under them.
+func TestOpenDetailIsNotOverwrittenByANewFailure(t *testing.T) {
+	model := alertModel(t)
+	model.raise(errors.New(sshFailure))
+
+	updated, _ := model.Update(runeKey("e"))
+	model = updated.(Model)
+
+	updated, _ = model.Update(dashboardMsg{err: errors.New("daemon poll failed")})
+	model = updated.(Model)
+
+	view := ansi.Strip(model.renderAlertModal(model.bodyDimensions()))
+	if strings.Contains(view, "daemon poll failed") {
+		t.Fatalf("a background failure rewrote the message being read:\n%s", view)
+	}
+	if !strings.Contains(unwrapped(view), unwrapped(sshFailure)) {
+		t.Fatalf("the message being read went missing:\n%s", view)
+	}
+	if model.alertDetail.text == model.lastFailure.text {
+		t.Fatalf("the open view and the recall slot are the same storage")
+	}
+}
+
+// A dismissal that lasts 700ms is not a dismissal: the poll would raise the
+// identical failure on the next tick, forever.
+func TestDismissingARecurringFailureSticks(t *testing.T) {
+	model := alertModel(t)
+	down := func() dashboardMsg {
+		return dashboardMsg{err: errors.New("daemon is not listening")}
+	}
+
+	updated, _ := model.Update(down())
+	model = updated.(Model)
+	updated, _ = model.Update(tea.KeyPressMsg{Code: tea.KeyEscape})
+	model = updated.(Model)
+	if model.alert.active() {
+		t.Fatalf("Esc did not take the card down")
+	}
+
+	updated, _ = model.Update(down())
+	if next := updated.(Model); next.alert.active() {
+		t.Fatalf("the next tick raised the failure the reader just dismissed")
+	}
+	model = updated.(Model)
+
+	// Recovery lifts the hush: if it breaks again after working, that is
+	// news.
+	updated, _ = model.Update(dashboardMsg{})
+	model = updated.(Model)
+	updated, _ = model.Update(down())
+	if next := updated.(Model); !next.alert.active() {
+		t.Fatalf("a failure that returned after a recovery stayed silent")
+	}
+}
+
+// Reading a recurring failure dismisses it too, so it must not reappear as
+// a card underneath the view that is reading it.
+func TestReadingARecurringFailureDoesNotRaiseItAgain(t *testing.T) {
+	model := alertModel(t)
+	updated, _ := model.Update(dashboardMsg{err: errors.New("daemon is not listening")})
+	model = updated.(Model)
+
+	updated, _ = model.Update(runeKey("e"))
+	model = updated.(Model)
+
+	updated, _ = model.Update(dashboardMsg{err: errors.New("daemon is not listening")})
+	if next := updated.(Model); next.alert.active() {
+		t.Fatalf("the card came back under the view opened to read it")
+	}
+}
+
+// Any key closes an informational overlay, so treating that key as an
+// answer to a failure is the keystroke-wipe this surface exists to remove.
+func TestClosingAnInformationalOverlayKeepsTheFailure(t *testing.T) {
+	model := alertModel(t)
+	model.mode = modeHistory
+	model.raise(errors.New("session history is unreadable"))
+
+	updated, _ := model.Update(tea.KeyPressMsg{Code: tea.KeyEscape})
+	model = updated.(Model)
+	if model.mode != modeNormal {
+		t.Fatalf("Esc did not close the history: mode = %v", model.mode)
+	}
+	if !model.alert.active() {
+		t.Fatalf("closing the history discarded the failure it was showing")
+	}
+}
+
+// The window the scroll keys clamp to must be the one the message is drawn
+// into, card and all, or the tail is unreachable by every scroll key: the
+// state believes it is already at the bottom.
+func TestScrollReachesTheEndWhileACardStands(t *testing.T) {
+	model := alertModel(t)
+	model.width = 100
+	model.height = 30
+	// Distinct lines, because a message that repeats itself cannot tell a
+	// test whether it is looking at the last line or the tenth.
+	numbered := make([]string, 40)
+	for index := range numbered {
+		numbered[index] = fmt.Sprintf("failure detail line %02d", index+1)
+	}
+	model.raise(errors.New(strings.Join(numbered, "\n")))
+
+	updated, _ := model.Update(runeKey("e"))
+	model = updated.(Model)
+	// A poll failure raises a card under the open view, which is what
+	// shrinks the room the message is drawn into.
+	updated, _ = model.Update(dashboardMsg{err: errors.New("daemon poll failed")})
+	model = updated.(Model)
+	if !model.alert.active() {
+		t.Fatalf("expected a card standing under the detail view")
+	}
+
+	updated, _ = model.Update(runeKey("G"))
+	model = updated.(Model)
+
+	// Read the screen, not the state that decided what to put on it.
+	view := ansi.Strip(model.renderBody())
+	if !strings.Contains(view, numbered[len(numbered)-1]) {
+		t.Fatalf("G left the last line of the message unreachable:\n%s", view)
+	}
+}
+
+// A keys row too wide for the card wraps, costing the card the row its
+// frame was budgeted and the bottom border with it.
+func TestNarrowCardDropsItsKeysRatherThanItsFrame(t *testing.T) {
+	model := alertModel(t)
+	model.width = 25
+	model.height = 7
+	model.raise(errors.New("boom"))
+
+	width, height := model.bodyDimensions()
+	card := ansi.Strip(model.renderAlertCard(width, height))
+	if !strings.Contains(card, "╰") {
+		t.Fatalf("the card lost its bottom edge:\n%s", card)
+	}
+	if rows := strings.Count(card, "\n") + 1; rows > height {
+		t.Fatalf("the card rendered %d rows into a body of %d:\n%s", rows, height, card)
 	}
 }

--- a/internal/ui/alert_test.go
+++ b/internal/ui/alert_test.go
@@ -763,3 +763,169 @@ func TestBodyIsUntouchedWithoutACard(t *testing.T) {
 		t.Fatalf("an empty card still rewrote the body:\n%q\n\n%q", got, want)
 	}
 }
+
+// A form may only claim the card it actually raised. One standing for
+// another reason is not the form's to take with it when it closes.
+func TestAFormDoesNotClaimACardItDidNotRaise(t *testing.T) {
+	model := alertModel(t)
+	repeated := "workspace directory is unavailable: /gone"
+	updated, _ := model.Update(dashboardMsg{err: errors.New(repeated)})
+	model = updated.(Model)
+	if model.alert.raisedIn != modeNormal {
+		t.Fatalf("a polled failure was tagged %v", model.alert.raisedIn)
+	}
+
+	// The same text arrives again, this time as a form's own objection.
+	model.mode = modeAddWorkspace
+	model.complain(errors.New(repeated))
+	if model.alert.raisedIn != modeNormal {
+		t.Fatalf("the form claimed a card it did not raise: %v", model.alert.raisedIn)
+	}
+}
+
+// The task composer is persistent state sized from the room the modal has.
+// A card shortens that room, and a textarea that believes it is taller than
+// the box it is drawn into scrolls itself and stays scrolled.
+func TestDispatchComposerIsSizedForTheModalActuallyDrawn(t *testing.T) {
+	model := alertModel(t)
+	updated, _ := model.beginDispatch(false)
+	model = updated.(Model)
+	if model.mode != modeDispatch {
+		t.Fatalf("the dispatch form did not open: mode = %v", model.mode)
+	}
+
+	updated, _ = model.Update(dashboardMsg{err: errors.New(sshFailure)})
+	model = updated.(Model)
+	if !model.alert.active() {
+		t.Fatalf("expected a card under the form")
+	}
+
+	// Derived independently of dispatchContentDimensions: this is the
+	// shape renderModeBody draws.
+	bodyWidth, bodyHeight := model.bodyDimensions()
+	region := model.modalRegion(bodyWidth, bodyHeight)
+	modalWidth, modalHeight := model.dispatchModalDimensions(bodyWidth, region)
+	drawn := model.dispatchLayout(max(1, modalWidth-2), max(1, modalHeight-2))
+	if got := model.taskInput.Height(); got != drawn.taskHeight {
+		t.Fatalf("composer kept at %d rows while the form draws it at %d",
+			got, drawn.taskHeight)
+	}
+}
+
+// The composer is laid out narrower than its pane, and three columns is a
+// wrapped line: a lift measured at the wrong width covers the rule it
+// exists to clear.
+func TestComposerStripIsMeasuredWhereTheComposerIsDrawn(t *testing.T) {
+	model := alertModel(t)
+	model.mode = modeCompose
+	width, _ := model.bodyDimensions()
+	composerWidth, _ := model.interactionDimensions()
+	_, _, paneWidth := model.paneWidths(width)
+	if composerWidth == paneWidth {
+		t.Skip("this layout does not distinguish the two widths")
+	}
+
+	// A draft that fits on one line at the pane's width and wraps at the
+	// composer's.
+	model.sendInput.SetValue(strings.Repeat("x", composerWidth))
+	if got, want := model.inputStripRows(width),
+		composerHeight(model.sendInput.Value(), composerWidth)+2; got != want {
+		t.Fatalf("strip measured %d rows, composer draws %d", got, want)
+	}
+	if model.inputStripRows(width) ==
+		composerHeight(model.sendInput.Value(), paneWidth)+2 {
+		t.Fatalf("the strip was measured at the pane width, not the composer's")
+	}
+}
+
+// A card that timed out unread takes its polled flag with it, but reading
+// the message afterwards is still answering it.
+func TestReadingATimedOutPollHushesIt(t *testing.T) {
+	model := alertModel(t)
+	model.ptyEnabled = true
+	model.activePane = paneInteraction
+	updated, _ := model.Update(dashboardMsg{err: errors.New("daemon is not listening")})
+	model = updated.(Model)
+
+	moment := time.Now()
+	model.ageAlert(moment)
+	model.ageAlert(moment.Add(alertLinger + time.Second))
+	if model.alert.active() {
+		t.Fatalf("the card should have timed out")
+	}
+
+	model.activePane = paneAgents
+	updated, _ = model.Update(runeKey("e"))
+	model = updated.(Model)
+	if model.mode != modeAlert {
+		t.Fatalf("e did not open the message: mode = %v", model.mode)
+	}
+
+	updated, _ = model.Update(dashboardMsg{err: errors.New("daemon is not listening")})
+	if next := updated.(Model); next.alert.active() {
+		t.Fatalf("the card came back over the view opened to read it")
+	}
+}
+
+// A failure that arrives first from an action and then repeats from the
+// poll is the poll's card too, or it never clears when the daemon returns.
+func TestAFailureThePollRepeatsLearnsToClearItself(t *testing.T) {
+	model := alertModel(t)
+	shared := "read unix ->/tmp/stormlight/daemon.sock: i/o timeout"
+
+	updated, _ := model.Update(actionMsg{err: errors.New(shared)})
+	model = updated.(Model)
+	updated, _ = model.Update(dashboardMsg{err: errors.New(shared)})
+	model = updated.(Model)
+	if !model.alert.active() {
+		t.Fatalf("the card went missing")
+	}
+
+	updated, _ = model.Update(dashboardMsg{})
+	if next := updated.(Model); next.alert.active() {
+		t.Fatalf("the daemon came back and the card kept insisting it was down")
+	}
+}
+
+// The card must not name a key that does something else first.
+func TestCardNamesEscapeOnlyWhenEscapeAnswersIt(t *testing.T) {
+	model := alertModel(t)
+	model.ptyEnabled = false
+	model.activePane = paneInteraction
+	model.raise(errors.New("interrupt failed"))
+
+	card := ansi.Strip(model.renderAlertCard(model.bodyDimensions()))
+	if !strings.Contains(card, "Esc dismiss") {
+		t.Fatalf("with nothing in front of it the card should name Esc:\n%s", card)
+	}
+
+	model.search.query = "needle"
+	card = ansi.Strip(model.renderAlertCard(model.bodyDimensions()))
+	if strings.Contains(card, "Esc dismiss") {
+		t.Fatalf("Esc clears the search first; the card must not claim it:\n%s", card)
+	}
+	if !strings.Contains(card, "e detail") {
+		t.Fatalf("the card dropped the key it does own:\n%s", card)
+	}
+}
+
+// errorWithSlice is not comparable: two interfaces holding it panic on ==.
+type errorWithSlice struct{ parts []string }
+
+func (e errorWithSlice) Error() string { return strings.Join(e.parts, " ") }
+
+// A dependency's value-typed error must not take the dashboard down on the
+// next keypress.
+func TestANonComparableErrorDoesNotPanicOnTheNextKey(t *testing.T) {
+	model := alertModel(t)
+	model.mode = modeRename
+	model.renameInput = newLineInput("New name")
+	model.complain(errorWithSlice{parts: []string{"could not", "rename"}})
+
+	// Any key at all: the mode-close check compares the standing failure
+	// against itself.
+	updated, _ := model.Update(runeKey("j"))
+	if next := updated.(Model); !next.alert.active() {
+		t.Fatalf("the complaint vanished")
+	}
+}

--- a/internal/ui/alert_test.go
+++ b/internal/ui/alert_test.go
@@ -432,8 +432,14 @@ func TestCardKeepsItsFrameOnAShortTerminal(t *testing.T) {
 	if lines := strings.Count(card, "\n") + 1; lines > 4 {
 		t.Fatalf("the card rendered %d rows into 4", lines)
 	}
-	if shorter := model.renderAlertCard(60, 3); shorter != "" {
-		t.Fatalf("a card drew into three rows:\n%s", shorter)
+	// Too short for a frame is not too short for the message: going quiet
+	// because the terminal is small is the one thing this must never do.
+	shorter := ansi.Strip(model.renderAlertCard(60, 3))
+	if strings.Contains(shorter, "╭") || strings.Contains(shorter, "╰") {
+		t.Fatalf("a frame drew into three rows:\n%s", shorter)
+	}
+	if !strings.Contains(shorter, "boom") {
+		t.Fatalf("a short terminal was told nothing:\n%q", shorter)
 	}
 }
 
@@ -1274,5 +1280,88 @@ func TestCardStaysOffTheTranscriptsFootRow(t *testing.T) {
 	model.mode = modeNormal
 	if got := model.inputStripRows(); got != 0 {
 		t.Fatalf("the portal reserved %d rows; it has no foot row", got)
+	}
+}
+
+// Reading a failure that has already recovered must not arm a hush against
+// its next occurrence — that would be the dashboard going silent about a
+// daemon that is down.
+func TestRecallingARecoveredFailureDoesNotSilenceItsReturn(t *testing.T) {
+	model := alertModel(t)
+	down := func() dashboardMsg {
+		return dashboardMsg{err: errors.New("daemon is not listening")}
+	}
+
+	updated, _ := model.Update(down())
+	model = updated.(Model)
+	updated, _ = model.Update(dashboardMsg{})
+	model = updated.(Model)
+	if model.alert.active() {
+		t.Fatalf("the card outlived the recovery")
+	}
+
+	// Minutes later the reader re-reads the message that recall exists for.
+	updated, _ = model.Update(runeKey("e"))
+	model = updated.(Model)
+	updated, _ = model.Update(tea.KeyPressMsg{Code: tea.KeyEscape})
+	model = updated.(Model)
+
+	updated, _ = model.Update(down())
+	if next := updated.(Model); !next.alert.active() {
+		t.Fatalf("the daemon went down again and the dashboard said nothing")
+	}
+}
+
+// Sessions is a list the reader moves through, filters and resumes from.
+// A card over it covers rows they need, and Esc there closes the modal
+// rather than the card.
+func TestTheCardMakesRoomForSurfacesTheReaderWorksIn(t *testing.T) {
+	for _, surface := range []mode{modeHistory, modeAlert} {
+		model := alertModel(t)
+		model.width = 120
+		model.height = 24
+		model.mode = surface
+		model.raise(errors.New(sshFailure))
+
+		width, height := model.bodyDimensions()
+		if got := model.modalRegion(width, height); got >= height {
+			t.Fatalf("mode %v gave the card no room: region %d of %d",
+				surface, got, height)
+		}
+		modalTop, modalBottom := frameSpan(model.renderModeBody(width, height), 1)
+		cardTop, _ := frameSpan(model.renderBody(), 0)
+		if modalTop < 0 || cardTop < 0 {
+			t.Fatalf("mode %v: expected a modal and a card (%d..%d, %d)",
+				surface, modalTop, modalBottom, cardTop)
+		}
+		if cardTop <= modalBottom {
+			t.Fatalf("mode %v: the card lands on it: modal %d..%d, card from %d",
+				surface, modalTop, modalBottom, cardTop)
+		}
+	}
+}
+
+// The composer closing itself is still the composer closing, and its
+// objection goes with it.
+func TestAnAutoClosedComposerTakesItsComplaintWithIt(t *testing.T) {
+	model := alertModel(t)
+	model.ptyEnabled = false
+	model.agents = []agent.Agent{{ID: "a1", Name: "one", ProcessLive: true}}
+	model.rebuildGroups("", "a1")
+	model.activePane = paneInteraction
+	model.mode = modeCompose
+	model.complain(errors.New("message cannot be empty"))
+
+	// The agent puts up a prompt, which closes the composer from under it.
+	updated, _ := model.Update(dashboardMsg{agents: []agent.Agent{{
+		ID: "a1", Name: "one", ProcessLive: true,
+		Attention: agent.AttentionApproval,
+	}}})
+	model = updated.(Model)
+	if model.mode == modeCompose {
+		t.Skip("this model did not auto-close the composer")
+	}
+	if model.alert.active() {
+		t.Fatalf("the composer's objection outlived the composer: %v", model.alert.err)
 	}
 }

--- a/internal/ui/alert_test.go
+++ b/internal/ui/alert_test.go
@@ -9,6 +9,8 @@ import (
 
 	tea "charm.land/bubbletea/v2"
 	"github.com/charmbracelet/x/ansi"
+	"github.com/trentkm/stormlight/internal/agent"
+	"github.com/trentkm/stormlight/internal/workspace"
 )
 
 const sshFailure = "set up thaidex: ssh: connect to host thaidex port 22: " +
@@ -1058,5 +1060,150 @@ func TestFooterNamesScrollOnlyWhenTheMessageScrolls(t *testing.T) {
 		footer, "j/k scroll",
 	) {
 		t.Fatalf("a message that scrolls did not say so: %q", footer)
+	}
+}
+
+// A path that worked disproves the form's objection to the last one — and
+// that form closes on a message, not a keystroke, so the sweep never sees
+// it.
+func TestASuccessfulAddRetractsItsComplaint(t *testing.T) {
+	model := alertModel(t)
+	updated, _ := model.beginAddWorkspace()
+	model = updated.(Model)
+	updated, _ = model.submitAddWorkspace("/definitely/not/here")
+	model = updated.(Model)
+	if model.alert.raisedIn != modeAddWorkspace {
+		t.Fatalf("the form's objection was tagged %v: %v",
+			model.alert.raisedIn, model.alert.err)
+	}
+
+	updated, _ = model.Update(workspaceAddedMsg{
+		value: workspace.Context{ID: "w1", Root: "/tmp", Name: "tmp"},
+	})
+	if next := updated.(Model); next.alert.active() {
+		t.Fatalf("the add succeeded and its complaint stayed: %v", next.alert.err)
+	}
+}
+
+// A message that sends disproves "message cannot be empty", and the
+// composer outlives the send.
+func TestASuccessfulSendRetractsItsComplaint(t *testing.T) {
+	model := alertModel(t)
+	model.ptyEnabled = false
+	model.agents = []agent.Agent{{ID: "a1", Name: "one", ProcessLive: true}}
+	model.rebuildGroups("", "a1")
+	model.activePane = paneInteraction
+	model.mode = modeCompose
+	model.sendInput.Focus()
+
+	updated, _ := model.Update(tea.KeyPressMsg{Code: tea.KeyEnter})
+	model = updated.(Model)
+	if model.alert.message() != "message cannot be empty" {
+		t.Skipf("this model cannot reach the empty-message guard: %v", model.alert.err)
+	}
+
+	model.sendInput.SetValue("a real message")
+	updated, _ = model.Update(tea.KeyPressMsg{Code: tea.KeyEnter})
+	if next := updated.(Model); next.alert.active() {
+		t.Fatalf("the send left its own objection standing: %v", next.alert.err)
+	}
+}
+
+// The path navigator serves the add-workspace picker too, so it must clear
+// whichever form is using it.
+func TestThePathNavigatorClearsTheFormUsingIt(t *testing.T) {
+	model := alertModel(t)
+	updated, _ := model.beginAddWorkspace()
+	model = updated.(Model)
+	model.complain(errors.New("no such directory: /definitely/not/here"))
+	if model.alert.raisedIn != modeAddWorkspace {
+		t.Fatalf("complaint tagged %v", model.alert.raisedIn)
+	}
+
+	model.clearComplaint(model.mode)
+	if model.alert.active() {
+		t.Fatalf("the picker's own complaint survived its success: %v", model.alert.err)
+	}
+}
+
+// A card shrinks the form exactly like a smaller terminal does, so the
+// same guard has to run: typing must not land in a field that is no longer
+// drawn.
+func TestACardNeverLeavesFocusOnAnUndrawnField(t *testing.T) {
+	for height := 20; height <= 26; height++ {
+		model := alertModel(t)
+		model.width = 120
+		model.height = height
+		updated, _ := model.beginDispatch(false)
+		model = updated.(Model)
+		if !model.dispatchNameVisible() {
+			continue
+		}
+		model.formFocus = dispatchName
+		model.focusForm()
+
+		updated, _ = model.Update(dashboardMsg{err: errors.New(sshFailure)})
+		model = updated.(Model)
+		if !model.dispatchNameVisible() && model.formFocus == dispatchName {
+			t.Fatalf("at height %d focus stayed on a name row the form no longer draws",
+				height)
+		}
+	}
+}
+
+// Read-only overlays are sized to their own content and close on any key;
+// taking rows out of them truncates their last lines.
+func TestReadingOverlaysKeepTheirLastLines(t *testing.T) {
+	model := alertModel(t)
+	model.width = 120
+	model.height = 44
+	width, height := model.bodyDimensions()
+	bare := model.renderHelpModal(width, height)
+
+	model.raise(errors.New(sshFailure))
+	model.mode = modeHelp
+	if got := model.renderModeBody(width, height); !strings.Contains(
+		ansi.Strip(got), strings.TrimSpace(ansi.Strip(lastLine(bare))),
+	) {
+		t.Fatalf("the help lost its last line to the card:\n%s", ansi.Strip(got))
+	}
+	if card := model.renderAlertCard(width, height); card != "" {
+		t.Fatalf("the card drew over a reading overlay:\n%s", card)
+	}
+}
+
+func lastLine(block string) string {
+	lines := strings.Split(strings.TrimRight(block, "\n"), "\n")
+	for index := len(lines) - 1; index >= 0; index-- {
+		if strings.TrimSpace(ansi.Strip(lines[index])) != "" {
+			return lines[index]
+		}
+	}
+	return ""
+}
+
+// Recovery is news everywhere, including for a card held back inside the
+// portal.
+func TestRecoveryLiftsTheHoldBackToo(t *testing.T) {
+	model := alertModel(t)
+	model.ptyEnabled = true
+	model.activePane = paneInteraction
+	down := func() dashboardMsg {
+		return dashboardMsg{err: errors.New("daemon is not listening")}
+	}
+	updated, _ := model.Update(down())
+	model = updated.(Model)
+	moment := time.Now()
+	model.ageAlert(moment)
+	model.ageAlert(moment.Add(alertLinger + time.Second))
+	if model.heldBack == "" {
+		t.Fatalf("the timeout did not hold the failure back")
+	}
+
+	updated, _ = model.Update(dashboardMsg{})
+	model = updated.(Model)
+	updated, _ = model.Update(down())
+	if next := updated.(Model); !next.alert.active() {
+		t.Fatalf("a failure that returned after a recovery stayed held back")
 	}
 }

--- a/internal/ui/alert_test.go
+++ b/internal/ui/alert_test.go
@@ -739,8 +739,8 @@ func TestCardStaysOffTheComposer(t *testing.T) {
 	model.sendInput.SetValue("a reply in progress")
 	model.raise(errors.New(sshFailure))
 
-	width, height := model.bodyDimensions()
-	lift := model.inputStripRows(width)
+	_, height := model.bodyDimensions()
+	lift := model.inputStripRows()
 	if lift < 3 {
 		t.Fatalf("the composer strip measured %d rows", lift)
 	}
@@ -828,11 +828,11 @@ func TestComposerStripIsMeasuredWhereTheComposerIsDrawn(t *testing.T) {
 	// A draft that fits on one line at the pane's width and wraps at the
 	// composer's.
 	model.sendInput.SetValue(strings.Repeat("x", composerWidth))
-	if got, want := model.inputStripRows(width),
+	if got, want := model.inputStripRows(),
 		composerHeight(model.sendInput.Value(), composerWidth)+2; got != want {
 		t.Fatalf("strip measured %d rows, composer draws %d", got, want)
 	}
-	if model.inputStripRows(width) ==
+	if model.inputStripRows() ==
 		composerHeight(model.sendInput.Value(), paneWidth)+2 {
 		t.Fatalf("the strip was measured at the pane width, not the composer's")
 	}
@@ -927,5 +927,136 @@ func TestANonComparableErrorDoesNotPanicOnTheNextKey(t *testing.T) {
 	updated, _ := model.Update(runeKey("j"))
 	if next := updated.(Model); !next.alert.active() {
 		t.Fatalf("the complaint vanished")
+	}
+}
+
+// Recovery hands the card's rows back to the modal, and whatever was
+// sized for the shorter one has to hear about it.
+func TestRecoveryRefitsTheDispatchComposer(t *testing.T) {
+	model := alertModel(t)
+	updated, _ := model.Update(dashboardMsg{err: errors.New("daemon is not listening")})
+	model = updated.(Model)
+	updated, _ = model.beginDispatch(false)
+	model = updated.(Model)
+
+	updated, _ = model.Update(dashboardMsg{})
+	model = updated.(Model)
+	if model.alert.active() {
+		t.Fatalf("the card outlived the recovery")
+	}
+
+	bodyWidth, bodyHeight := model.bodyDimensions()
+	region := model.modalRegion(bodyWidth, bodyHeight)
+	modalWidth, modalHeight := model.dispatchModalDimensions(bodyWidth, region)
+	drawn := model.dispatchLayout(max(1, modalWidth-2), max(1, modalHeight-2))
+	if got := model.taskInput.Height(); got != drawn.taskHeight {
+		t.Fatalf("composer left at %d rows while the form draws it at %d",
+			got, drawn.taskHeight)
+	}
+}
+
+// Opening a form is not reading the failure that happened to be on screen.
+func TestOpeningAFormKeepsAFailureItDidNotRaise(t *testing.T) {
+	for _, open := range []struct {
+		name string
+		key  string
+	}{{"dispatch", "n"}, {"history", "H"}, {"mark", "m"}, {"rename", "R"}} {
+		model := alertModel(t)
+		model.activePane = paneAgents
+		model.raise(errors.New("set up thaidex: ssh: could not resolve hostname"))
+
+		updated, _ := model.Update(runeKey(open.key))
+		if next := updated.(Model); !next.alert.active() {
+			t.Fatalf("%s wiped an unread failure it did not raise", open.name)
+		}
+	}
+}
+
+// A form still drops its own stale objection when it reopens.
+func TestReopeningAFormDropsItsOwnStaleComplaint(t *testing.T) {
+	model := alertModel(t)
+	updated, _ := model.beginDispatch(false)
+	model = updated.(Model)
+	model.formFocus = dispatchTask
+	model.taskInput.SetValue("")
+
+	updated, _ = model.submitDispatch()
+	model = updated.(Model)
+	if model.alert.raisedIn != modeDispatch {
+		t.Fatalf("the form's objection was tagged %v: %v",
+			model.alert.raisedIn, model.alert.err)
+	}
+	model.mode = modeNormal
+
+	updated, _ = model.beginDispatch(false)
+	if next := updated.(Model); next.alert.active() {
+		t.Fatalf("the form reopened still wearing its last objection: %v",
+			next.alert.err)
+	}
+}
+
+// Inside the portal a card cannot be answered, so one that timed out must
+// not return every twelve seconds for as long as the daemon is down — and
+// must return the moment the reader is back where they can act on it.
+func TestATimedOutCardWaitsForTheReaderToComeBack(t *testing.T) {
+	model := alertModel(t)
+	model.ptyEnabled = true
+	model.activePane = paneInteraction
+	down := func() dashboardMsg {
+		return dashboardMsg{err: errors.New("daemon is not listening")}
+	}
+	updated, _ := model.Update(down())
+	model = updated.(Model)
+
+	moment := time.Now()
+	model.ageAlert(moment)
+	model.ageAlert(moment.Add(alertLinger + time.Second))
+	if model.alert.active() {
+		t.Fatalf("the card should have timed out")
+	}
+
+	updated, _ = model.Update(down())
+	model = updated.(Model)
+	if model.alert.active() {
+		t.Fatalf("the card came back over the terminal on the next tick")
+	}
+
+	model.activePane = paneAgents
+	updated, _ = model.Update(down())
+	if next := updated.(Model); !next.alert.active() {
+		t.Fatalf("the failure never returned once the reader could answer it")
+	}
+}
+
+// A card must not cost the body a column it drew.
+func TestCardDoesNotCropTheBody(t *testing.T) {
+	model := alertModel(t)
+	width, height := model.bodyDimensions()
+	bare := blockWidth(model.renderModeBody(width, height))
+
+	model.raise(errors.New(sshFailure))
+	if got := blockWidth(model.renderBody()); got != bare {
+		t.Fatalf("body is %d columns wide with a card, %d without", got, bare)
+	}
+}
+
+// The footer names the scroll keys only when there is something to scroll.
+func TestFooterNamesScrollOnlyWhenTheMessageScrolls(t *testing.T) {
+	short := alertModel(t)
+	short.raise(errors.New("boom"))
+	updated, _ := short.Update(runeKey("e"))
+	if footer := ansi.Strip(updated.(Model).renderFooter()); strings.Contains(
+		footer, "j/k scroll",
+	) {
+		t.Fatalf("a one-line message advertised scrolling: %q", footer)
+	}
+
+	long := alertModel(t)
+	long.raise(errors.New(strings.Repeat("a line of failure output. ", 60)))
+	updated, _ = long.Update(runeKey("e"))
+	if footer := ansi.Strip(updated.(Model).renderFooter()); !strings.Contains(
+		footer, "j/k scroll",
+	) {
+		t.Fatalf("a message that scrolls did not say so: %q", footer)
 	}
 }

--- a/internal/ui/alert_test.go
+++ b/internal/ui/alert_test.go
@@ -244,3 +244,207 @@ func TestAlertCardFitsASmallTerminal(t *testing.T) {
 		t.Fatalf("a card clipped by a small screen must offer the rest:\n%s", view)
 	}
 }
+
+// Opening something is not leaving anything: a card raised on the dashboard
+// is still there when the reader comes back from the help.
+func TestAlertSurvivesATripThroughTheHelp(t *testing.T) {
+	model := alertModel(t)
+	model.raise(errors.New("interrupt failed"))
+
+	updated, _ := model.Update(runeKey("?"))
+	model = updated.(Model)
+	if model.mode != modeHelp {
+		t.Fatalf("? did not open the help: mode = %v", model.mode)
+	}
+	if !model.alert.active() {
+		t.Fatalf("opening the help dismissed the card")
+	}
+
+	updated, _ = model.Update(tea.KeyPressMsg{Code: tea.KeyEscape})
+	model = updated.(Model)
+	if model.mode != modeNormal {
+		t.Fatalf("the help did not close: mode = %v", model.mode)
+	}
+	if !model.alert.active() {
+		t.Fatalf("closing the help dismissed a card the help never raised")
+	}
+}
+
+// The refresh is the one failure that reports its own recovery: it runs on
+// a timer, so a card insisting the daemon is down after it came back is a
+// lie the reader never asked for.
+func TestRecoveredPollClearsItsOwnCard(t *testing.T) {
+	model := alertModel(t)
+
+	updated, _ := model.Update(dashboardMsg{err: errors.New("daemon is not listening")})
+	model = updated.(Model)
+	if !model.alert.active() {
+		t.Fatalf("a failed refresh raised no card")
+	}
+
+	updated, _ = model.Update(dashboardMsg{})
+	if next := updated.(Model); next.alert.active() {
+		t.Fatalf("the daemon came back and the card stayed: %v", next.alert.err)
+	}
+}
+
+// Succeeding at something else is not an answer to an unread failure.
+func TestSuccessElsewhereLeavesTheCardStanding(t *testing.T) {
+	model := alertModel(t)
+	model.raise(errors.New("interrupt failed"))
+
+	updated, _ := model.Update(actionMsg{})
+	if next := updated.(Model); !next.alert.active() {
+		t.Fatalf("an unrelated success wiped the card")
+	}
+
+	// Nor does a refresh that was never the thing complaining.
+	updated, _ = updated.(Model).Update(dashboardMsg{})
+	if next := updated.(Model); !next.alert.active() {
+		t.Fatalf("a successful refresh answered a failure it did not raise")
+	}
+}
+
+// Where no key is the dashboard's — inside the portal, under a form — the
+// card names none, and says so by ending in an ellipsis rather than
+// mid-word.
+func TestClippedCardAdmitsThereIsMoreAndClaimsNoKeys(t *testing.T) {
+	model := alertModel(t)
+	model.mode = modeDispatch
+	model.raise(errors.New(strings.Repeat("stderr says something long. ", 30)))
+
+	card := ansi.Strip(model.renderAlertCard(model.bodyDimensions()))
+	if !strings.Contains(card, "…") {
+		t.Fatalf("a clipped card gave no sign it was clipped:\n%s", card)
+	}
+	for _, claim := range []string{"Esc dismiss", "e detail", "e read it all"} {
+		if strings.Contains(card, claim) {
+			t.Fatalf("the card claimed %q, which belongs to the form:\n%s", claim, card)
+		}
+	}
+}
+
+// `e` reaches the last failure even after its card is gone. Inside the
+// portal no key is ours, so the card ages out unread — recall is the only
+// thing that makes those messages readable at all.
+func TestDetailRecallsTheLastFailureAfterItsCardIsGone(t *testing.T) {
+	model := alertModel(t)
+	model.ptyEnabled = true
+	model.activePane = paneInteraction
+	model.raise(errors.New(sshFailure))
+
+	moment := time.Now()
+	model.ageAlert(moment)
+	model.ageAlert(moment.Add(alertLinger + time.Second))
+	if model.alert.active() {
+		t.Fatalf("the card should have aged out inside the portal")
+	}
+
+	model.activePane = paneAgents
+	updated, _ := model.Update(runeKey("e"))
+	model = updated.(Model)
+	if model.mode != modeAlert {
+		t.Fatalf("e did not recall the last failure: mode = %v", model.mode)
+	}
+	view := ansi.Strip(model.renderAlertModal(model.bodyDimensions()))
+	if !strings.Contains(unwrapped(view), unwrapped(sshFailure)) {
+		t.Fatalf("the recalled message is not the failure:\n%s", view)
+	}
+}
+
+// The card is anchored to the foot of the body and a modal centers in what
+// is left, so the card never lands on the form it is complaining about.
+func TestModalKeepsItsRowsWhenACardStands(t *testing.T) {
+	// Sizes matter here: a roomy terminal separates the two by luck, and
+	// it is the ordinary ones — where the form fills most of the body —
+	// that the card used to land on.
+	for _, size := range [][2]int{{80, 24}, {90, 30}, {100, 34}, {120, 40}} {
+		model := alertModel(t)
+		model.width, model.height = size[0], size[1]
+		model.mode = modeDispatch
+		model.raise(errors.New(sshFailure))
+
+		width, height := model.bodyDimensions()
+		modalTop, modalBottom := frameSpan(model.renderModeBody(width, height), 1)
+		cardTop, cardBottom := frameSpan(model.renderBody(), 0)
+		if modalTop < 0 || cardTop < 0 {
+			t.Fatalf("%dx%d: expected a form and a card (form %d..%d, card %d..%d)",
+				size[0], size[1], modalTop, modalBottom, cardTop, cardBottom)
+		}
+		if cardTop <= modalBottom {
+			t.Fatalf("%dx%d: the card lands on the form: form rows %d..%d, card rows %d..%d",
+				size[0], size[1], modalTop, modalBottom, cardTop, cardBottom)
+		}
+	}
+}
+
+// frameSpan finds the rows of a rounded frame drawn at more than `indent`
+// columns in (a centered modal) or at exactly one (the card, against the
+// left edge).
+func frameSpan(block string, minIndent int) (int, int) {
+	top, bottom := -1, -1
+	for index, line := range strings.Split(ansi.Strip(block), "\n") {
+		trimmed := strings.TrimLeft(line, " ")
+		indent := len(line) - len(trimmed)
+		if minIndent == 0 && indent != 1 || minIndent > 0 && indent <= minIndent {
+			continue
+		}
+		switch {
+		case strings.HasPrefix(trimmed, "╭") && top < 0:
+			top = index
+		case strings.HasPrefix(trimmed, "╰"):
+			bottom = index
+		}
+	}
+	return top, bottom
+}
+
+// A modal sized short of its own text makes the reader scroll for nothing.
+func TestDetailFitsItsMessageWhenTheBodyHasRoom(t *testing.T) {
+	model := alertModel(t)
+	model.width = 61
+	model.height = 40
+	model.raise(errors.New(strings.Repeat("a line of failure output. ", 12)))
+
+	updated, _ := model.Update(runeKey("e"))
+	model = updated.(Model)
+
+	textWidth, window := model.alertDetailWindow()
+	if lines := wrapMessage(model.alertDetail.text, textWidth); len(lines) > window {
+		t.Fatalf("modal holds %d of %d lines with %d rows of body free",
+			window, len(lines), model.height)
+	}
+}
+
+// A card is two borders, a line, and its keys. Rendering one into fewer
+// rows than that is how it loses its bottom edge.
+func TestCardKeepsItsFrameOnAShortTerminal(t *testing.T) {
+	model := alertModel(t)
+	model.raise(errors.New("boom"))
+
+	card := ansi.Strip(model.renderAlertCard(60, 4))
+	if !strings.Contains(card, "╰") {
+		t.Fatalf("the card lost its bottom edge:\n%s", card)
+	}
+	if lines := strings.Count(card, "\n") + 1; lines > 4 {
+		t.Fatalf("the card rendered %d rows into 4", lines)
+	}
+	if shorter := model.renderAlertCard(60, 3); shorter != "" {
+		t.Fatalf("a card drew into three rows:\n%s", shorter)
+	}
+}
+
+func TestFooterNamesTheDetailViewsOwnKeys(t *testing.T) {
+	model := alertModel(t)
+	model.raise(errors.New("boom"))
+	updated, _ := model.Update(runeKey("e"))
+	model = updated.(Model)
+
+	footer := ansi.Strip(model.renderFooter())
+	if !strings.Contains(footer, "y copy") || !strings.Contains(footer, "Esc close") {
+		t.Fatalf("footer does not name the detail view's keys: %q", footer)
+	}
+	if strings.Contains(footer, "n new") || strings.Contains(footer, "q quit") {
+		t.Fatalf("footer advertises keys the detail view does not answer: %q", footer)
+	}
+}

--- a/internal/ui/chrome.go
+++ b/internal/ui/chrome.go
@@ -247,6 +247,8 @@ func (m Model) commandHints() []string {
 		return []string{"Enter apply", "Esc cancel"}
 	case modeMark:
 		return []string{"w in progress", "a needs attention", "c clear", "Esc cancel"}
+	case modeAlert:
+		return []string{"j/k scroll", "y copy", "Esc close"}
 	}
 	rowMode := "z expand rows"
 	if m.rowsExpanded {

--- a/internal/ui/chrome.go
+++ b/internal/ui/chrome.go
@@ -248,7 +248,12 @@ func (m Model) commandHints() []string {
 	case modeMark:
 		return []string{"w in progress", "a needs attention", "c clear", "Esc cancel"}
 	case modeAlert:
-		return []string{"j/k scroll", "y copy", "Esc close"}
+		// Only when there is something to scroll, exactly as the view's
+		// own key line decides it.
+		if m.alertDetailScrolls() {
+			return []string{"j/k scroll", "y copy", "Esc close"}
+		}
+		return []string{"y copy", "Esc close"}
 	}
 	rowMode := "z expand rows"
 	if m.rowsExpanded {

--- a/internal/ui/chrome.go
+++ b/internal/ui/chrome.go
@@ -33,16 +33,12 @@ func (m Model) renderFooter() string {
 			// the footer matches whichever side of the seam is lit.
 			hintStyle = lipgloss.NewStyle().Foreground(colorBand())
 		}
-		hints := renderHints(m.commandHints(), hintStyle)
-		content = ansi.Truncate(hints, inner, "…")
-		if m.err != nil {
-			content = renderFooterError(inner, m.err.Error(), hints)
-		} else {
-			// The portal is the right pane, so its controls sit under it:
-			// the footer's alignment follows the seam the same way its
-			// color does.
-			rightAligned = m.terminalFocused()
-		}
+		content = ansi.Truncate(
+			renderHints(m.commandHints(), hintStyle), inner, "…")
+		// The portal is the right pane, so its controls sit under it:
+		// the footer's alignment follows the seam the same way its
+		// color does.
+		rightAligned = m.terminalFocused()
 	}
 	glintStyle := lipgloss.NewStyle().
 		Foreground(theme.Color(theme.Pair{
@@ -167,22 +163,6 @@ func renderHints(items []string, style lipgloss.Style) string {
 		rendered[index] = style.Render(item)
 	}
 	return strings.Join(rendered, separator)
-}
-
-// renderFooterError lets an error talk over the left end of the hint row.
-// Errors are the one message that still shares the row — everything else
-// the footer used to announce either shows where it happens or rides in
-// the hints — and the hints keep their own ink beside it rather than
-// fading to gray.
-func renderFooterError(width int, message, hints string) string {
-	available := max(1, width)
-	messageWidth := clamp(available/3, 8, 28)
-	hintWidth := available - messageWidth - 2
-	if hintWidth < 12 {
-		return errorStyle().Render(truncate(message, available))
-	}
-	return errorStyle().Render(truncate(message, messageWidth)) +
-		"  " + ansi.Truncate(hints, hintWidth, "…")
 }
 
 // searchMatchLabel is the live position among search matches; it rides in

--- a/internal/ui/clipboard_test.go
+++ b/internal/ui/clipboard_test.go
@@ -83,8 +83,8 @@ func TestComposeCtrlVInsertsPastedImagePath(t *testing.T) {
 	if !strings.HasSuffix(value, " ") {
 		t.Fatalf("no trailing space after pasted path: %q", value)
 	}
-	if model.err != nil {
-		t.Fatalf("unexpected error: %v", model.err)
+	if model.alert.err != nil {
+		t.Fatalf("unexpected error: %v", model.alert.err)
 	}
 	os.Remove(path)
 }
@@ -101,8 +101,8 @@ func TestComposeCtrlVReportsMissingImage(t *testing.T) {
 	updated, _ = model.Update(tea.KeyPressMsg{Code: 'v', Mod: tea.ModCtrl})
 	model = updated.(Model)
 
-	if model.err == nil || model.err.Error() != "clipboard has no image" {
-		t.Fatalf("got err %v, want clipboard has no image", model.err)
+	if model.alert.err == nil || model.alert.message() != "clipboard has no image" {
+		t.Fatalf("got err %v, want clipboard has no image", model.alert.err)
 	}
 	if got := model.sendInput.Value(); got != "before" {
 		t.Fatalf("composer changed on failed paste: %q", got)

--- a/internal/ui/compose.go
+++ b/internal/ui/compose.go
@@ -63,7 +63,9 @@ func (m Model) updateCompose(msg tea.KeyPressMsg) (tea.Model, tea.Cmd) {
 			return m, nil
 		}
 		// The composer stays open for the next message; one i enters the
-		// conversation, Esc leaves it.
+		// conversation, Esc leaves it. Which is why the send has to
+		// retract the objection it disproves — the box outlives it.
+		m.clearComplaint(modeCompose)
 		m.sendInput.SetValue("")
 		m.syncComposerSize()
 		return m, actionCmd("Message sent", func(ctx context.Context) error {

--- a/internal/ui/compose.go
+++ b/internal/ui/compose.go
@@ -36,10 +36,10 @@ func (m Model) updateCompose(msg tea.KeyPressMsg) (tea.Model, tea.Cmd) {
 		// (Text paste still arrives through the terminal's own paste.)
 		path, err := pasteClipboardImage()
 		if err != nil {
-			m.raise(err)
+			m.complain(err)
 			return m, nil
 		}
-		m.dismissAlert()
+		m.clearAlert()
 		m.insertComposerToken(path)
 		m.syncComposerSize()
 		return m, nil
@@ -53,13 +53,13 @@ func (m Model) updateCompose(msg tea.KeyPressMsg) (tea.Model, tea.Cmd) {
 			// The agent is showing a prompt or picker; a pasted message
 			// would type into it and Enter would pick whatever is
 			// highlighted. Answer where the prompt lives.
-			m.raise(fmt.Errorf(
+			m.complain(fmt.Errorf(
 				"agent is showing a prompt — Esc, then Enter opens its terminal"))
 			return m, nil
 		}
 		text := strings.TrimSpace(m.sendInput.Value())
 		if text == "" {
-			m.raise(fmt.Errorf("message cannot be empty"))
+			m.complain(fmt.Errorf("message cannot be empty"))
 			return m, nil
 		}
 		// The composer stays open for the next message; one i enters the

--- a/internal/ui/compose.go
+++ b/internal/ui/compose.go
@@ -39,7 +39,7 @@ func (m Model) updateCompose(msg tea.KeyPressMsg) (tea.Model, tea.Cmd) {
 			m.complain(err)
 			return m, nil
 		}
-		m.clearAlert()
+		m.clearComplaint(modeCompose)
 		m.insertComposerToken(path)
 		m.syncComposerSize()
 		return m, nil

--- a/internal/ui/compose.go
+++ b/internal/ui/compose.go
@@ -36,10 +36,10 @@ func (m Model) updateCompose(msg tea.KeyPressMsg) (tea.Model, tea.Cmd) {
 		// (Text paste still arrives through the terminal's own paste.)
 		path, err := pasteClipboardImage()
 		if err != nil {
-			m.err = err
+			m.raise(err)
 			return m, nil
 		}
-		m.err = nil
+		m.dismissAlert()
 		m.insertComposerToken(path)
 		m.syncComposerSize()
 		return m, nil
@@ -53,13 +53,13 @@ func (m Model) updateCompose(msg tea.KeyPressMsg) (tea.Model, tea.Cmd) {
 			// The agent is showing a prompt or picker; a pasted message
 			// would type into it and Enter would pick whatever is
 			// highlighted. Answer where the prompt lives.
-			m.err = fmt.Errorf(
-				"agent is showing a prompt — Esc, then Enter opens its terminal")
+			m.raise(fmt.Errorf(
+				"agent is showing a prompt — Esc, then Enter opens its terminal"))
 			return m, nil
 		}
 		text := strings.TrimSpace(m.sendInput.Value())
 		if text == "" {
-			m.err = fmt.Errorf("message cannot be empty")
+			m.raise(fmt.Errorf("message cannot be empty"))
 			return m, nil
 		}
 		// The composer stays open for the next message; one i enters the

--- a/internal/ui/dispatch.go
+++ b/internal/ui/dispatch.go
@@ -492,6 +492,16 @@ func (m Model) dispatchNameVisible() bool {
 	return m.dispatchLayout(m.dispatchContentDimensions()).density.showsName()
 }
 
+// dispatchNameVisibleIn answers the same question for a region the modal is
+// not being drawn in yet — what the form would look like if it were given
+// this much room.
+func (m Model) dispatchNameVisibleIn(region int) bool {
+	width, _ := m.bodyDimensions()
+	modalWidth, modalHeight := m.dispatchModalDimensions(width, region)
+	return m.dispatchLayout(
+		max(1, modalWidth-2), max(1, modalHeight-2)).density.showsName()
+}
+
 // dispatchContentDimensions is the modal's interior for the terminal as it
 // stands, matching what renderBody hands renderDispatchModal.
 func (m Model) dispatchContentDimensions() (int, int) {

--- a/internal/ui/dispatch.go
+++ b/internal/ui/dispatch.go
@@ -1039,20 +1039,20 @@ func (m *Model) handlePathNavKey(msg tea.KeyPressMsg) bool {
 	case "enter":
 		if attempted, ok := m.pathNav.jump(); attempted {
 			if !ok {
-				m.raise(fmt.Errorf(
+				m.complain(fmt.Errorf(
 					"no such directory: %s",
 					strings.TrimSpace(m.pathNav.filter.Value()),
 				))
 			} else {
-				m.dismissAlert()
+				m.clearAlert()
 			}
 			return false
 		}
 		if m.pathNav.chosen() == "" {
-			m.raise(fmt.Errorf("no matching directory"))
+			m.complain(fmt.Errorf("no matching directory"))
 			return false
 		}
-		m.dismissAlert()
+		m.clearAlert()
 		return true
 	}
 	m.pathNav.update(msg)
@@ -1496,7 +1496,7 @@ func (m *Model) moveDispatchFocus(delta int) {
 
 func (m Model) submitDispatch() (tea.Model, tea.Cmd) {
 	if len(m.providers) == 0 {
-		m.raise(fmt.Errorf("no providers configured"))
+		m.complain(fmt.Errorf("no providers configured"))
 		return m, nil
 	}
 	request := app.DispatchRequest{
@@ -1508,7 +1508,7 @@ func (m Model) submitDispatch() (tea.Model, tea.Cmd) {
 		Host:     m.dispatchHost,
 	}
 	if request.Task == "" {
-		m.raise(fmt.Errorf("task cannot be empty"))
+		m.complain(fmt.Errorf("task cannot be empty"))
 		return m, nil
 	}
 	// Only this machine's directories can be checked here. On another
@@ -1516,7 +1516,7 @@ func (m Model) submitDispatch() (tea.Model, tea.Cmd) {
 	// path that happens to exist here too would pass for the wrong
 	// reason. That host resolves it, and says so if it cannot.
 	if request.Host == "" && !isDirectory(request.Cwd) {
-		m.raise(fmt.Errorf("working directory is unavailable: %s", request.Cwd))
+		m.complain(fmt.Errorf("working directory is unavailable: %s", request.Cwd))
 		return m, nil
 	}
 	m.mode = modeNormal
@@ -1569,7 +1569,7 @@ func (m Model) beginDispatch(chooseDirectory bool) (tea.Model, tea.Cmd) {
 	m.dispatchPrefix = ""
 	m.focusForm()
 	m.syncTaskComposerSize()
-	m.dismissAlert()
+	m.clearAlert()
 	return m, nil
 }
 

--- a/internal/ui/dispatch.go
+++ b/internal/ui/dispatch.go
@@ -495,7 +495,13 @@ func (m Model) dispatchNameVisible() bool {
 // dispatchContentDimensions is the modal's interior for the terminal as it
 // stands, matching what renderBody hands renderDispatchModal.
 func (m Model) dispatchContentDimensions() (int, int) {
-	modalWidth, modalHeight := m.dispatchModalDimensions(m.bodyDimensions())
+	// The region the modal is drawn in, not the whole body: the task
+	// composer is persistent state sized from this, and a textarea sized
+	// for a taller box than the one it is drawn into scrolls itself and
+	// stays scrolled. See resetTextareaScroll.
+	width, height := m.bodyDimensions()
+	modalWidth, modalHeight := m.dispatchModalDimensions(
+		width, m.modalRegion(width, height))
 	return max(1, modalWidth-2), max(1, modalHeight-2)
 }
 

--- a/internal/ui/dispatch.go
+++ b/internal/ui/dispatch.go
@@ -1050,7 +1050,10 @@ func (m *Model) handlePathNavKey(msg tea.KeyPressMsg) bool {
 					strings.TrimSpace(m.pathNav.filter.Value()),
 				))
 			} else {
-				m.clearComplaint(modeDispatch)
+				// m.mode, not the dispatch form: this navigator is the
+				// add-workspace picker too, and a hardcoded surface makes
+				// the clear a no-op there.
+				m.clearComplaint(m.mode)
 			}
 			return false
 		}
@@ -1058,7 +1061,7 @@ func (m *Model) handlePathNavKey(msg tea.KeyPressMsg) bool {
 			m.complain(fmt.Errorf("no matching directory"))
 			return false
 		}
-		m.clearComplaint(modeDispatch)
+		m.clearComplaint(m.mode)
 		return true
 	}
 	m.pathNav.update(msg)

--- a/internal/ui/dispatch.go
+++ b/internal/ui/dispatch.go
@@ -1050,7 +1050,7 @@ func (m *Model) handlePathNavKey(msg tea.KeyPressMsg) bool {
 					strings.TrimSpace(m.pathNav.filter.Value()),
 				))
 			} else {
-				m.clearAlert()
+				m.clearComplaint(modeDispatch)
 			}
 			return false
 		}
@@ -1058,7 +1058,7 @@ func (m *Model) handlePathNavKey(msg tea.KeyPressMsg) bool {
 			m.complain(fmt.Errorf("no matching directory"))
 			return false
 		}
-		m.clearAlert()
+		m.clearComplaint(modeDispatch)
 		return true
 	}
 	m.pathNav.update(msg)
@@ -1575,7 +1575,7 @@ func (m Model) beginDispatch(chooseDirectory bool) (tea.Model, tea.Cmd) {
 	m.dispatchPrefix = ""
 	m.focusForm()
 	m.syncTaskComposerSize()
-	m.clearAlert()
+	m.clearComplaint(modeDispatch)
 	return m, nil
 }
 

--- a/internal/ui/dispatch.go
+++ b/internal/ui/dispatch.go
@@ -1039,20 +1039,20 @@ func (m *Model) handlePathNavKey(msg tea.KeyPressMsg) bool {
 	case "enter":
 		if attempted, ok := m.pathNav.jump(); attempted {
 			if !ok {
-				m.err = fmt.Errorf(
+				m.raise(fmt.Errorf(
 					"no such directory: %s",
 					strings.TrimSpace(m.pathNav.filter.Value()),
-				)
+				))
 			} else {
-				m.err = nil
+				m.dismissAlert()
 			}
 			return false
 		}
 		if m.pathNav.chosen() == "" {
-			m.err = fmt.Errorf("no matching directory")
+			m.raise(fmt.Errorf("no matching directory"))
 			return false
 		}
-		m.err = nil
+		m.dismissAlert()
 		return true
 	}
 	m.pathNav.update(msg)
@@ -1496,7 +1496,7 @@ func (m *Model) moveDispatchFocus(delta int) {
 
 func (m Model) submitDispatch() (tea.Model, tea.Cmd) {
 	if len(m.providers) == 0 {
-		m.err = fmt.Errorf("no providers configured")
+		m.raise(fmt.Errorf("no providers configured"))
 		return m, nil
 	}
 	request := app.DispatchRequest{
@@ -1508,7 +1508,7 @@ func (m Model) submitDispatch() (tea.Model, tea.Cmd) {
 		Host:     m.dispatchHost,
 	}
 	if request.Task == "" {
-		m.err = fmt.Errorf("task cannot be empty")
+		m.raise(fmt.Errorf("task cannot be empty"))
 		return m, nil
 	}
 	// Only this machine's directories can be checked here. On another
@@ -1516,7 +1516,7 @@ func (m Model) submitDispatch() (tea.Model, tea.Cmd) {
 	// path that happens to exist here too would pass for the wrong
 	// reason. That host resolves it, and says so if it cannot.
 	if request.Host == "" && !isDirectory(request.Cwd) {
-		m.err = fmt.Errorf("working directory is unavailable: %s", request.Cwd)
+		m.raise(fmt.Errorf("working directory is unavailable: %s", request.Cwd))
 		return m, nil
 	}
 	m.mode = modeNormal
@@ -1569,7 +1569,7 @@ func (m Model) beginDispatch(chooseDirectory bool) (tea.Model, tea.Cmd) {
 	m.dispatchPrefix = ""
 	m.focusForm()
 	m.syncTaskComposerSize()
-	m.err = nil
+	m.dismissAlert()
 	return m, nil
 }
 

--- a/internal/ui/flows_test.go
+++ b/internal/ui/flows_test.go
@@ -232,8 +232,8 @@ func TestComposerRefusesToSendIntoAnActivePrompt(t *testing.T) {
 	if cmd != nil {
 		t.Fatal("send fired into an active prompt")
 	}
-	if model.err == nil || !strings.Contains(model.err.Error(), "terminal") {
-		t.Fatalf("guard err = %v", model.err)
+	if model.alert.err == nil || !strings.Contains(model.alert.message(), "terminal") {
+		t.Fatalf("guard err = %v", model.alert.err)
 	}
 	if model.sendInput.Value() != "oranges" {
 		t.Fatal("guard discarded the typed message")

--- a/internal/ui/input_test.go
+++ b/internal/ui/input_test.go
@@ -795,14 +795,16 @@ func TestAddWorkspaceOnlyOffersNewDirectoryActions(t *testing.T) {
 	assertViewFitsPane(t, model, 100, 28)
 }
 
-func TestFooterKeepsCommandsVisibleWithError(t *testing.T) {
+func TestFooterLeavesFailuresToTheCard(t *testing.T) {
 	model := NewModel(stubBackend{})
 	model.width = 100
-	model.err = errors.New("attach failed")
+	model.raise(errors.New("attach failed"))
 
 	footer := ansi.Strip(model.renderFooter())
-	if !strings.Contains(footer, "attach failed") ||
-		!strings.Contains(footer, "j/k select") ||
+	if strings.Contains(footer, "attach failed") {
+		t.Fatalf("the hint row is still carrying the error: %q", footer)
+	}
+	if !strings.Contains(footer, "j/k select") ||
 		!strings.Contains(footer, "n add") {
 		t.Fatalf("error displaced contextual commands: %q", footer)
 	}
@@ -2410,20 +2412,28 @@ func TestDirectoryPickerIncludesDiscoveredExecutionRoots(t *testing.T) {
 	}
 }
 
-func TestActionErrorSurvivesSuccessfulRefresh(t *testing.T) {
+func TestActionErrorSurvivesRefreshAndKeystrokes(t *testing.T) {
 	model := NewModel(stubBackend{})
-	model.err = errors.New("attach failed")
+	model.raise(errors.New("attach failed"))
 
 	updated, _ := model.Update(dashboardMsg{})
 	model = updated.(Model)
-	if model.err == nil || model.err.Error() != "attach failed" {
-		t.Fatalf("refresh cleared action error: %#v", model.err)
+	if model.alert.err == nil || model.alert.message() != "attach failed" {
+		t.Fatalf("refresh cleared action error: %#v", model.alert.err)
 	}
 
+	// Moving the cursor is not an answer to a failure: the card stays
+	// until it is read, dismissed, or replaced.
 	updated, _ = model.Update(runeKey("j"))
 	model = updated.(Model)
-	if model.err != nil {
-		t.Fatalf("key did not clear action error: err=%v", model.err)
+	if model.alert.err == nil {
+		t.Fatalf("a keystroke swept the failure away")
+	}
+
+	updated, _ = model.Update(tea.KeyPressMsg{Code: tea.KeyEscape})
+	model = updated.(Model)
+	if model.alert.err != nil {
+		t.Fatalf("Esc did not dismiss the failure: %v", model.alert.err)
 	}
 }
 

--- a/internal/ui/layout.go
+++ b/internal/ui/layout.go
@@ -81,9 +81,16 @@ func (m Model) renderBody() string {
 		)
 	}
 	// The failure card sits above even that: whatever is on screen, a
-	// thing that just went wrong is the most important thing on it.
+	// thing that just went wrong is the most important thing on it. With
+	// no card there is nothing to composite, and the body goes out as the
+	// mode drew it — compositing anyway would crop every frame to
+	// bodyDimensions and cost the pane titles their last column.
+	card := m.renderAlertCard(width, contentHeight)
+	if card == "" {
+		return body
+	}
 	return overlayBottomLeft(
-		body, m.renderAlertCard(width, contentHeight), width, contentHeight, 1,
+		body, card, width, contentHeight, 1, m.inputStripRows(width),
 	)
 }
 
@@ -456,12 +463,12 @@ func overlayCenteredIn(
 // cursor is working in.
 func overlayBottomLeft(
 	background, foreground string,
-	width, height, indent int,
+	width, height, indent, lift int,
 ) string {
 	return overlayComposite(background, foreground, width, height,
 		func(foregroundWidth, foregroundHeight int) (int, int) {
 			return clamp(indent, 0, max(0, width-foregroundWidth)),
-				max(0, height-foregroundHeight)
+				max(0, height-foregroundHeight-max(0, lift))
 		})
 }
 

--- a/internal/ui/layout.go
+++ b/internal/ui/layout.go
@@ -93,7 +93,7 @@ func (m Model) renderModeBody(width, contentHeight int) string {
 	// card is anchored to the foot of the body and the two would otherwise
 	// want the same rows — and the card would win, covering the form's
 	// last lines while the only key it named cancelled that form.
-	region := max(1, contentHeight-m.alertRows(width, contentHeight))
+	region := m.modalRegion(width, contentHeight)
 	var modal string
 	switch m.mode {
 	case modeDispatch:

--- a/internal/ui/layout.go
+++ b/internal/ui/layout.go
@@ -73,14 +73,18 @@ func (m Model) renderBody() string {
 		// The floating program draws over everything, the mode's own
 		// modal included — Yazi opened from the dispatch form floats
 		// above the form it will answer.
-		return overlayCentered(
+		body = overlayCentered(
 			body,
 			m.renderOverlayPopup(),
 			width,
 			contentHeight,
 		)
 	}
-	return body
+	// The failure card sits above even that: whatever is on screen, a
+	// thing that just went wrong is the most important thing on it.
+	return overlayBottomLeft(
+		body, m.renderAlertCard(width, contentHeight), width, contentHeight, 1,
+	)
 }
 
 func (m Model) renderModeBody(width, contentHeight int) string {
@@ -132,6 +136,13 @@ func (m Model) renderModeBody(width, contentHeight int) string {
 		return overlayCentered(
 			dashboard,
 			m.renderHistoryModal(width, contentHeight),
+			width,
+			contentHeight,
+		)
+	case modeAlert:
+		return overlayCentered(
+			dashboard,
+			m.renderAlertModal(width, contentHeight),
 			width,
 			contentHeight,
 		)
@@ -454,6 +465,36 @@ func renderModal(content string, width, height int) string {
 }
 
 func overlayCentered(background, foreground string, width, height int) string {
+	return overlayComposite(background, foreground, width, height,
+		func(foregroundWidth, foregroundHeight int) (int, int) {
+			return max(0, (width-foregroundWidth)/2),
+				max(0, (height-foregroundHeight)/2)
+		})
+}
+
+// overlayBottomLeft floats a block against the foot of the body, indented
+// from the left edge — where a message about what just happened belongs,
+// near the footer that answers for it, and out of the way of the rows the
+// cursor is working in.
+func overlayBottomLeft(
+	background, foreground string,
+	width, height, indent int,
+) string {
+	return overlayComposite(background, foreground, width, height,
+		func(foregroundWidth, foregroundHeight int) (int, int) {
+			return clamp(indent, 0, max(0, width-foregroundWidth)),
+				max(0, height-foregroundHeight)
+		})
+}
+
+// overlayComposite paints foreground over background at the position the
+// placer picks for its measured size. Nothing reflows: the background keeps
+// its dimensions and the block covers what it covers.
+func overlayComposite(
+	background, foreground string,
+	width, height int,
+	place func(foregroundWidth, foregroundHeight int) (int, int),
+) string {
 	if width <= 0 || height <= 0 {
 		return ""
 	}
@@ -471,8 +512,7 @@ func overlayCentered(background, foreground string, width, height int) string {
 		return strings.Join(backgroundLines, "\n")
 	}
 
-	left := max(0, (width-foregroundWidth)/2)
-	top := max(0, (height-len(foregroundLines))/2)
+	left, top := place(foregroundWidth, len(foregroundLines))
 	for index, foregroundLine := range foregroundLines {
 		row := top + index
 		if row >= len(backgroundLines) {

--- a/internal/ui/layout.go
+++ b/internal/ui/layout.go
@@ -89,8 +89,13 @@ func (m Model) renderBody() string {
 	if card == "" {
 		return body
 	}
+	// Composited at the body's own width rather than the nominal one:
+	// a row the mode drew wider than bodyDimensions — the pane titles
+	// run to the screen's edge — would otherwise lose its last column
+	// for as long as a card stands.
 	return overlayBottomLeft(
-		body, card, width, contentHeight, 1, m.inputStripRows(width),
+		body, card, max(width, blockWidth(body)), contentHeight, 1,
+		m.inputStripRows(),
 	)
 }
 
@@ -516,6 +521,15 @@ func overlayComposite(
 			fitLine(after, width-rightStart)
 	}
 	return strings.Join(backgroundLines, "\n")
+}
+
+// blockWidth is the widest row of a rendered block.
+func blockWidth(block string) int {
+	widest := 0
+	for _, line := range strings.Split(block, "\n") {
+		widest = max(widest, ansi.StringWidth(line))
+	}
+	return widest
 }
 
 func fitBlock(content string, width, height int) string {

--- a/internal/ui/layout.go
+++ b/internal/ui/layout.go
@@ -89,65 +89,33 @@ func (m Model) renderBody() string {
 
 func (m Model) renderModeBody(width, contentHeight int) string {
 	dashboard := m.renderDashboardBody(width, contentHeight)
+	// A modal centers in what the failure card leaves, not under it. The
+	// card is anchored to the foot of the body and the two would otherwise
+	// want the same rows — and the card would win, covering the form's
+	// last lines while the only key it named cancelled that form.
+	region := max(1, contentHeight-m.alertRows(width, contentHeight))
+	var modal string
 	switch m.mode {
 	case modeDispatch:
-		return overlayCentered(
-			dashboard,
-			m.renderDispatchModal(width, contentHeight),
-			width,
-			contentHeight,
-		)
+		modal = m.renderDispatchModal(width, region)
 	case modeAddWorkspace:
-		return overlayCentered(
-			dashboard,
-			m.renderAddWorkspaceModal(width, contentHeight),
-			width,
-			contentHeight,
-		)
+		modal = m.renderAddWorkspaceModal(width, region)
 	case modeRename:
-		return overlayCentered(
-			dashboard,
-			m.renderRenameModal(width, contentHeight),
-			width,
-			contentHeight,
-		)
+		modal = m.renderRenameModal(width, region)
 	case modeMark:
-		return overlayCentered(
-			dashboard,
-			m.renderMarkModal(width, contentHeight),
-			width,
-			contentHeight,
-		)
+		modal = m.renderMarkModal(width, region)
 	case modeInfo:
-		return overlayCentered(
-			dashboard,
-			m.renderInfoModal(width, contentHeight),
-			width,
-			contentHeight,
-		)
+		modal = m.renderInfoModal(width, region)
 	case modeHelp:
-		return overlayCentered(
-			dashboard,
-			m.renderHelpModal(width, contentHeight),
-			width,
-			contentHeight,
-		)
+		modal = m.renderHelpModal(width, region)
 	case modeHistory:
-		return overlayCentered(
-			dashboard,
-			m.renderHistoryModal(width, contentHeight),
-			width,
-			contentHeight,
-		)
+		modal = m.renderHistoryModal(width, region)
 	case modeAlert:
-		return overlayCentered(
-			dashboard,
-			m.renderAlertModal(width, contentHeight),
-			width,
-			contentHeight,
-		)
+		modal = m.renderAlertModal(width, region)
+	default:
+		return dashboard
 	}
-	return dashboard
+	return overlayCenteredIn(dashboard, modal, width, contentHeight, region)
 }
 
 func (m Model) renderDashboardBody(width, contentHeight int) string {
@@ -465,10 +433,20 @@ func renderModal(content string, width, height int) string {
 }
 
 func overlayCentered(background, foreground string, width, height int) string {
+	return overlayCenteredIn(background, foreground, width, height, height)
+}
+
+// overlayCenteredIn centers a block horizontally across the background and
+// vertically within its top region rows — the whole height, unless
+// something else has claimed the rows below it.
+func overlayCenteredIn(
+	background, foreground string,
+	width, height, region int,
+) string {
 	return overlayComposite(background, foreground, width, height,
 		func(foregroundWidth, foregroundHeight int) (int, int) {
 			return max(0, (width-foregroundWidth)/2),
-				max(0, (height-foregroundHeight)/2)
+				max(0, (min(region, height)-foregroundHeight)/2)
 		})
 }
 

--- a/internal/ui/machine_test.go
+++ b/internal/ui/machine_test.go
@@ -146,7 +146,7 @@ func TestAMissingLocalYaziDoesNotHideARemoteOne(t *testing.T) {
 		t.Fatalf("browsing another machine should still be offered: %#v", model.directories)
 	}
 	if _, cmd := model.openYazi(); cmd == nil {
-		t.Fatalf("opening the remote picker was refused: %v", model.err)
+		t.Fatalf("opening the remote picker was refused: %v", model.alert.err)
 	}
 }
 
@@ -160,7 +160,7 @@ func TestATypedRemotePathIsNotCheckedHere(t *testing.T) {
 
 	updated, cmd := model.submitAddWorkspace("/srv/api")
 	if cmd == nil {
-		t.Fatalf("a remote path was refused: %v", updated.(Model).err)
+		t.Fatalf("a remote path was refused: %v", updated.(Model).alert.err)
 	}
 	message, ok := cmd().(workspaceAddedMsg)
 	if !ok || message.err != nil {
@@ -176,7 +176,7 @@ func TestATypedRemotePathIsNotCheckedHere(t *testing.T) {
 	if cmd != nil {
 		t.Fatal("a relative remote path must be refused")
 	}
-	if next.(Model).err == nil {
+	if next.(Model).alert.err == nil {
 		t.Fatal("refusing it should say why")
 	}
 }
@@ -211,7 +211,7 @@ func TestTheNewAgentPickerBrowsesTheFormsMachine(t *testing.T) {
 	model.cwdInput.SetValue("/srv/api")
 
 	if _, cmd := model.openYazi(); cmd == nil {
-		t.Fatalf("browsing was refused: %v", model.err)
+		t.Fatalf("browsing was refused: %v", model.alert.err)
 	}
 	spec := yaziPickerSpec(model.dispatchHost, "", model.yaziPath)
 	if spec.host != "devbox" {
@@ -222,7 +222,7 @@ func TestTheNewAgentPickerBrowsesTheFormsMachine(t *testing.T) {
 	// is pointing.
 	model.dispatchHost = ""
 	if _, cmd := model.openYazi(); cmd == nil {
-		t.Fatalf("local browsing was refused: %v", model.err)
+		t.Fatalf("local browsing was refused: %v", model.alert.err)
 	}
 }
 
@@ -235,7 +235,7 @@ func TestNoLocalYaziStillBrowsesAnotherMachineFromTheAgentForm(t *testing.T) {
 	model.dispatchHost = "devbox"
 
 	if _, cmd := model.openYazi(); cmd == nil {
-		t.Fatalf("a remote browse should not need a local yazi: %v", model.err)
+		t.Fatalf("a remote browse should not need a local yazi: %v", model.alert.err)
 	}
 }
 

--- a/internal/ui/marks.go
+++ b/internal/ui/marks.go
@@ -64,7 +64,6 @@ func (m Model) beginMark() (tea.Model, tea.Cmd) {
 	m.markAgentID = selected.ID
 	m.markIndex = markChoiceIndex(selected.EffectiveMark())
 	m.mode = modeMark
-	m.clearComplaint(modeMark)
 	return m, nil
 }
 

--- a/internal/ui/marks.go
+++ b/internal/ui/marks.go
@@ -64,7 +64,7 @@ func (m Model) beginMark() (tea.Model, tea.Cmd) {
 	m.markAgentID = selected.ID
 	m.markIndex = markChoiceIndex(selected.EffectiveMark())
 	m.mode = modeMark
-	m.err = nil
+	m.dismissAlert()
 	return m, nil
 }
 

--- a/internal/ui/marks.go
+++ b/internal/ui/marks.go
@@ -64,7 +64,7 @@ func (m Model) beginMark() (tea.Model, tea.Cmd) {
 	m.markAgentID = selected.ID
 	m.markIndex = markChoiceIndex(selected.EffectiveMark())
 	m.mode = modeMark
-	m.clearAlert()
+	m.clearComplaint(modeMark)
 	return m, nil
 }
 

--- a/internal/ui/marks.go
+++ b/internal/ui/marks.go
@@ -64,7 +64,7 @@ func (m Model) beginMark() (tea.Model, tea.Cmd) {
 	m.markAgentID = selected.ID
 	m.markIndex = markChoiceIndex(selected.EffectiveMark())
 	m.mode = modeMark
-	m.dismissAlert()
+	m.clearAlert()
 	return m, nil
 }
 

--- a/internal/ui/modals.go
+++ b/internal/ui/modals.go
@@ -212,7 +212,7 @@ func (m Model) beginRename() (tea.Model, tea.Cmd) {
 	m.renameInput.SetValue(current)
 	m.renameInput.Focus()
 	m.mode = modeRename
-	m.clearAlert()
+	m.clearComplaint(modeRename)
 	return m, nil
 }
 

--- a/internal/ui/modals.go
+++ b/internal/ui/modals.go
@@ -212,7 +212,7 @@ func (m Model) beginRename() (tea.Model, tea.Cmd) {
 	m.renameInput.SetValue(current)
 	m.renameInput.Focus()
 	m.mode = modeRename
-	m.dismissAlert()
+	m.clearAlert()
 	return m, nil
 }
 
@@ -224,7 +224,7 @@ func (m Model) updateRename(msg tea.KeyPressMsg) (tea.Model, tea.Cmd) {
 	case "enter":
 		name := strings.TrimSpace(m.renameInput.Value())
 		if name == "" {
-			m.raise(fmt.Errorf("name cannot be empty"))
+			m.complain(fmt.Errorf("name cannot be empty"))
 			return m, nil
 		}
 		m.mode = modeNormal

--- a/internal/ui/modals.go
+++ b/internal/ui/modals.go
@@ -164,6 +164,7 @@ func (m Model) renderHelpModal(width, height int) string {
 			{"< / >", "narrow or widen the focused pane"},
 			{"z", "toggle compact and expanded rows"},
 			{"r / Ctrl-l", "refresh"},
+			{"e", "read a failure in full; y copies it"},
 			{"?", "this help"},
 			{"q", "quit the dashboard"},
 		}},
@@ -211,7 +212,7 @@ func (m Model) beginRename() (tea.Model, tea.Cmd) {
 	m.renameInput.SetValue(current)
 	m.renameInput.Focus()
 	m.mode = modeRename
-	m.err = nil
+	m.dismissAlert()
 	return m, nil
 }
 
@@ -223,7 +224,7 @@ func (m Model) updateRename(msg tea.KeyPressMsg) (tea.Model, tea.Cmd) {
 	case "enter":
 		name := strings.TrimSpace(m.renameInput.Value())
 		if name == "" {
-			m.err = fmt.Errorf("name cannot be empty")
+			m.raise(fmt.Errorf("name cannot be empty"))
 			return m, nil
 		}
 		m.mode = modeNormal

--- a/internal/ui/model.go
+++ b/internal/ui/model.go
@@ -80,6 +80,17 @@ func (m mode) isForm() bool {
 	return false
 }
 
+// isReading reports an overlay that is read rather than filled in. They
+// close on any key and are sized to their own content, so the failure card
+// holds off while one is up rather than taking rows out of it.
+func (m mode) isReading() bool {
+	switch m {
+	case modeHelp, modeInfo, modeHistory, modeAlert:
+		return true
+	}
+	return false
+}
+
 // sortMode orders workspaces and agents. Sorting is always an explicit
 // user choice (the yazi-style `,` chord) — rows never rearrange on their
 // own; the default is stable newest-first.
@@ -552,14 +563,7 @@ func (m Model) Update(message tea.Msg) (tea.Model, tea.Cmd) {
 			m.interaction.SetWidth(interactionWidth)
 			m.interaction.SetHeight(contentHeight)
 		}
-		// A shrink can drop the optional name row out of the form; typing
-		// must not keep landing in a field that is no longer drawn.
-		if m.mode == modeDispatch && m.formFocus == dispatchName &&
-			!m.dispatchNameVisible() {
-			m.formFocus = dispatchTask
-			m.focusForm()
-		}
-		m.syncTaskComposerSize()
+		m.refitForms()
 		if m.overlay != nil {
 			outerWidth, outerHeight := m.overlayDimensions()
 			_, resize := m.overlay.widget.SetSize(
@@ -784,6 +788,10 @@ func (m Model) Update(message tea.Msg) (tea.Model, tea.Cmd) {
 			diagnostic.Logger().Error("add workspace failed", "error", msg.err)
 			return m, nil
 		}
+		// The form's objection to a path is disproved by a path that
+		// worked. Its own close arrives here rather than on a keystroke,
+		// so the keypress sweep never sees it.
+		m.clearComplaint(modeAddWorkspace)
 		m.mode = modeNormal
 		m.blurForm()
 		m.catalogWorkspaces = appendWorkspace(m.catalogWorkspaces, msg.value)

--- a/internal/ui/model.go
+++ b/internal/ui/model.go
@@ -251,37 +251,40 @@ type Model struct {
 	height          int
 	ready           bool
 
-	mode                    mode
-	formFocus               dispatchFocus
-	providers               []provider.Info
-	providerIndex           int
-	cwdInput                lineInput
-	nameInput               lineInput
-	taskInput               textarea.Model
-	sendInput               textarea.Model
-	initialCwd              string
-	initialWorkspaceID      string
-	interactionContent      string
-	search                  transcriptSearch
-	selectionActive         bool
-	selectionDragging       bool
-	selectionAnchor         int
-	selectionHead           int
-	directories             []directoryChoice
-	directoryIndex          int
-	yaziPath                string
-	nvimPath                string
-	dispatchMode            agent.PermissionMode
-	modeForDir              func(string) (agent.PermissionMode, bool)
-	providerForDir          func(string) (agent.Provider, bool)
-	renameInput             lineInput
-	renameAgentID           string
-	renameWorkspace         workspace.Context
-	markAgentID             string
-	markIndex               int
-	historyRecords          []history.Record
-	historyCursor           int
-	historyLoading          bool
+	mode               mode
+	formFocus          dispatchFocus
+	providers          []provider.Info
+	providerIndex      int
+	cwdInput           lineInput
+	nameInput          lineInput
+	taskInput          textarea.Model
+	sendInput          textarea.Model
+	initialCwd         string
+	initialWorkspaceID string
+	interactionContent string
+	search             transcriptSearch
+	selectionActive    bool
+	selectionDragging  bool
+	selectionAnchor    int
+	selectionHead      int
+	directories        []directoryChoice
+	directoryIndex     int
+	yaziPath           string
+	nvimPath           string
+	dispatchMode       agent.PermissionMode
+	modeForDir         func(string) (agent.PermissionMode, bool)
+	providerForDir     func(string) (agent.Provider, bool)
+	renameInput        lineInput
+	renameAgentID      string
+	renameWorkspace    workspace.Context
+	markAgentID        string
+	markIndex          int
+	historyRecords     []history.Record
+	historyCursor      int
+	historyLoading     bool
+	// historyFailed is why the shelf is empty, when it is empty because
+	// nothing could be read rather than because nothing is there.
+	historyFailed           error
 	historyFilter           lineInput
 	historyFiltering        bool
 	pathNav                 pathNav
@@ -563,6 +566,7 @@ func (m Model) Update(message tea.Msg) (tea.Model, tea.Cmd) {
 			m.interaction.SetWidth(interactionWidth)
 			m.interaction.SetHeight(contentHeight)
 		}
+		m.syncTaskComposerSize()
 		m.refitForms()
 		if m.overlay != nil {
 			outerWidth, outerHeight := m.overlayDimensions()
@@ -659,6 +663,7 @@ func (m Model) Update(message tea.Msg) (tea.Model, tea.Cmd) {
 
 	case historyMsg:
 		m.historyLoading = false
+		m.historyFailed = msg.err
 		if msg.err != nil {
 			m.raise(msg.err)
 			return m, nil

--- a/internal/ui/model.go
+++ b/internal/ui/model.go
@@ -865,7 +865,7 @@ func (m Model) Update(message tea.Msg) (tea.Model, tea.Cmd) {
 		if model, ok := updated.(Model); ok &&
 			standing != "" && model.alert.message() == standing &&
 			mode == raisedIn && raisedIn.isForm() && model.mode != mode {
-			model.clearAlert()
+			model.retract()
 			return model, cmd
 		}
 		return updated, cmd
@@ -1208,12 +1208,10 @@ func (m Model) updateNormal(msg tea.KeyPressMsg) (tea.Model, tea.Cmd) {
 				return m, nil
 			}
 			m.mode = modeDelete
-			m.clearComplaint(modeDelete)
 			return m, nil
 		}
 		if _, ok := m.selectedAgent(); ok {
 			m.mode = modeDelete
-			m.clearComplaint(modeDelete)
 			return m, nil
 		}
 	case "r", "ctrl+l":

--- a/internal/ui/model.go
+++ b/internal/ui/model.go
@@ -592,9 +592,13 @@ func (m Model) Update(message tea.Msg) (tea.Model, tea.Cmd) {
 		agentID := m.selectedAgentID()
 		previous, _ := m.selectedAgent()
 		if msg.err != nil {
-			m.raise(msg.err)
+			m.raisePolled(msg.err)
 			diagnostic.Logger().Error("dashboard refresh failed", "error", msg.err)
 		} else {
+			// The poll that failed is the poll that reports its own
+			// recovery; a card still insisting the daemon is down after
+			// it came back is worse than no card.
+			m.resolvePolled()
 			m.agents = msg.agents
 			m.catalogWorkspaces = msg.workspaces
 			m.workspaceRoots = msg.roots
@@ -693,18 +697,22 @@ func (m Model) Update(message tea.Msg) (tea.Model, tea.Cmd) {
 				return attachReturnedMsg{name: msg.name, err: err}
 			})
 		}
-		m.dismissAlert()
 		return m, nil
 
 	case attachReturnedMsg:
-		m.raise(msg.err)
+		if msg.err != nil {
+			m.raise(msg.err)
+		}
 		// The attached client owned the window sizes while it looked;
 		// reassert the herd's 1:1 grid now that the dashboard is back.
 		return m, tea.Batch(m.refreshCmd(), resizeAllPTYCmd(m.ptyManager))
 
 	case actionMsg:
-		m.raise(msg.err)
+		// Only a failure speaks here. Succeeding at something else is not
+		// an answer to the card standing unread from the last failure —
+		// copying a selection used to wipe it.
 		if msg.err != nil {
+			m.raise(msg.err)
 			diagnostic.Logger().Error("dashboard action failed", "error", msg.err)
 		}
 		return m, m.refreshCmd()
@@ -797,13 +805,16 @@ func (m Model) Update(message tea.Msg) (tea.Model, tea.Cmd) {
 
 	case tea.KeyPressMsg:
 		// A failure card is not swept away by the next keystroke — it is
-		// read, dismissed, or replaced. What a keystroke does end is the
-		// mode the card was raised in: a form's complaint has nothing
-		// left to say once the form is gone.
-		standing, mode := m.alert.err, m.mode
+		// read, dismissed, or replaced. The one keystroke that does end it
+		// is the one that closes the form it was raised in: a complaint
+		// about a name or a path has nothing left to say once the field
+		// is gone. A card the dashboard itself raised belongs to no form,
+		// so it survives a trip through the help and back.
+		standing, raisedIn, mode := m.alert.err, m.alert.raisedIn, m.mode
 		updated, cmd := m.updateKey(msg)
 		if model, ok := updated.(Model); ok &&
-			model.mode != mode && model.alert.err == standing {
+			standing != nil && model.alert.err == standing &&
+			mode == raisedIn && mode != modeNormal && model.mode != mode {
 			model.dismissAlert()
 			return model, cmd
 		}
@@ -1168,7 +1179,9 @@ func (m Model) updateNormal(msg tea.KeyPressMsg) (tea.Model, tea.Cmd) {
 	case "H":
 		return m.beginHistory()
 	case "e":
-		if m.alert.active() {
+		// Not only while a card stands: the failures hardest to read are
+		// the ones whose card is already gone.
+		if m.readableFailure() {
 			return m.openAlertDetail()
 		}
 	case "?":

--- a/internal/ui/model.go
+++ b/internal/ui/model.go
@@ -80,12 +80,18 @@ func (m mode) isForm() bool {
 	return false
 }
 
-// isReading reports an overlay that is read rather than filled in. They
-// close on any key and are sized to their own content, so the failure card
-// holds off while one is up rather than taking rows out of it.
+// isReading reports an overlay that is read once and closes on any key.
+// Those are sized to their own content, so shrinking them to make room for
+// the card cuts their last lines off with nothing to scroll them back —
+// the card floats over them instead.
+//
+// Everything else makes room, including the surfaces that merely look
+// passive: Sessions is a list the reader moves through, filters and
+// resumes from, and the detail view scrolls. A card over either covers
+// rows they need, and Esc there belongs to the surface, not the card.
 func (m mode) isReading() bool {
 	switch m {
-	case modeHelp, modeInfo, modeHistory, modeAlert:
+	case modeHelp, modeInfo:
 		return true
 	}
 	return false
@@ -641,6 +647,11 @@ func (m Model) Update(message tea.Msg) (tea.Model, tea.Cmd) {
 					// receive text, so the composer yields to the attention
 					// band without waiting for an Esc. The draft stays in
 					// the box.
+					//
+					// The composer's own objection goes with it. This close
+					// arrives on a message rather than a keystroke, so the
+					// sweep in Update never sees it.
+					m.clearComplaint(modeCompose)
 					m.mode = modeNormal
 					m.sendInput.Blur()
 				}

--- a/internal/ui/model.go
+++ b/internal/ui/model.go
@@ -287,8 +287,11 @@ type Model struct {
 	lastFailure alertDetail
 	alertDetail alertDetail
 	// hushedPoll is a self-repeating failure the reader has dismissed,
-	// silenced until the poll recovers.
+	// silenced until the poll recovers. heldBack is one that timed out
+	// where no key could answer it — inside the portal — kept back only
+	// until the reader is somewhere they can.
 	hushedPoll     string
+	heldBack       string
 	shimmerPhase   int
 	shimmerRunning bool
 
@@ -772,7 +775,7 @@ func (m Model) Update(message tea.Msg) (tea.Model, tea.Cmd) {
 		m.formFocus = dispatchTask
 		m.focusForm()
 		m.syncTaskComposerSize()
-		m.clearAlert()
+		m.clearComplaint(modeDispatch)
 		return m, nil
 
 	case workspaceAddedMsg:
@@ -1164,7 +1167,7 @@ func (m Model) updateNormal(msg tea.KeyPressMsg) (tea.Model, tea.Cmd) {
 			// again picks it back up rather than discarding it.
 			m.syncComposerSize()
 			m.sendInput.Focus()
-			m.clearAlert()
+			m.clearComplaint(modeCompose)
 			return m, nil
 		}
 	case "x":
@@ -1181,12 +1184,12 @@ func (m Model) updateNormal(msg tea.KeyPressMsg) (tea.Model, tea.Cmd) {
 				return m, nil
 			}
 			m.mode = modeDelete
-			m.clearAlert()
+			m.clearComplaint(modeDelete)
 			return m, nil
 		}
 		if _, ok := m.selectedAgent(); ok {
 			m.mode = modeDelete
-			m.clearAlert()
+			m.clearComplaint(modeDelete)
 			return m, nil
 		}
 	case "r", "ctrl+l":

--- a/internal/ui/model.go
+++ b/internal/ui/model.go
@@ -772,7 +772,7 @@ func (m Model) Update(message tea.Msg) (tea.Model, tea.Cmd) {
 		m.formFocus = dispatchTask
 		m.focusForm()
 		m.syncTaskComposerSize()
-		m.dismissAlert()
+		m.clearAlert()
 		return m, nil
 
 	case workspaceAddedMsg:
@@ -834,7 +834,7 @@ func (m Model) Update(message tea.Msg) (tea.Model, tea.Cmd) {
 		if model, ok := updated.(Model); ok &&
 			standing != nil && model.alert.err == standing &&
 			mode == raisedIn && raisedIn.isForm() && model.mode != mode {
-			model.dismissAlert()
+			model.clearAlert()
 			return model, cmd
 		}
 		return updated, cmd
@@ -1116,17 +1116,22 @@ func (m Model) updateNormal(msg tea.KeyPressMsg) (tea.Model, tea.Cmd) {
 			return m, nil
 		}
 	case "esc", "ctrl+[":
-		if m.alert.active() {
-			// The card waited to be read; Esc is the reader saying so.
-			m.dismissAlert()
-			return m, nil
-		}
+		// The card is last in line. Esc means what it always meant —
+		// drop the selection, clear the search — and only once there is
+		// nothing else to undo does it answer the card. A failure that
+		// stands for as long as the daemon is down must not quietly
+		// redefine the key for that whole time.
 		if m.selectionActive {
 			m.selectionActive = false
 			return m, nil
 		}
 		if m.activePane == paneInteraction && m.search.query != "" {
 			m.clearSearch()
+			return m, nil
+		}
+		if m.alert.active() {
+			// The card waited to be read; Esc is the reader saying so.
+			m.dismissAlert()
 			return m, nil
 		}
 	case "o":
@@ -1155,7 +1160,7 @@ func (m Model) updateNormal(msg tea.KeyPressMsg) (tea.Model, tea.Cmd) {
 			// again picks it back up rather than discarding it.
 			m.syncComposerSize()
 			m.sendInput.Focus()
-			m.dismissAlert()
+			m.clearAlert()
 			return m, nil
 		}
 	case "x":
@@ -1172,15 +1177,19 @@ func (m Model) updateNormal(msg tea.KeyPressMsg) (tea.Model, tea.Cmd) {
 				return m, nil
 			}
 			m.mode = modeDelete
-			m.dismissAlert()
+			m.clearAlert()
 			return m, nil
 		}
 		if _, ok := m.selectedAgent(); ok {
 			m.mode = modeDelete
-			m.dismissAlert()
+			m.clearAlert()
 			return m, nil
 		}
 	case "r", "ctrl+l":
+		// Asking again is asking to be told. A hushed failure that is
+		// still failing has to answer an explicit refresh, or the retry
+		// looks exactly like success.
+		m.hushedPoll = ""
 		return m, tea.Batch(m.refreshCmd(), m.loadInteractionCmd())
 	case "R":
 		return m.beginRename()

--- a/internal/ui/model.go
+++ b/internal/ui/model.go
@@ -64,6 +64,7 @@ const (
 	modeInfo
 	modeHelp
 	modeHistory
+	modeAlert
 )
 
 // sortMode orders workspaces and agents. Sorting is always an explicit
@@ -265,9 +266,12 @@ type Model struct {
 
 	interactionID       string
 	interactionLoadedAt time.Time
-	err                 error
-	shimmerPhase        int
-	shimmerRunning      bool
+	// The failure surface: the card standing over the body, and the
+	// snapshot the detail view reads from. See alert.go.
+	alert          alert
+	alertDetail    alertDetail
+	shimmerPhase   int
+	shimmerRunning bool
 
 	normalPrefix   string
 	sortMode       sortMode
@@ -550,6 +554,7 @@ func (m Model) Update(message tea.Msg) (tea.Model, tea.Cmd) {
 		return m, tea.Batch(m.loadInteractionCmd(), m.ensurePTYCmd())
 
 	case tickMsg:
+		m.ageAlert(time.Time(msg))
 		return m, tea.Batch(m.refreshCmd(), tickCmd())
 
 	case machineCheckedMsg:
@@ -587,7 +592,7 @@ func (m Model) Update(message tea.Msg) (tea.Model, tea.Cmd) {
 		agentID := m.selectedAgentID()
 		previous, _ := m.selectedAgent()
 		if msg.err != nil {
-			m.err = msg.err
+			m.raise(msg.err)
 			diagnostic.Logger().Error("dashboard refresh failed", "error", msg.err)
 		} else {
 			m.agents = msg.agents
@@ -625,7 +630,7 @@ func (m Model) Update(message tea.Msg) (tea.Model, tea.Cmd) {
 	case historyMsg:
 		m.historyLoading = false
 		if msg.err != nil {
-			m.err = msg.err
+			m.raise(msg.err)
 			return m, nil
 		}
 		m.historyRecords = msg.records
@@ -670,7 +675,7 @@ func (m Model) Update(message tea.Msg) (tea.Model, tea.Cmd) {
 
 	case attachMsg:
 		if msg.err != nil {
-			m.err = msg.err
+			m.raise(msg.err)
 			diagnostic.Logger().Error("dashboard open failed",
 				"agent", msg.name,
 				"error", msg.err,
@@ -688,17 +693,17 @@ func (m Model) Update(message tea.Msg) (tea.Model, tea.Cmd) {
 				return attachReturnedMsg{name: msg.name, err: err}
 			})
 		}
-		m.err = nil
+		m.dismissAlert()
 		return m, nil
 
 	case attachReturnedMsg:
-		m.err = msg.err
+		m.raise(msg.err)
 		// The attached client owned the window sizes while it looked;
 		// reassert the herd's 1:1 grid now that the dashboard is back.
 		return m, tea.Batch(m.refreshCmd(), resizeAllPTYCmd(m.ptyManager))
 
 	case actionMsg:
-		m.err = msg.err
+		m.raise(msg.err)
 		if msg.err != nil {
 			diagnostic.Logger().Error("dashboard action failed", "error", msg.err)
 		}
@@ -706,7 +711,7 @@ func (m Model) Update(message tea.Msg) (tea.Model, tea.Cmd) {
 
 	case directoryPickedMsg:
 		if msg.err != nil {
-			m.err = msg.err
+			m.raise(msg.err)
 			diagnostic.Logger().Error("directory picker failed", "error", msg.err)
 			return m, nil
 		}
@@ -726,13 +731,13 @@ func (m Model) Update(message tea.Msg) (tea.Model, tea.Cmd) {
 
 	case machinePreparedMsg:
 		if msg.err != nil {
-			m.err = fmt.Errorf("set up %s: %w", msg.host, msg.err)
+			m.raise(fmt.Errorf("set up %s: %w", msg.host, msg.err))
 		}
 		return m, nil
 
 	case taskEditedMsg:
 		if msg.err != nil {
-			m.err = msg.err
+			m.raise(msg.err)
 			diagnostic.Logger().Error("task editor failed", "error", msg.err)
 			return m, nil
 		}
@@ -740,12 +745,12 @@ func (m Model) Update(message tea.Msg) (tea.Model, tea.Cmd) {
 		m.formFocus = dispatchTask
 		m.focusForm()
 		m.syncTaskComposerSize()
-		m.err = nil
+		m.dismissAlert()
 		return m, nil
 
 	case workspaceAddedMsg:
 		if msg.err != nil {
-			m.err = msg.err
+			m.raise(msg.err)
 			diagnostic.Logger().Error("add workspace failed", "error", msg.err)
 			return m, nil
 		}
@@ -791,61 +796,18 @@ func (m Model) Update(message tea.Msg) (tea.Model, tea.Cmd) {
 		return m.updatePaste(msg)
 
 	case tea.KeyPressMsg:
-		m.err = nil
-		if m.overlay != nil {
-			// The floating program owns the keyboard while it is up;
-			// ctrl+q cancels it.
-			return m.updateOverlayKey(msg)
+		// A failure card is not swept away by the next keystroke — it is
+		// read, dismissed, or replaced. What a keystroke does end is the
+		// mode the card was raised in: a form's complaint has nothing
+		// left to say once the form is gone.
+		standing, mode := m.alert.err, m.mode
+		updated, cmd := m.updateKey(msg)
+		if model, ok := updated.(Model); ok &&
+			model.mode != mode && model.alert.err == standing {
+			model.dismissAlert()
+			return model, cmd
 		}
-		if m.ptyEnabled && m.mode == modeNormal &&
-			m.activePane == paneInteraction {
-			// The Spanreed is not a preview: while it holds focus, the
-			// keyboard belongs to the agent's terminal, exactly like a
-			// focused terminal tab. ctrl+q is the one key that stays ours.
-			return m.updateTerminalKey(msg)
-		}
-		switch m.mode {
-		case modeDispatch:
-			return m.updateDispatch(msg)
-		case modeCompose:
-			return m.updateCompose(msg)
-		case modeSearch:
-			return m.updateSearch(msg)
-		case modeDelete:
-			return m.updateDelete(msg)
-		case modeAddWorkspace:
-			return m.updateAddWorkspace(msg)
-		case modeRename:
-			return m.updateRename(msg)
-		case modeMark:
-			return m.updateMark(msg)
-		case modeHistory:
-			return m.updateHistory(msg)
-		case modeInfo, modeHelp:
-			// Any key dismisses an informational overlay.
-			m.mode = modeNormal
-			return m, nil
-		default:
-			// Reading the result is the presence proof: if an unseen result
-			// is on screen right now (selected, transcript loaded) and the
-			// human engages with it, it has been seen.
-			seenID := ""
-			if selected, ok := m.selectedAgent(); ok &&
-				selected.ProcessLive &&
-				(selected.Attention == agent.AttentionWaiting ||
-					selected.EffectiveMark() == agent.MarkAttention) &&
-				m.interactionID == selected.ID &&
-				marksResultSeen(msg.String(), m.activePane) {
-				seenID = selected.ID
-			}
-			updated, cmd := m.updateNormal(msg)
-			model, isModel := updated.(Model)
-			if seenID == "" || !isModel {
-				return updated, cmd
-			}
-			model.markAttentionSeen(seenID)
-			return model, tea.Batch(cmd, clearAttentionCmd(model.backend, seenID))
-		}
+		return updated, cmd
 	}
 
 	if m.ptyEnabled && m.ready {
@@ -860,6 +822,67 @@ func (m Model) Update(message tea.Msg) (tea.Model, tea.Cmd) {
 		return m, cmd
 	}
 	return m, nil
+}
+
+// updateKey routes one keypress to whatever owns the keyboard: a floating
+// program, the portal, the mode's own handler, or the dashboard itself.
+func (m Model) updateKey(msg tea.KeyPressMsg) (tea.Model, tea.Cmd) {
+	if m.overlay != nil {
+		// The floating program owns the keyboard while it is up;
+		// ctrl+q cancels it.
+		return m.updateOverlayKey(msg)
+	}
+	if m.ptyEnabled && m.mode == modeNormal &&
+		m.activePane == paneInteraction {
+		// The Spanreed is not a preview: while it holds focus, the
+		// keyboard belongs to the agent's terminal, exactly like a
+		// focused terminal tab. ctrl+q is the one key that stays ours.
+		return m.updateTerminalKey(msg)
+	}
+	switch m.mode {
+	case modeDispatch:
+		return m.updateDispatch(msg)
+	case modeCompose:
+		return m.updateCompose(msg)
+	case modeSearch:
+		return m.updateSearch(msg)
+	case modeDelete:
+		return m.updateDelete(msg)
+	case modeAddWorkspace:
+		return m.updateAddWorkspace(msg)
+	case modeRename:
+		return m.updateRename(msg)
+	case modeMark:
+		return m.updateMark(msg)
+	case modeHistory:
+		return m.updateHistory(msg)
+	case modeAlert:
+		return m.updateAlertDetail(msg)
+	case modeInfo, modeHelp:
+		// Any key dismisses an informational overlay.
+		m.mode = modeNormal
+		return m, nil
+	default:
+		// Reading the result is the presence proof: if an unseen result
+		// is on screen right now (selected, transcript loaded) and the
+		// human engages with it, it has been seen.
+		seenID := ""
+		if selected, ok := m.selectedAgent(); ok &&
+			selected.ProcessLive &&
+			(selected.Attention == agent.AttentionWaiting ||
+				selected.EffectiveMark() == agent.MarkAttention) &&
+			m.interactionID == selected.ID &&
+			marksResultSeen(msg.String(), m.activePane) {
+			seenID = selected.ID
+		}
+		updated, cmd := m.updateNormal(msg)
+		model, isModel := updated.(Model)
+		if seenID == "" || !isModel {
+			return updated, cmd
+		}
+		model.markAttentionSeen(seenID)
+		return model, tea.Batch(cmd, clearAttentionCmd(model.backend, seenID))
+	}
 }
 
 // View draws the dashboard and, with it, declares the terminal state the
@@ -1063,6 +1086,11 @@ func (m Model) updateNormal(msg tea.KeyPressMsg) (tea.Model, tea.Cmd) {
 			return m, nil
 		}
 	case "esc", "ctrl+[":
+		if m.alert.active() {
+			// The card waited to be read; Esc is the reader saying so.
+			m.dismissAlert()
+			return m, nil
+		}
 		if m.selectionActive {
 			m.selectionActive = false
 			return m, nil
@@ -1086,8 +1114,8 @@ func (m Model) updateNormal(msg tea.KeyPressMsg) (tea.Model, tea.Cmd) {
 			if selected.ProcessLive && selected.Attention.TerminalOwned() {
 				// An active prompt owns the agent's input; composing here
 				// would type into it. The band already says where to go.
-				m.err = fmt.Errorf(
-					"agent is waiting on a prompt — Enter opens its terminal")
+				m.raise(fmt.Errorf(
+					"agent is waiting on a prompt — Enter opens its terminal"))
 				return m, nil
 			}
 			m.activePane = paneInteraction
@@ -1097,7 +1125,7 @@ func (m Model) updateNormal(msg tea.KeyPressMsg) (tea.Model, tea.Cmd) {
 			// again picks it back up rather than discarding it.
 			m.syncComposerSize()
 			m.sendInput.Focus()
-			m.err = nil
+			m.dismissAlert()
 			return m, nil
 		}
 	case "x":
@@ -1114,12 +1142,12 @@ func (m Model) updateNormal(msg tea.KeyPressMsg) (tea.Model, tea.Cmd) {
 				return m, nil
 			}
 			m.mode = modeDelete
-			m.err = nil
+			m.dismissAlert()
 			return m, nil
 		}
 		if _, ok := m.selectedAgent(); ok {
 			m.mode = modeDelete
-			m.err = nil
+			m.dismissAlert()
 			return m, nil
 		}
 	case "r", "ctrl+l":
@@ -1139,6 +1167,10 @@ func (m Model) updateNormal(msg tea.KeyPressMsg) (tea.Model, tea.Cmd) {
 		}
 	case "H":
 		return m.beginHistory()
+	case "e":
+		if m.alert.active() {
+			return m.openAlertDetail()
+		}
 	case "?":
 		m.mode = modeHelp
 		return m, nil

--- a/internal/ui/model.go
+++ b/internal/ui/model.go
@@ -829,10 +829,14 @@ func (m Model) Update(message tea.Msg) (tea.Model, tea.Cmd) {
 		// about a name or a path has nothing left to say once the field
 		// is gone. A card the dashboard itself raised belongs to no form,
 		// so it survives a trip through the help and back.
-		standing, raisedIn, mode := m.alert.err, m.alert.raisedIn, m.mode
+		// Compared by message rather than by error value: two interfaces
+		// holding the same non-comparable dynamic type panic on ==, and a
+		// dependency's value-typed error would take the dashboard down on
+		// the next keypress.
+		standing, raisedIn, mode := m.alert.message(), m.alert.raisedIn, m.mode
 		updated, cmd := m.updateKey(msg)
 		if model, ok := updated.(Model); ok &&
-			standing != nil && model.alert.err == standing &&
+			standing != "" && model.alert.message() == standing &&
 			mode == raisedIn && raisedIn.isForm() && model.mode != mode {
 			model.clearAlert()
 			return model, cmd

--- a/internal/ui/model.go
+++ b/internal/ui/model.go
@@ -67,6 +67,19 @@ const (
 	modeAlert
 )
 
+// isForm reports that a mode is one the human is filling in — a field, a
+// path, a task. Those own their complaints: the objection dies with the
+// form. The informational overlays are not forms; any key closes them, so
+// treating that key as an answer to a failure would be the keystroke-wipe
+// this whole surface exists to remove.
+func (m mode) isForm() bool {
+	switch m {
+	case modeDispatch, modeAddWorkspace, modeRename, modeCompose:
+		return true
+	}
+	return false
+}
+
 // sortMode orders workspaces and agents. Sorting is always an explicit
 // user choice (the yazi-style `,` chord) — rows never rearrange on their
 // own; the default is stable newest-first.
@@ -266,10 +279,16 @@ type Model struct {
 
 	interactionID       string
 	interactionLoadedAt time.Time
-	// The failure surface: the card standing over the body, and the
-	// snapshot the detail view reads from. See alert.go.
-	alert          alert
-	alertDetail    alertDetail
+	// The failure surface. See alert.go.
+	alert alert
+	// lastFailure is the most recent failure's full text, kept past its
+	// card so `e` can still reach it; alertDetail is the copy an open
+	// detail view is reading, which nothing may overwrite mid-read.
+	lastFailure alertDetail
+	alertDetail alertDetail
+	// hushedPoll is a self-repeating failure the reader has dismissed,
+	// silenced until the poll recovers.
+	hushedPoll     string
 	shimmerPhase   int
 	shimmerRunning bool
 
@@ -814,7 +833,7 @@ func (m Model) Update(message tea.Msg) (tea.Model, tea.Cmd) {
 		updated, cmd := m.updateKey(msg)
 		if model, ok := updated.(Model); ok &&
 			standing != nil && model.alert.err == standing &&
-			mode == raisedIn && mode != modeNormal && model.mode != mode {
+			mode == raisedIn && raisedIn.isForm() && model.mode != mode {
 			model.dismissAlert()
 			return model, cmd
 		}

--- a/internal/ui/overlays.go
+++ b/internal/ui/overlays.go
@@ -202,7 +202,7 @@ func (m Model) overlayCursor() *tea.Cursor {
 
 func (m Model) openTaskEditor() (tea.Model, tea.Cmd) {
 	if m.nvimPath == "" {
-		m.raise(fmt.Errorf("Neovim is not installed or not on PATH"))
+		m.complain(fmt.Errorf("Neovim is not installed or not on PATH"))
 		return m, nil
 	}
 	cwd := strings.TrimSpace(m.cwdInput.Value())
@@ -273,7 +273,7 @@ func (m Model) openYazi() (tea.Model, tea.Cmd) {
 	// A missing Yazi here says nothing about another machine, which has
 	// its own PATH and answers for itself.
 	if m.yaziPath == "" && m.addWorkspaceHostName() == "" && m.dispatchHost == "" {
-		m.raise(fmt.Errorf("yazi is not installed or not on PATH"))
+		m.complain(fmt.Errorf("yazi is not installed or not on PATH"))
 		return m, nil
 	}
 	// The picker browses the machine the form is already aimed at.

--- a/internal/ui/overlays.go
+++ b/internal/ui/overlays.go
@@ -96,7 +96,7 @@ func (m *Model) openOverlay(spec overlaySpec) tea.Cmd {
 func (m Model) handleOverlayOpened(msg overlayOpenedMsg) (tea.Model, tea.Cmd) {
 	if msg.err != nil {
 		msg.spec.cleanup()
-		m.err = msg.err
+		m.raise(msg.err)
 		return m, nil
 	}
 	if msg.generation != m.overlayGeneration || m.overlay != nil {
@@ -202,7 +202,7 @@ func (m Model) overlayCursor() *tea.Cursor {
 
 func (m Model) openTaskEditor() (tea.Model, tea.Cmd) {
 	if m.nvimPath == "" {
-		m.err = fmt.Errorf("Neovim is not installed or not on PATH")
+		m.raise(fmt.Errorf("Neovim is not installed or not on PATH"))
 		return m, nil
 	}
 	cwd := strings.TrimSpace(m.cwdInput.Value())
@@ -211,7 +211,7 @@ func (m Model) openTaskEditor() (tea.Model, tea.Cmd) {
 	}
 	spec, err := taskEditorSpec(m.nvimPath, cwd, m.taskInput.Value())
 	if err != nil {
-		m.err = err
+		m.raise(err)
 		return m, nil
 	}
 	return m, m.openOverlay(spec)
@@ -273,7 +273,7 @@ func (m Model) openYazi() (tea.Model, tea.Cmd) {
 	// A missing Yazi here says nothing about another machine, which has
 	// its own PATH and answers for itself.
 	if m.yaziPath == "" && m.addWorkspaceHostName() == "" && m.dispatchHost == "" {
-		m.err = fmt.Errorf("yazi is not installed or not on PATH")
+		m.raise(fmt.Errorf("yazi is not installed or not on PATH"))
 		return m, nil
 	}
 	// The picker browses the machine the form is already aimed at.

--- a/internal/ui/ptymode.go
+++ b/internal/ui/ptymode.go
@@ -347,10 +347,21 @@ func (m Model) ptyCursor() *tea.Cursor {
 	if !visible {
 		return nil
 	}
+	return m.gridCursorAt(x, y)
+}
+
+// gridCursorAt places a cursor sitting at the terminal grid's (x, y), or
+// answers that it has nowhere to go.
+func (m Model) gridCursorAt(x, y int) *tea.Cursor {
 	width := max(1, m.width-1)
 	if width < 72 {
 		// The narrow single-pane layout draws no Spanreed grid to anchor
 		// a cursor to.
+		return nil
+	}
+	if m.alertCoversRow(ptyGridTop + y) {
+		// The card is composited over the cell the cursor names, and the
+		// cursor is hardware: it would blink inside the error box.
 		return nil
 	}
 	if m.ptyZoom {

--- a/internal/ui/remote_dispatch_test.go
+++ b/internal/ui/remote_dispatch_test.go
@@ -76,7 +76,7 @@ func TestDispatchCarriesTheChosenMachine(t *testing.T) {
 	model.taskInput.SetValue("fix the flaky test")
 
 	if _, cmd := model.submitDispatch(); cmd == nil {
-		t.Fatalf("dispatch was refused: %v", model.err)
+		t.Fatalf("dispatch was refused: %v", model.alert.err)
 	} else {
 		cmd()
 	}
@@ -100,7 +100,7 @@ func TestARemotePathIsNotCheckedAgainstThisFilesystem(t *testing.T) {
 
 	_, cmd := model.submitDispatch()
 	if cmd == nil {
-		t.Fatalf("a remote path must not be refused for being absent here: %v", model.err)
+		t.Fatalf("a remote path must not be refused for being absent here: %v", model.alert.err)
 	}
 	cmd()
 	if backend.request.Cwd != "/nowhere/near/this/machine" {
@@ -113,7 +113,7 @@ func TestARemotePathIsNotCheckedAgainstThisFilesystem(t *testing.T) {
 	if cmd != nil {
 		t.Fatal("a local path that does not exist should be refused")
 	}
-	if next.(Model).err == nil {
+	if next.(Model).alert.err == nil {
 		t.Fatal("refusing a missing local directory should say so")
 	}
 }

--- a/internal/ui/sessions.go
+++ b/internal/ui/sessions.go
@@ -23,7 +23,7 @@ import (
 
 func (m Model) beginHistory() (tea.Model, tea.Cmd) {
 	m.mode = modeHistory
-	m.err = nil
+	m.dismissAlert()
 	m.historyCursor = 0
 	m.historyRecords = nil
 	m.historyLoading = true

--- a/internal/ui/sessions.go
+++ b/internal/ui/sessions.go
@@ -23,7 +23,7 @@ import (
 
 func (m Model) beginHistory() (tea.Model, tea.Cmd) {
 	m.mode = modeHistory
-	m.clearAlert()
+	m.clearComplaint(modeHistory)
 	m.historyCursor = 0
 	m.historyRecords = nil
 	m.historyLoading = true

--- a/internal/ui/sessions.go
+++ b/internal/ui/sessions.go
@@ -23,7 +23,7 @@ import (
 
 func (m Model) beginHistory() (tea.Model, tea.Cmd) {
 	m.mode = modeHistory
-	m.dismissAlert()
+	m.clearAlert()
 	m.historyCursor = 0
 	m.historyRecords = nil
 	m.historyLoading = true

--- a/internal/ui/sessions.go
+++ b/internal/ui/sessions.go
@@ -23,7 +23,6 @@ import (
 
 func (m Model) beginHistory() (tea.Model, tea.Cmd) {
 	m.mode = modeHistory
-	m.clearComplaint(modeHistory)
 	m.historyCursor = 0
 	m.historyRecords = nil
 	m.historyLoading = true

--- a/internal/ui/sessions.go
+++ b/internal/ui/sessions.go
@@ -215,6 +215,16 @@ func (m Model) renderHistoryModal(width, height int) string {
 	switch {
 	case m.historyLoading:
 		lines = append(lines, "  "+mutedStyle().Render("Loading…"))
+	case m.historyFailed != nil:
+		// Not an empty shelf — an unreadable one. Saying "nothing here
+		// yet" would be the screen telling the reader something untrue.
+		lines = append(lines,
+			"  "+errorStyle().Render("Could not read past sessions."))
+		for _, line := range wrapMessage(
+			strings.TrimSpace(m.historyFailed.Error()), max(1, contentWidth-2),
+		) {
+			lines = append(lines, "  "+mutedStyle().Render(line))
+		}
 	case len(m.historyRecords) == 0:
 		lines = append(lines,
 			"  "+mutedStyle().Render("No past sessions recorded yet."),

--- a/internal/ui/workspaces.go
+++ b/internal/ui/workspaces.go
@@ -515,7 +515,7 @@ func (m Model) beginAddWorkspace() (tea.Model, tea.Cmd) {
 	m.formFocus = dispatchDirectory
 	m.dispatchPrefix = ""
 	m.focusForm()
-	m.err = nil
+	m.dismissAlert()
 	return m, nil
 }
 
@@ -525,11 +525,11 @@ func (m Model) submitAddWorkspace(path string) (tea.Model, tea.Cmd) {
 	// Only this machine's directories can be checked here; that host
 	// resolves its own, and says so if the path is not there.
 	if host == "" && !isDirectory(path) {
-		m.err = fmt.Errorf("workspace directory is unavailable: %s", path)
+		m.raise(fmt.Errorf("workspace directory is unavailable: %s", path))
 		return m, nil
 	}
 	if host != "" && !filepath.IsAbs(path) {
-		m.err = fmt.Errorf("a path on %s must be absolute: %s", host, path)
+		m.raise(fmt.Errorf("a path on %s must be absolute: %s", host, path))
 		return m, nil
 	}
 	m.blurForm()

--- a/internal/ui/workspaces.go
+++ b/internal/ui/workspaces.go
@@ -515,7 +515,7 @@ func (m Model) beginAddWorkspace() (tea.Model, tea.Cmd) {
 	m.formFocus = dispatchDirectory
 	m.dispatchPrefix = ""
 	m.focusForm()
-	m.dismissAlert()
+	m.clearAlert()
 	return m, nil
 }
 
@@ -525,11 +525,11 @@ func (m Model) submitAddWorkspace(path string) (tea.Model, tea.Cmd) {
 	// Only this machine's directories can be checked here; that host
 	// resolves its own, and says so if the path is not there.
 	if host == "" && !isDirectory(path) {
-		m.raise(fmt.Errorf("workspace directory is unavailable: %s", path))
+		m.complain(fmt.Errorf("workspace directory is unavailable: %s", path))
 		return m, nil
 	}
 	if host != "" && !filepath.IsAbs(path) {
-		m.raise(fmt.Errorf("a path on %s must be absolute: %s", host, path))
+		m.complain(fmt.Errorf("a path on %s must be absolute: %s", host, path))
 		return m, nil
 	}
 	m.blurForm()

--- a/internal/ui/workspaces.go
+++ b/internal/ui/workspaces.go
@@ -515,7 +515,7 @@ func (m Model) beginAddWorkspace() (tea.Model, tea.Cmd) {
 	m.formFocus = dispatchDirectory
 	m.dispatchPrefix = ""
 	m.focusForm()
-	m.clearAlert()
+	m.clearComplaint(modeAddWorkspace)
 	return m, nil
 }
 


### PR DESCRIPTION
## The problem

Error messages were unreadable by construction, in two independent ways:

- **Cut at 28 columns.** `renderFooterError` gave the message `clamp(width/3, 8, 28)`
  columns — twenty-eight at the widest, on any terminal — after `truncate` flattened
  its newlines to spaces. An ssh failure read `set up thaidex: ssh: connect t…`, with
  the hint row taking the rest of the line.
- **Wiped by the next keystroke.** `case tea.KeyPressMsg: m.err = nil` ran before
  anything else, so those twenty-eight characters were gone before they could be read.

The full text survived only in the diagnostic log, and only on the paths that log there.

## The change

A failure floats in a card over the foot of the body:

```
 ╭──────────────────────────────────────────────────────────────────────────╮
 │ ! this machine: read unix ->/tmp/stormlight/daemon.sock: i/o             │
 │   timeout                                                                │
 │                                                 e detail  ·  Esc dismiss │
 ╰──────────────────────────────────────────────────────────────────────────╯
 ───────────────────────────────────────────────────────────────────────────
 ✦ j/k select · l agents · n add · K info · , sort · ? help · q quit
```

- **Wrapped, not cut**, keeping the line breaks the error chose. Three lines before
  the rest is a keystroke away, and a clipped message ends in an ellipsis. A terminal
  too small for a frame still gets the message, unframed.
- **It waits.** A card ends in exactly five ways and only the first counts as read:
  dismissed (Esc or `e`), superseded, answered (the poll that raised it succeeded),
  swept (the form that raised it closed), or timed out (where no key of ours reaches
  it). Only a card that was *read* may silence a failure that repeats.
- **`e` opens the whole thing** — scrollable, `y` copies it — and reaches the last
  failure whether or not its card still stands, stamped with its age when recalled
  later. Inside the portal no key is the dashboard's, so that recall is the only way
  those messages are ever readable in full.
- **The hint row is hints again.** `renderFooterError` is gone.

## Design notes

**The card floats; it never reflows.** The Spanreed is a real terminal sized 1:1 to
its pane, so a card that changed the body's height would reflow every agent's screen
on every failure.

**Who makes room for whom.** A form makes room — it is being typed into, and a card
over the field is intolerable; it also never moves the cursor, because a failure that
arrived on its own must not relocate the field someone is typing in. A surface the
reader *works* in (Sessions, the detail view) makes room too. Only help and info are
read once and closed with any key, and those keep their full height with the card
floating over them, because shrinking a content-sized overlay silently cuts its end
off. The card also stays off the transcript's foot row, which is never blank.

**A card belongs to the surface that raised it.** Form objections retire with their
form — including when the form closes on a message rather than a keystroke, and
including the success that disproves them. Everything else belongs to the dashboard
and outlives every overlay.

**A failing refresh reports its own recovery**, clears itself when the daemon returns,
and is hushed while dismissed — but never by a timeout, a form opening, or a recall of
a failure that has already recovered. Every one of those was a bug where the dashboard
went silent about a daemon that was down.

## Review

Ten rounds of adversarial review; 51 findings fixed, including two highs whose symptom
was the dashboard going quiet about a broken backend. Rounds 3–8 each found defects
created by the previous round's fix; round 9 was the first with no high.

Every regression test was validated by reverting its fix and watching it go red. Five
passed vacuously first and were rewritten — one rendered a path that never composites
the card, one asserted through the function that carried the bug, one reverted a
different call site than the test exercised, one asserted a modal's border rather than
the content truncating above it.

Driven live in scratch tmux sessions at 80×24 through 120×44 with isolated XDG and
`WINDRUNNER_DIR`: a bad path in the add-workspace form, remote setup against an
unreachable host, and a frozen daemon — dismissed, recalled intact while polls kept
failing, cleared on recovery, raised again as news, and a name typed into the dispatch
form while a card arrived unbidden.

## Follow-ups

- #153 — an overlay's failure still reports only its exit status, not what it printed.
- A redesign issue (filed with this merge): four of the five ways a card can end exist
  to manage one self-repeating failure, and both highs lived in that machinery. A
  recurring condition is status, not an alert — "the daemon is unreachable" belongs in
  the header band, which would delete `polled`, `hushedPoll`, `heldBack`,
  `resolvePolled` and `raisePolled` outright.