### PR TITLE
Install yazi from its own release, and say what a machine is doing

### DIFF
--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -240,8 +240,19 @@ published archive and says so instead of guessing at a version. The
 installed path is recorded as that host's `bin`, because a
 non-interactive SSH shell frequently has no `~/.local/bin` on its PATH
 and would not find what was just put there.
-Yazi is offered only through the host's own package manager, and
-described rather than guessed at when there is none. Members exist at start-up for the machines the
+Yazi comes from its own published build for that platform, put beside
+Stormlight in the same directory. Not through the host's package
+manager: it is absent from some distributions' repositories entirely, and
+a package install wants a password that a popup is a poor place to ask
+for. A user-local binary needs no privileges and is the same everywhere.
+
+Opening a machine asks it what it has before offering to browse it, so
+the answer can be "this one has no Stormlight yet" with the row that
+fixes that already under the cursor, rather than a picker that hangs and
+then fails. Reaching it shows a spinner, because SSH takes as long as it
+takes and a modal showing nothing is one nobody can tell from a broken
+one. Silence is never read as a verdict: a machine still being asked, or
+one there is no way to ask, keeps every row it would otherwise have. Members exist at start-up for the machines the
 catalog says hold a workspace — listing names no host, so without that a
 machine's agents would be invisible until something mentioned one — and
 any other joins the moment it is first named. `[hosts.<name>]` is where a

--- a/internal/remote/install.go
+++ b/internal/remote/install.go
@@ -2,14 +2,18 @@ package remote
 
 import (
 	"archive/tar"
+	"archive/zip"
+	"bytes"
 	"compress/gzip"
 	"context"
 	"crypto/sha256"
 	"encoding/hex"
+	"encoding/json"
 	"fmt"
 	"io"
 	"net/http"
 	"os"
+	"path"
 	"strings"
 	"time"
 )
@@ -164,4 +168,111 @@ func binaryFromArchive(payload []byte) ([]byte, error) {
 // same platform.
 func localBinary(path string) ([]byte, error) {
 	return os.ReadFile(path)
+}
+
+// yaziRelease is where Yazi publishes its own builds.
+const yaziRelease = "https://api.github.com/repos/sxyazi/yazi/releases/latest"
+
+// yaziTriple names a platform the way Rust does, which is how Yazi's
+// archives are named.
+func yaziTriple(target Target, musl bool) (string, bool) {
+	arch := ""
+	switch target.Arch {
+	case "arm64":
+		arch = "aarch64"
+	case "amd64":
+		arch = "x86_64"
+	default:
+		return "", false
+	}
+	switch target.OS {
+	case "darwin":
+		return arch + "-apple-darwin", true
+	case "linux":
+		if musl {
+			return arch + "-unknown-linux-musl", true
+		}
+		return arch + "-unknown-linux-gnu", true
+	}
+	return "", false
+}
+
+// YaziBinaries fetches Yazi's own published build for a platform and
+// returns the executables inside it, keyed by name.
+//
+// Downloading rather than asking a package manager is the reliable
+// answer and the polite one. Yazi is not in every distribution's
+// repositories — it is absent from Fedora's, which is where assuming
+// otherwise was found out — and a package install wants a password that
+// a popup is a poor place to ask for. This puts a user-local binary in
+// the same directory Stormlight went to, and needs no privileges at all.
+func YaziBinaries(ctx context.Context, target Target, musl bool) (map[string][]byte, error) {
+	triple, ok := yaziTriple(target, musl)
+	if !ok {
+		return nil, fmt.Errorf("yazi publishes no build for %s", target)
+	}
+	metadata, err := fetch(ctx, yaziRelease)
+	if err != nil {
+		return nil, fmt.Errorf("ask what yazi has published: %w", err)
+	}
+	var release struct {
+		Tag    string `json:"tag_name"`
+		Assets []struct {
+			Name string `json:"name"`
+			URL  string `json:"browser_download_url"`
+		} `json:"assets"`
+	}
+	if err := json.Unmarshal(metadata, &release); err != nil {
+		return nil, err
+	}
+	want := "yazi-" + triple + ".zip"
+	url := ""
+	for _, asset := range release.Assets {
+		if asset.Name == want {
+			url = asset.URL
+			break
+		}
+	}
+	if url == "" {
+		return nil, fmt.Errorf("yazi %s publishes no %s", release.Tag, want)
+	}
+
+	payload, err := fetch(ctx, url)
+	if err != nil {
+		return nil, fmt.Errorf("download %s: %w", want, err)
+	}
+	return binariesFromZip(payload)
+}
+
+// binariesFromZip pulls the two executables out of a Yazi archive: the
+// browser, and the `ya` tool its plugins are managed with.
+func binariesFromZip(payload []byte) (map[string][]byte, error) {
+	archive, err := zip.NewReader(bytes.NewReader(payload), int64(len(payload)))
+	if err != nil {
+		return nil, err
+	}
+	binaries := map[string][]byte{}
+	for _, file := range archive.File {
+		name := path.Base(file.Name)
+		if name != "yazi" && name != "ya" {
+			continue
+		}
+		if file.FileInfo().IsDir() {
+			continue
+		}
+		opened, err := file.Open()
+		if err != nil {
+			return nil, err
+		}
+		content, err := io.ReadAll(opened)
+		opened.Close()
+		if err != nil {
+			return nil, err
+		}
+		binaries[name] = content
+	}
+	if len(binaries["yazi"]) == 0 {
+		return nil, fmt.Errorf("the yazi archive holds no yazi binary")
+	}
+	return binaries, nil
 }

--- a/internal/remote/setup.go
+++ b/internal/remote/setup.go
@@ -36,10 +36,13 @@ type Report struct {
 	Home       string
 	Stormlight Requirement
 	Yazi       Requirement
-	// PackageManager is the first recognised one on the host, and the
-	// only thing that makes installing Yazi something Stormlight can
-	// offer rather than describe.
+	// PackageManager is the first recognised one on the host. It is
+	// reported for the message it makes possible, not because Yazi is
+	// installed with it.
 	PackageManager string
+	// Musl says the host links against musl rather than glibc, which is
+	// a different binary rather than a slower one.
+	Musl bool
 }
 
 // Ready reports whether the host can host agents at all.
@@ -57,7 +60,19 @@ look() {
 }
 printf 'platform=%s\n' "$(uname -sm)"
 printf 'home=%s\n' "$HOME"
-sl=$(look stormlight) && printf 'stormlight=%s\n' "$sl"
+if [ -e /lib/ld-musl-x86_64.so.1 ] || [ -e /lib/ld-musl-aarch64.so.1 ] || \
+   (command -v ldd >/dev/null 2>&1 && ldd --version 2>&1 | grep -qi musl); then
+  printf 'libc=musl\n'
+fi
+# A configured bin is the binary the bridge will actually run, so it is
+# the one worth asking about — a Stormlight elsewhere on PATH says
+# nothing about whether the configured path exists.
+if [ -n "$STORMLIGHT_CONFIGURED_BIN" ]; then
+  [ -x "$STORMLIGHT_CONFIGURED_BIN" ] && sl="$STORMLIGHT_CONFIGURED_BIN"
+else
+  sl=$(look stormlight)
+fi
+[ -n "$sl" ] && printf 'stormlight=%s\n' "$sl"
 [ -n "$sl" ] && printf 'stormlight_version=%s\n' "$("$sl" --version 2>/dev/null | head -1)"
 yz=$(look yazi) && printf 'yazi=%s\n' "$yz"
 for manager in brew apt-get dnf pacman apk; do
@@ -69,7 +84,15 @@ done
 // machine, so its errors are the ones that have to be legible: an
 // unaccepted host key, a refused login, a name that does not resolve.
 func Probe(ctx context.Context, transport *Transport) (Report, error) {
-	command := transport.ShellCommand(ctx, probeScript)
+	// The configured binary travels as an environment variable rather
+	// than spliced into the script: it is a path someone typed, and a
+	// script is not the place to find out it had a quote in it.
+	script := probeScript
+	if bin := transport.Host().Bin; bin != "" {
+		script = "STORMLIGHT_CONFIGURED_BIN=" +
+			shellQuote([]string{bin}) + "\n" + script
+	}
+	command := transport.ShellCommand(ctx, script)
 	var stdout, stderr bytes.Buffer
 	command.Stdout = &stdout
 	command.Stderr = &stderr
@@ -103,6 +126,8 @@ func Probe(ctx context.Context, transport *Transport) (Report, error) {
 			report.Yazi.Path = value
 		case "package_manager":
 			report.PackageManager = value
+		case "libc":
+			report.Musl = value == "musl"
 		}
 	}
 	return report, nil
@@ -134,22 +159,20 @@ func (r Report) CanCopyBinary() bool {
 // Target is the host's platform in the naming published builds use.
 func (r Report) Target() (Target, bool) { return TargetFor(r.Platform) }
 
-// YaziInstallCommand is how this host would install Yazi, or empty when
-// Stormlight has no business guessing. Package management belongs to the
-// machine's owner; offering to run the one command its own package
-// manager would use is help, and inventing one is damage.
+// YaziInstallCommand is what this host's own package manager would use,
+// for the machines where Yazi is actually packaged.
+//
+// It is a suggestion printed for the reader, not the path Stormlight
+// takes. Yazi is in Homebrew and in Arch's repositories; it is not in
+// Fedora's, and its presence in Debian's and Alpine's depends on how new
+// they are. Naming a command that does not exist is worse than naming
+// none — `No match for argument: yazi` is how that was found out.
 func (r Report) YaziInstallCommand() string {
 	switch r.PackageManager {
 	case "brew":
 		return "brew install yazi"
-	case "apt-get":
-		return "sudo apt-get install -y yazi"
-	case "dnf":
-		return "sudo dnf install -y yazi"
 	case "pacman":
-		return "sudo pacman -S --noconfirm yazi"
-	case "apk":
-		return "sudo apk add yazi"
+		return "sudo pacman -S yazi"
 	default:
 		return ""
 	}
@@ -241,26 +264,60 @@ func pathDir(path string) string {
 	return "."
 }
 
-// InstallYazi runs the host's own package manager.
+// InstallYazi puts Yazi's own published build beside Stormlight on the
+// host.
+//
+// Not through the host's package manager: Yazi is absent from some
+// distributions' repositories entirely, and a package install wants a
+// password that a popup is a poor place to ask for. A user-local binary
+// needs no privileges and is the same everywhere.
 func InstallYazi(
 	ctx context.Context,
 	transport *Transport,
 	report Report,
 	progress io.Writer,
 ) error {
-	install := report.YaziInstallCommand()
-	if install == "" {
+	target, ok := report.Target()
+	if !ok {
 		return fmt.Errorf(
-			"%s has no package manager Stormlight recognises; install yazi there yourself, "+
-				"or use Enter a path instead of browsing", report.Host)
+			"%s reports %q, which is not a platform yazi publishes for — "+
+				"use Enter a path instead of browsing", report.Host, report.Platform)
 	}
-	fmt.Fprintf(progress, "running on %s: %s\n", report.Host, install)
-	// A login shell, because the package manager is usually on the PATH
-	// a profile sets rather than the one ssh hands a bare command.
-	command := transport.ShellCommand(ctx, `"$SHELL" -lc `+shellQuote([]string{install})+"\n")
-	command.Stdout = progress
-	command.Stderr = progress
-	return command.Run()
+	fmt.Fprintf(progress, "fetching yazi's %s build\n", target)
+	binaries, err := YaziBinaries(ctx, target, report.Musl)
+	if err != nil {
+		return err
+	}
+
+	directory := pathDir(report.InstallPath())
+	prepare := transport.ShellCommand(ctx, fmt.Sprintf("set -e\nmkdir -p %q\n", directory))
+	prepare.Stdout, prepare.Stderr = progress, progress
+	if err := prepare.Run(); err != nil {
+		return fmt.Errorf("prepare %s on %s: %w", directory, report.Host, err)
+	}
+
+	// yazi is the browser; ya is what its plugins are managed with, and
+	// costs one more copy to have rather than to explain the absence of.
+	for _, name := range []string{"yazi", "ya"} {
+		payload := binaries[name]
+		if len(payload) == 0 {
+			continue
+		}
+		destination := directory + "/" + name
+		fmt.Fprintf(progress, "installing to %s:%s\n", report.Host, destination)
+		copyIn := transport.PipeCommand(ctx, bytes.NewReader(payload), "tee", destination+".new")
+		copyIn.Stdout, copyIn.Stderr = io.Discard, progress
+		if err := copyIn.Run(); err != nil {
+			return fmt.Errorf("copy %s to %s: %w", name, report.Host, err)
+		}
+		finish := transport.ShellCommand(ctx, fmt.Sprintf(
+			"set -e\nchmod 0755 %[1]q.new\nmv %[1]q.new %[1]q\n", destination))
+		finish.Stdout, finish.Stderr = progress, progress
+		if err := finish.Run(); err != nil {
+			return fmt.Errorf("install %s on %s: %w", name, report.Host, err)
+		}
+	}
+	return nil
 }
 
 // localPlatform is this machine's `uname -sm`, asked the same way the

--- a/internal/remote/setup_test.go
+++ b/internal/remote/setup_test.go
@@ -44,8 +44,10 @@ printf 'package_manager=apt-get\n'`)
 	if !report.Ready() {
 		t.Fatal("a host with stormlight can hold agents, yazi or not")
 	}
-	if got := report.YaziInstallCommand(); !strings.Contains(got, "apt-get") {
-		t.Fatalf("install command = %q", got)
+	// apt is not one of the package managers Yazi is reliably in, and
+	// Stormlight installs it from Yazi's own release regardless.
+	if got := report.YaziInstallCommand(); got != "" {
+		t.Fatalf("install command = %q, want none suggested", got)
 	}
 	if got := report.InstallPath(); got != "/home/trent/.local/bin/stormlight" {
 		t.Fatalf("install path = %q", got)
@@ -156,26 +158,53 @@ func TestAChecksumMismatchRefuses(t *testing.T) {
 	}
 }
 
-// TestYaziIsOnlyOfferedWhereItCanBeInstalled: package management belongs
-// to the machine's owner. Offering the one command its own package
-// manager would use is help; inventing one is damage.
-func TestYaziIsOnlyOfferedWhereItCanBeInstalled(t *testing.T) {
+// TestYaziIsOnlySuggestedWhereItIsPackaged: naming a command that does
+// not exist is worse than naming none. Yazi is in Homebrew and Arch's
+// repositories; it is not in Fedora's, which is where
+// `No match for argument: yazi` came from.
+func TestYaziIsOnlySuggestedWhereItIsPackaged(t *testing.T) {
 	for manager, want := range map[string]string{
 		"brew":    "brew install yazi",
 		"pacman":  "pacman -S",
+		"dnf":     "",
+		"apt-get": "",
+		"apk":     "",
 		"unknown": "",
 	} {
 		got := (Report{PackageManager: manager}).YaziInstallCommand()
 		if want == "" && got != "" {
-			t.Fatalf("%s: offered %q", manager, got)
+			t.Fatalf("%s: suggested %q, which may not exist there", manager, got)
 		}
 		if want != "" && !strings.Contains(got, want) {
 			t.Fatalf("%s: got %q", manager, got)
 		}
 	}
-	err := InstallYazi(context.Background(), nil, Report{Host: "devbox"}, nil)
+
+	// A platform Yazi does not publish for says what still works.
+	err := InstallYazi(
+		context.Background(), nil, Report{Host: "devbox", Platform: "Plan9 386"}, nil)
 	if err == nil || !strings.Contains(err.Error(), "Enter a path") {
 		t.Fatalf("it should say what still works instead: %v", err)
+	}
+}
+
+// TestYaziTriplesMatchWhatItPublishes: Rust names platforms a third way,
+// and musl is a different binary rather than a slower one.
+func TestYaziTriplesMatchWhatItPublishes(t *testing.T) {
+	for _, test := range []struct {
+		target Target
+		musl   bool
+		want   string
+	}{
+		{Target{"linux", "arm64"}, false, "aarch64-unknown-linux-gnu"},
+		{Target{"linux", "amd64"}, false, "x86_64-unknown-linux-gnu"},
+		{Target{"linux", "amd64"}, true, "x86_64-unknown-linux-musl"},
+		{Target{"darwin", "arm64"}, false, "aarch64-apple-darwin"},
+	} {
+		got, ok := yaziTriple(test.target, test.musl)
+		if !ok || got != test.want {
+			t.Fatalf("%v musl=%v → %q, want %q", test.target, test.musl, got, test.want)
+		}
 	}
 }
 

--- a/internal/ui/dispatch.go
+++ b/internal/ui/dispatch.go
@@ -4,11 +4,14 @@ package ui
 // Split from model.go; see #34.
 
 import (
+	"context"
 	"fmt"
 	"path/filepath"
 	"strings"
+	"time"
 	"unicode/utf8"
 
+	"charm.land/bubbles/v2/spinner"
 	tea "charm.land/bubbletea/v2"
 	"charm.land/lipgloss/v2"
 	"github.com/charmbracelet/x/ansi"
@@ -239,6 +242,9 @@ func (m Model) renderAddWorkspaceAt(width, height int) string {
 		return strings.Join(lines, "\n")
 	}
 
+	if line := m.renderMachineStatus(contentWidth); line != "" {
+		lines = append(lines, "  "+line, "")
+	}
 	lines = append(lines, "  "+m.renderDispatchSectionTitle(
 		accentStyle(),
 		"Choose a directory",
@@ -297,6 +303,54 @@ func (m Model) renderAddWorkspaceTabs(width int) string {
 		return truncate(tabs, width)
 	}
 	return tabs
+}
+
+// reaching is the animation for a machine being contacted: Bubbles' own
+// Points spinner, whose ∙ and ● are already this dashboard's vocabulary
+// for quiet and working. The frames and the pace both come from the
+// library rather than being invented here.
+//
+// It rides the tick the working glow already runs on — 90ms — rather
+// than starting a second loop, so each frame is held for as many ticks
+// as the spinner's own FPS asks for.
+var reaching = spinner.Points
+
+// reachingHold is how many 90ms ticks one frame lasts, from the
+// spinner's declared rate.
+var reachingHold = max(1, int(reaching.FPS/(90*time.Millisecond)))
+
+// renderMachineStatus says what is happening with the machine the modal
+// has opened — reaching it, what it lacks, or why it could not be
+// reached. Empty for this machine, which needs no explaining.
+func (m Model) renderMachineStatus(width int) string {
+	if m.addWorkspaceHost == "" {
+		return ""
+	}
+	host := m.addWorkspaceHost
+	if !m.machineState.running && !m.machineAnswered() {
+		return ""
+	}
+	if m.machineState.running {
+		frame := reaching.Frames[0]
+		if phase := m.shimmerPhaseOrRest(); phase >= 0 {
+			frame = reaching.Frames[(phase/reachingHold)%len(reaching.Frames)]
+		}
+		return truncate(accentStyle().Render(frame)+" "+
+			mutedStyle().Render("Reaching "+host+"…"), width)
+	}
+	switch {
+	case m.machineState.err != nil:
+		return truncate(lipgloss.NewStyle().Foreground(colorWaiting()).
+			Render("Cannot reach "+host+" — "+m.machineState.err.Error()), width)
+	case !m.machineState.ready:
+		return truncate(lipgloss.NewStyle().Foreground(colorWaiting()).
+			Render(host+" has no Stormlight yet. Set it up below."), width)
+	case !m.machineState.yazi:
+		return truncate(mutedStyle().
+			Render(host+" has no yazi — type a path, or set it up below."), width)
+	default:
+		return truncate(mutedStyle().Render(host+" · "+m.machineState.detail), width)
+	}
 }
 
 // renderMachineRows lists the machines the Remote tab can open.
@@ -1176,8 +1230,19 @@ func (m *Model) setAddWorkspaceChoices() {
 		where = "Browse " + host
 		typed = "A path on " + host
 	}
-	choices := make([]directoryChoice, 0, 2)
-	if m.yaziPath != "" || host != "" {
+	choices := make([]directoryChoice, 0, 3)
+	// Browsing needs a picker over there, so it is offered once the
+	// machine has said it has one — and while it is still being asked,
+	// which is the common case of a machine that is simply fine.
+	browsable := m.yaziPath != ""
+	if host != "" {
+		// Offered unless the machine has actually said it cannot. Still
+		// being asked, or no way to ask, is not an answer — and refusing
+		// on an absence of evidence hides the row that works.
+		browsable = !m.machineAnswered() ||
+			(m.machineState.err == nil && m.machineState.ready && m.machineState.yazi)
+	}
+	if browsable {
 		choices = append(choices, directoryChoice{
 			kind:   directoryYazi,
 			host:   host,
@@ -1195,15 +1260,35 @@ func (m *Model) setAddWorkspaceChoices() {
 		// A machine needs Stormlight before it can be reached at all, and
 		// Yazi before it can be browsed. Offering to put them there beats
 		// failing at the first thing that needs them.
+		detail := "Check and install what " + host + " needs"
+		if m.machineAnswered() {
+			switch {
+			case m.machineState.err != nil:
+				detail = "Install Stormlight on " + host + " and try again"
+			case !m.machineState.ready:
+				detail = host + " has no Stormlight yet"
+			case !m.machineState.yazi:
+				detail = host + " has no yazi, so it cannot be browsed"
+			}
+		}
 		choices = append(choices, directoryChoice{
 			kind:   directorySetup,
 			host:   host,
 			label:  "Set up this machine",
-			detail: "Check and install what " + host + " needs",
+			detail: detail,
 		})
 	}
 	m.directories = choices
 	m.directoryIndex = 0
+	// A machine that cannot do anything else should open on the row that
+	// fixes that, rather than on one that will fail.
+	if host != "" && m.machineAnswered() && !m.machineReady() {
+		for index, choice := range choices {
+			if choice.kind == directorySetup {
+				m.directoryIndex = index
+			}
+		}
+	}
 }
 
 // addWorkspaceHostName is the machine the modal is on; empty is this one.
@@ -1254,7 +1339,43 @@ func (m *Model) enterMachine(host string) {
 	// Nothing here knows that machine's directories; its own Stormlight
 	// starts the picker wherever it lands.
 	m.pickerStart = ""
+	m.machineState = machineCheck{host: host, running: m.checkHost != nil}
 	m.setAddWorkspaceChoices()
+}
+
+// checkMachineCmd asks the machine what it has, so the modal can say
+// "not set up yet" rather than offering a browse that will fail.
+func (m Model) checkMachineCmd(host string) tea.Cmd {
+	if m.checkHost == nil {
+		return nil
+	}
+	check := m.checkHost
+	return func() tea.Msg {
+		// Long enough for a machine that is merely slow, short enough
+		// that one that is gone does not hold the modal all day.
+		ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+		defer cancel()
+		status, err := check(ctx, host)
+		return machineCheckedMsg{host: host, status: status, err: err}
+	}
+}
+
+// machineAnswered reports whether the opened machine has actually said
+// something about itself. Nothing here treats silence as a verdict: a
+// machine still being asked, or one there is no way to ask, is unknown
+// rather than broken.
+func (m Model) machineAnswered() bool {
+	return m.checkHost != nil &&
+		!m.machineState.running &&
+		m.machineState.host == m.addWorkspaceHost &&
+		m.addWorkspaceHost != ""
+}
+
+// machineReady reports whether the opened machine can be browsed and
+// dispatched to. Unknown counts as not ready: the rows that need it stay
+// out of the way until the machine has answered.
+func (m Model) machineReady() bool {
+	return m.machineState.err == nil && !m.machineState.running && m.machineState.ready
 }
 
 // leaveMachine goes back to the machine list, which is what Esc means

--- a/internal/ui/machine_test.go
+++ b/internal/ui/machine_test.go
@@ -1,6 +1,8 @@
 package ui
 
 import (
+	"context"
+	"fmt"
 	"strings"
 	"testing"
 
@@ -234,5 +236,136 @@ func TestNoLocalYaziStillBrowsesAnotherMachineFromTheAgentForm(t *testing.T) {
 
 	if _, cmd := model.openYazi(); cmd == nil {
 		t.Fatalf("a remote browse should not need a local yazi: %v", model.err)
+	}
+}
+
+func checkedFixture(t *testing.T, status HostStatus, err error) Model {
+	t.Helper()
+	model := addWorkspaceFixture(t, "devbox")
+	model.checkHost = func(context.Context, string) (HostStatus, error) {
+		return status, err
+	}
+	model.switchAddWorkspaceTab(tabRemote)
+	model.openMachine()
+	// What the command would have delivered.
+	updated, _ := model.Update(machineCheckedMsg{
+		host: "devbox", status: status, err: err})
+	return updated.(Model)
+}
+
+// TestReachingAMachineSaysSo: SSH takes as long as it takes, and a modal
+// that shows nothing while it happens is one nobody can tell from a
+// broken one.
+func TestReachingAMachineSaysSo(t *testing.T) {
+	model := addWorkspaceFixture(t, "devbox")
+	model.checkHost = func(context.Context, string) (HostStatus, error) {
+		return HostStatus{Ready: true, Yazi: true}, nil
+	}
+	model.switchAddWorkspaceTab(tabRemote)
+	model.openMachine()
+
+	if !model.machineState.running {
+		t.Fatal("opening a machine should start reaching it")
+	}
+	status := model.renderMachineStatus(70)
+	if !strings.Contains(status, "Reaching devbox") {
+		t.Fatalf("status = %q", status)
+	}
+	// A frame of the spinner, whichever it is on.
+	if !strings.ContainsAny(status, "∙●") {
+		t.Fatalf("no spinner in %q", status)
+	}
+	// While it is unknown, browsing is still offered — silence is not a
+	// verdict.
+	if model.directories[0].kind != directoryYazi {
+		t.Fatalf("choices = %#v", model.directories)
+	}
+}
+
+// TestAMachineWithNoStormlightOffersToFixItself: the case that started
+// this — a host that cannot be reached at all should say so and point at
+// the row that fixes it, not offer a browse that will fail.
+func TestAMachineWithNoStormlightOffersToFixItself(t *testing.T) {
+	model := checkedFixture(t, HostStatus{Ready: false}, nil)
+
+	status := model.renderMachineStatus(70)
+	if !strings.Contains(status, "no Stormlight") {
+		t.Fatalf("status = %q", status)
+	}
+	for _, choice := range model.directories {
+		if choice.kind == directoryYazi {
+			t.Fatal("browsing must not be offered on a machine that cannot do it")
+		}
+	}
+	selected, ok := model.selectedDirectory()
+	if !ok || selected.kind != directorySetup {
+		t.Fatalf("it should open on the row that fixes this: %#v", selected)
+	}
+}
+
+// TestAnUnreachableMachineSaysWhy: the error belongs on screen, not in a
+// log — it is usually a host key or a name that does not resolve, and
+// both have obvious fixes once seen.
+func TestAnUnreachableMachineSaysWhy(t *testing.T) {
+	model := checkedFixture(t, HostStatus{},
+		fmt.Errorf("devbox: ssh: Could not resolve hostname devbox"))
+
+	status := model.renderMachineStatus(70)
+	if !strings.Contains(status, "Cannot reach devbox") ||
+		!strings.Contains(status, "resolve hostname") {
+		t.Fatalf("status = %q", status)
+	}
+	selected, ok := model.selectedDirectory()
+	if !ok || selected.kind != directorySetup {
+		t.Fatalf("selected = %#v", selected)
+	}
+}
+
+// TestAMachineWithoutYaziKeepsTypedPaths: yazi's absence costs browsing
+// and nothing else.
+func TestAMachineWithoutYaziKeepsTypedPaths(t *testing.T) {
+	model := checkedFixture(t, HostStatus{Ready: true, Yazi: false}, nil)
+
+	if !strings.Contains(model.renderMachineStatus(70), "no yazi") {
+		t.Fatalf("status = %q", model.renderMachineStatus(70))
+	}
+	var typed bool
+	for _, choice := range model.directories {
+		if choice.kind == directoryYazi {
+			t.Fatal("a machine without yazi cannot be browsed")
+		}
+		if choice.kind == directoryCustom {
+			typed = true
+		}
+	}
+	if !typed {
+		t.Fatal("typing a path still works")
+	}
+}
+
+// TestAReadyMachineJustWorks: the common case stays quiet — a line
+// naming the machine, and the rows as they were.
+func TestAReadyMachineJustWorks(t *testing.T) {
+	model := checkedFixture(t,
+		HostStatus{Ready: true, Yazi: true, Detail: "Linux aarch64"}, nil)
+
+	if !strings.Contains(model.renderMachineStatus(70), "Linux aarch64") {
+		t.Fatalf("status = %q", model.renderMachineStatus(70))
+	}
+	if model.directories[0].kind != directoryYazi {
+		t.Fatalf("choices = %#v", model.directories)
+	}
+}
+
+// TestALateAnswerForAnotherMachineIsIgnored: someone who moved on before
+// a slow machine replied should not have the modal change under them.
+func TestALateAnswerForAnotherMachineIsIgnored(t *testing.T) {
+	model := checkedFixture(t, HostStatus{Ready: true, Yazi: true}, nil)
+	before := model.renderMachineStatus(70)
+
+	updated, _ := model.Update(machineCheckedMsg{
+		host: "somewhere-else", status: HostStatus{Ready: false}})
+	if got := updated.(Model).renderMachineStatus(70); got != before {
+		t.Fatalf("a late answer for another machine changed this one: %q", got)
 	}
 }

--- a/internal/ui/model.go
+++ b/internal/ui/model.go
@@ -110,6 +110,41 @@ const (
 	tabRemote
 )
 
+// machineCheck is the state of asking a machine whether it can host
+// agents at all.
+//
+// Reaching another machine takes as long as SSH takes, which is not
+// instant and is sometimes forever. Asking when a machine is opened —
+// rather than when someone finally presses Browse — is what lets the
+// answer be "this machine is not set up yet" instead of a picker that
+// hangs and then fails.
+type machineCheck struct {
+	host    string
+	running bool
+	// err is why the machine could not be reached or read.
+	err error
+	// ready says Stormlight is installed there; without it nothing else
+	// on that machine can work.
+	ready bool
+	// yazi says it can be browsed. Its absence costs browsing and
+	// nothing else, so it is a note rather than a refusal.
+	yazi   bool
+	detail string
+}
+
+// HostStatus is what a machine reported about itself.
+type HostStatus struct {
+	Ready  bool
+	Yazi   bool
+	Detail string
+}
+
+type machineCheckedMsg struct {
+	host   string
+	status HostStatus
+	err    error
+}
+
 // machineChoice is one row of the Remote tab: a machine from the user's
 // SSH configuration, or the row for naming one it does not list.
 type machineChoice struct {
@@ -167,6 +202,9 @@ type Model struct {
 	catalogWorkspaces []workspace.Context
 	workspaceRoots    []workspace.Context
 	groups            []workspaceGroup
+	// machineState is what the machine being opened said about itself,
+	// and whether it has said anything yet.
+	machineState machineCheck
 	// The Add Workspace modal: which tab is showing, which machine the
 	// Remote tab has been opened on, and the machines it can offer.
 	addWorkspaceTab  addWorkspaceTab
@@ -174,6 +212,7 @@ type Model struct {
 	machines         []machineChoice
 	machineIndex     int
 	hostInput        lineInput
+	checkHost        func(context.Context, string) (HostStatus, error)
 	// dispatchHost is the machine the open dispatch form is aimed at. It
 	// travels with the directory rather than being asked for separately:
 	// a path only means anything alongside the machine it is on.
@@ -364,6 +403,9 @@ type Options struct {
 	Columns ColumnPrefs
 	// Keys rebinds the seam chords; empty lists keep the defaults.
 	Keys KeyBindings
+	// CheckHost asks a machine what it has. It is what the Add Workspace
+	// modal waits on before offering to browse one.
+	CheckHost func(context.Context, string) (HostStatus, error)
 	// Hosts are the machines to offer when adding a workspace, in the
 	// order they should appear — read from the user's SSH configuration.
 	// This machine is not among them; it has its own tab.
@@ -428,6 +470,7 @@ func NewModelWithOptions(backend Backend, options Options) Model {
 		ptyManager:         ptyview.NewManager(backend),
 		keys:               fillKeyDefaults(options.Keys),
 		machines:           machineChoices(options.Hosts),
+		checkHost:          options.CheckHost,
 		hostInput:          newLineInput("user@host"),
 	}
 	for index, info := range model.providers {
@@ -509,8 +552,24 @@ func (m Model) Update(message tea.Msg) (tea.Model, tea.Cmd) {
 	case tickMsg:
 		return m, tea.Batch(m.refreshCmd(), tickCmd())
 
+	case machineCheckedMsg:
+		// A late answer for a machine nobody is looking at any more is
+		// not an answer to anything.
+		if m.machineState.host != msg.host {
+			return m, nil
+		}
+		m.machineState = machineCheck{
+			host:   msg.host,
+			err:    msg.err,
+			ready:  msg.status.Ready,
+			yazi:   msg.status.Yazi,
+			detail: msg.status.Detail,
+		}
+		m.setAddWorkspaceChoices()
+		return m, nil
+
 	case shimmerTickMsg:
-		if !m.anyAgentsActive() {
+		if !m.anyAgentsActive() && !m.machineState.running {
 			m.shimmerRunning = false
 			m.shimmerPhase = 0
 			return m, nil
@@ -1130,6 +1189,17 @@ func (m Model) anyAgentsActive() bool {
 
 // shimmerPhaseOrRest returns the sweep phase while the shimmer is running
 // and the resting (uniform base shade) phase otherwise.
+// startShimmer begins the animation tick if it is not already running.
+// It drives the working glow and the machine-check spinner both, so
+// whichever starts first carries the other.
+func (m *Model) startShimmer() tea.Cmd {
+	if m.shimmerRunning {
+		return nil
+	}
+	m.shimmerRunning = true
+	return shimmerTickCmd()
+}
+
 func (m Model) shimmerPhaseOrRest() int {
 	if m.shimmerRunning {
 		return m.shimmerPhase

--- a/internal/ui/workspaces.go
+++ b/internal/ui/workspaces.go
@@ -114,6 +114,12 @@ func (m Model) updateAddWorkspace(msg tea.KeyPressMsg) (tea.Model, tea.Cmd) {
 	case "enter":
 		if m.showingMachines() {
 			m.openMachine()
+			if m.machineState.running {
+				// The spinner rides the same tick the working glow does,
+				// which only runs while something is moving.
+				return m, tea.Batch(
+					m.checkMachineCmd(m.machineState.host), m.startShimmer())
+			}
 			return m, nil
 		}
 		selected, ok := m.selectedDirectory()

--- a/main.go
+++ b/main.go
@@ -508,6 +508,20 @@ func runDashboard(command *cobra.Command, cfg config.Config, openPath string) er
 		// here. Naming one is what makes it usable, so this list is
 		// suggestions rather than permission.
 		Hosts: dashboardHosts(cfg),
+		// Asking a machine what it has, so the modal can say "not set up
+		// yet" rather than offering a browse that will hang and fail.
+		CheckHost: func(ctx context.Context, host string) (ui.HostStatus, error) {
+			transport := remote.NewTransport(remoteHostFrom(host, cfg.Hosts[host]))
+			report, err := remote.Probe(ctx, transport)
+			if err != nil {
+				return ui.HostStatus{}, err
+			}
+			return ui.HostStatus{
+				Ready:  report.Ready(),
+				Yazi:   report.Yazi.Present(),
+				Detail: report.Platform,
+			}, nil
+		},
 	}
 	if openPath != "" {
 		value, err := service.AddWorkspace(context.Background(), "", openPath)

--- a/site/docs/architecture.html
+++ b/site/docs/architecture.html
@@ -251,9 +251,18 @@
     with no Stormlight to check anything with. A development build has no published archive
     and says so instead of guessing at a version. The installed path is recorded as that
     host's <code>bin</code>, because a non-interactive SSH shell frequently has no
-    <code>~/.local/bin</code> on its PATH and would not find what was just put there. Yazi is offered only through the host's own
-    package manager, and described rather than guessed at when there is none.
-    Members exist at start-up for the machines the catalog says hold a workspace — listing
+    <code>~/.local/bin</code> on its PATH and would not find what was just put there. Yazi comes
+    from its own published build for that platform, put beside Stormlight in the same
+    directory — not through the host's package manager, which is absent from some
+    distributions' repositories entirely and wants a password a popup is a poor place to ask
+    for.</p>
+    <p>Opening a machine asks it what it has before offering to browse it, so the answer can
+    be "this one has no Stormlight yet" with the row that fixes that already under the
+    cursor, rather than a picker that hangs and then fails. Reaching it shows a spinner,
+    because SSH takes as long as it takes and a modal showing nothing is one nobody can tell
+    from a broken one. Silence is never read as a verdict: a machine still being asked, or
+    one there is no way to ask, keeps every row it would otherwise have.</p>
+    <p>Members exist at start-up for the machines the catalog says hold a workspace — listing
     names no host, so without that a machine's agents would be invisible until something
     mentioned one — and any other joins the moment it is first named.
     <code>[hosts.&lt;name&gt;]</code> is where a machine differs from its name: a different


### PR DESCRIPTION
Fixes #156, and adds the modal feedback that makes a machine's state visible
while it is being reached.

## Yazi comes from Yazi

`sudo dnf install -y yazi` fails with `No match for argument: yazi` — it is not
in Fedora's repositories. My package-manager table was guesswork dressed as
knowledge: right for Homebrew and Arch, wrong for Fedora, dependent on release
age for Debian and Alpine.

Yazi now comes from its own published build for the host's platform, put beside
Stormlight in the same directory. That works everywhere and needs **no
privileges at all** — worth having on its own, since the old path asked for a
sudo password inside a popup. The package manager is still named where Yazi
really is packaged, as a suggestion to the reader rather than a command
anything runs.

Rust names platforms a third way, so `linux/arm64` becomes
`aarch64-unknown-linux-gnu` — and musl is a different binary rather than a
slower one, so the probe detects it.

## The modal says what is happening

Opening a machine now asks it what it has, and the answer shapes what is
offered:

- **no Stormlight** — browsing is not offered at all, and the cursor opens on
  the row that fixes it: `notsetup has no Stormlight yet. Set it up below.`
- **no Yazi** — typed paths stay, browsing goes
- **unreachable** — says why, which is usually a host key or an unresolvable
  name, both obvious once seen
- **ready** — a quiet line naming the machine and its platform

While it is being asked, the modal turns Bubbles' `spinner.Points`, whose `∙`
and `●` are already this dashboard's vocabulary for quiet and working. It rides
the 90ms tick the working glow runs on rather than starting a second loop.

**Silence is never a verdict.** A machine still being asked, or one there is no
way to ask, keeps every row it would otherwise have; only an actual answer takes
one away.

## One thing the check found on itself

The probe looked for `stormlight` on PATH even when the host's configuration
named a binary outright — so a `bin` pointing at nothing reported a machine as
*ready* that could never connect. It asks about the binary the bridge will
actually run.

## Testing

`go test ./...` and `go vet ./...` green. New coverage: Yazi triples including
musl; the package-manager suggestion is empty for dnf/apt/apk and present for
brew/pacman; every modal state (reaching, no Stormlight, no Yazi, unreachable,
ready); a late answer for a machine nobody is looking at is ignored; unknown
state keeps the rows.

**In the dashboard**, against a real host: the spinner animates, a host with a
bogus `bin` reports "no Stormlight yet" with Set up preselected and no browse
row, and an unresolvable name shows its ssh error.

**Non-regression**: the local Add Workspace modal renders byte-identically to
`main`.

## Not covered

Installing Yazi onto a genuinely foreign host — no Linux machine to reach. The
fetch, the triple, and the archive extraction are exercised; the copy after
them is the same path Stormlight's own install already uses.