### PR TITLE
Find yazi where it was put, and say why when it is not there

### DIFF
--- a/internal/picker/picker.go
+++ b/internal/picker/picker.go
@@ -80,6 +80,17 @@ func findYazi() (string, error) {
 	if resolved, err := exec.LookPath("yazi"); err == nil {
 		return resolved, nil
 	}
+	// Beside this binary. `remote setup` installs both into the same
+	// directory, and that directory is regularly on no PATH at all: a
+	// fresh machine's ~/.local/bin is missing from the non-interactive
+	// environment and often from the login one too, because the profile
+	// that would add it checked for the directory before it existed.
+	if self, err := os.Executable(); err == nil {
+		beside := filepath.Join(filepath.Dir(self), "yazi")
+		if info, err := os.Stat(beside); err == nil && !info.IsDir() {
+			return beside, nil
+		}
+	}
 	shell := os.Getenv("SHELL")
 	if shell == "" {
 		shell = "/bin/sh"

--- a/internal/picker/picker_test.go
+++ b/internal/picker/picker_test.go
@@ -84,3 +84,31 @@ func TestChooseRefusesWithoutYazi(t *testing.T) {
 		t.Fatal("a machine without yazi should say so")
 	}
 }
+
+// TestYaziIsFoundBesideStormlight: `remote setup` installs both into the
+// same directory, and that directory is regularly on no PATH at all — a
+// fresh machine's ~/.local/bin is missing from the non-interactive
+// environment, and often from the login one too, because the profile
+// that would add it checked for the directory before it existed.
+func TestYaziIsFoundBesideStormlight(t *testing.T) {
+	self, err := os.Executable()
+	if err != nil {
+		t.Skip("cannot locate this test binary")
+	}
+	beside := filepath.Join(filepath.Dir(self), "yazi")
+	if err := os.WriteFile(beside, []byte("#!/bin/sh\nexit 0\n"), 0o755); err != nil {
+		t.Skipf("cannot write beside the test binary: %v", err)
+	}
+	defer os.Remove(beside)
+
+	// Nothing on PATH, so only the neighbour can answer.
+	t.Setenv("PATH", t.TempDir())
+	t.Setenv("SHELL", "/bin/sh")
+	found, err := findYazi()
+	if err != nil {
+		t.Fatalf("findYazi: %v", err)
+	}
+	if found != beside {
+		t.Fatalf("found %q, want the one beside this binary %q", found, beside)
+	}
+}

--- a/internal/remote/setup.go
+++ b/internal/remote/setup.go
@@ -74,7 +74,14 @@ else
 fi
 [ -n "$sl" ] && printf 'stormlight=%s\n' "$sl"
 [ -n "$sl" ] && printf 'stormlight_version=%s\n' "$("$sl" --version 2>/dev/null | head -1)"
-yz=$(look yazi) && printf 'yazi=%s\n' "$yz"
+yz=$(look yazi)
+# Beside Stormlight, which is where setup puts it and is regularly on no
+# PATH at all — without this, a machine reports yazi missing immediately
+# after being given one.
+if [ -z "$yz" ] && [ -n "$sl" ] && [ -x "$(dirname "$sl")/yazi" ]; then
+  yz="$(dirname "$sl")/yazi"
+fi
+[ -n "$yz" ] && printf 'yazi=%s\n' "$yz"
 for manager in brew apt-get dnf pacman apk; do
   if command -v "$manager" >/dev/null 2>&1; then printf 'package_manager=%s\n' "$manager"; break; fi
 done

--- a/internal/ui/overlay_test.go
+++ b/internal/ui/overlay_test.go
@@ -15,10 +15,11 @@ import (
 // fakeOverlaySession scripts one overlay program: a seeded terminal, a
 // recordable input side, and an exit the test fires by hand.
 type fakeOverlaySession struct {
-	seed   string
-	output chan pty.Message
-	exited chan int
-	answer string
+	seed      string
+	output    chan pty.Message
+	exited    chan int
+	answer    string
+	answerErr error
 
 	mu     sync.Mutex
 	writes []byte
@@ -34,7 +35,7 @@ func (f *fakeOverlaySession) Result(context.Context) (string, error) {
 	if f.closed {
 		return "", errClosedBeforeRead
 	}
-	return f.answer, nil
+	return f.answer, f.answerErr
 }
 
 var errClosedBeforeRead = errors.New("session was closed before its answer was read")
@@ -192,5 +193,62 @@ func TestOverlayExitReadsTheAnswerBack(t *testing.T) {
 	}
 	if !session.isClosed() {
 		t.Fatal("exit did not close the session")
+	}
+}
+
+// TestTheProgramsOwnReasonOutranksItsExitStatus: a picker that could not
+// find yazi writes why, and exits non-zero doing it. Reporting the status
+// instead threw away the only message worth reading — "Yazi exited with
+// status 1" explains nothing, and it was the first thing a real remote
+// host said.
+func TestTheProgramsOwnReasonOutranksItsExitStatus(t *testing.T) {
+	model := flowModelFixture(t, stubBackend{})
+	session := newFakeOverlaySession("seed")
+	session.answerErr = errors.New("yazi is not installed on devbox")
+	model = openFakeOverlay(t, model, session, overlaySpec{
+		title:   "Yazi",
+		cleanup: func() {},
+		result: func(answer string, err error) tea.Msg {
+			return directoryPickedMsg{path: answer, err: err}
+		},
+	})
+
+	updated, cmd := model.handleOverlayExited(overlayExitedMsg{
+		generation: model.overlay.generation,
+		code:       1,
+	})
+	_ = updated
+	picked, ok := cmd().(directoryPickedMsg)
+	if !ok || picked.err == nil {
+		t.Fatalf("exit result = %#v", picked)
+	}
+	if !strings.Contains(picked.err.Error(), "not installed on devbox") {
+		t.Fatalf("want the program's own reason, got %v", picked.err)
+	}
+	if strings.Contains(picked.err.Error(), "status 1") {
+		t.Fatalf("the status should not stand in for a reason: %v", picked.err)
+	}
+}
+
+// TestAFailureWithNothingToSayStillReports: a program that died without
+// writing a reason has only its status to offer.
+func TestAFailureWithNothingToSayStillReports(t *testing.T) {
+	model := flowModelFixture(t, stubBackend{})
+	session := newFakeOverlaySession("seed")
+	model = openFakeOverlay(t, model, session, overlaySpec{
+		title:   "Yazi",
+		cleanup: func() {},
+		result: func(answer string, err error) tea.Msg {
+			return directoryPickedMsg{path: answer, err: err}
+		},
+	})
+
+	_, cmd := model.handleOverlayExited(overlayExitedMsg{
+		generation: model.overlay.generation,
+		code:       1,
+	})
+	picked, ok := cmd().(directoryPickedMsg)
+	if !ok || picked.err == nil || !strings.Contains(picked.err.Error(), "status 1") {
+		t.Fatalf("exit result = %#v", picked)
 	}
 }

--- a/internal/ui/overlays.go
+++ b/internal/ui/overlays.go
@@ -136,12 +136,17 @@ func (m Model) handleOverlayExited(msg overlayExitedMsg) (tea.Model, tea.Cmd) {
 		// the session is where the answer is.
 		answer, answerErr := view.session.Result(context.Background())
 		view.widget.Close()
+		// The program's own account of what went wrong outranks its exit
+		// status, and it is written precisely when the status is not zero
+		// — checking the status first threw away the only message worth
+		// reading, leaving "exited with status 1" to explain a missing
+		// yazi.
+		if answerErr != nil {
+			return view.spec.result("", answerErr)
+		}
 		if msg.code != 0 {
 			return view.spec.result("", fmt.Errorf(
 				"%s exited with status %d", strings.TrimSpace(view.spec.title), msg.code))
-		}
-		if answerErr != nil {
-			return view.spec.result("", answerErr)
 		}
 		return view.spec.result(answer, nil)
 	}


### PR DESCRIPTION
Fixes #159. Installing yazi on a remote host and then failing to browse it with
`Yazi exited with status 1` is two faults meeting.

## It was looked for where it was not

`remote setup` installs yazi beside Stormlight, in `~/.local/bin` — a directory
regularly on no PATH at all. Absent from what a non-interactive `ssh host
command` gets, and often from the login shell too, because the profile that
would add it checks whether the directory exists and it did not at login.

So the picker installed a yazi it could not then find. The probe had the same
blind spot, so a machine reported yazi missing immediately after being given
one. Both look beside the running binary now, which is exactly where setup put
it.

Verified by running the probe script with `PATH` stripped and the login shell
neutered: it finds the neighbour, and still reports missing when the neighbour
is removed.

## The message said nothing

`_pick` records why it could not run into its own session, precisely so a popup
that closes can still be explained. The exit status was checked first and
returned instead — throwing the reason away in the one case where it exists,
since a program that writes a reason is a program that exits non-zero.

The program's own account outranks its status now; a failure with nothing to say
still reports the status, because that is all there is.

This is *which* error gets produced, not how it is displayed — no overlap with
#154, which does not touch `handleOverlayExited` and shares no files with this.
The two compose: #154 gives errors a card, and this gives that card something
worth reading.

## Testing

`go test ./...` and `go vet ./...` green. New coverage: yazi found beside the
running binary when nothing else has it; the program's reason outranks its exit
status; a failure with nothing to say still reports the status.

## Related, still open

#158 — the gnu build fetched for a host may want a newer glibc than that host
has. Different failure, not addressed here.