### PR TITLE
A binary is installed only once the host can run it

### DIFF
--- a/internal/remote/install.go
+++ b/internal/remote/install.go
@@ -175,7 +175,20 @@ const yaziRelease = "https://api.github.com/repos/sxyazi/yazi/releases/latest"
 
 // yaziTriple names a platform the way Rust does, which is how Yazi's
 // archives are named.
-func yaziTriple(target Target, musl bool) (string, bool) {
+//
+// Linux always gets the musl build, whatever the host's libc. Not because
+// musl is better, but because that archive is statically linked and the
+// gnu one is not: the gnu build of Yazi is compiled against whatever
+// glibc its own builder had — 2.39 at the time of writing — and refuses
+// to start on anything older. Amazon Linux 2023 ships glibc 2.34, so the
+// "correct" build for it was the one that could not run:
+//
+//	yazi: /lib64/libc.so.6: version `GLIBC_2.39' not found
+//
+// A static binary has no such opinion about the machine it lands on,
+// which is the only useful property when the machine is not this one and
+// its libc was never asked about.
+func yaziTriple(target Target, _ bool) (string, bool) {
 	arch := ""
 	switch target.Arch {
 	case "arm64":
@@ -189,10 +202,7 @@ func yaziTriple(target Target, musl bool) (string, bool) {
 	case "darwin":
 		return arch + "-apple-darwin", true
 	case "linux":
-		if musl {
-			return arch + "-unknown-linux-musl", true
-		}
-		return arch + "-unknown-linux-gnu", true
+		return arch + "-unknown-linux-musl", true
 	}
 	return "", false
 }

--- a/internal/remote/setup.go
+++ b/internal/remote/setup.go
@@ -58,6 +58,13 @@ look() {
   [ -n "$SHELL" ] && "$SHELL" -lc "command -v $1" 2>/dev/null && return 0
   return 1
 }
+# A file that will not start is not an installed program. A binary built
+# against a newer libc than this machine has exists, is executable, and
+# fails before main — reporting it present is how a host looks ready and
+# then cannot browse.
+runs() {
+  [ -n "$1" ] && "$1" --version >/dev/null 2>&1
+}
 printf 'platform=%s\n' "$(uname -sm)"
 printf 'home=%s\n' "$HOME"
 if [ -e /lib/ld-musl-x86_64.so.1 ] || [ -e /lib/ld-musl-aarch64.so.1 ] || \
@@ -72,6 +79,7 @@ if [ -n "$STORMLIGHT_CONFIGURED_BIN" ]; then
 else
   sl=$(look stormlight)
 fi
+runs "$sl" || sl=""
 [ -n "$sl" ] && printf 'stormlight=%s\n' "$sl"
 [ -n "$sl" ] && printf 'stormlight_version=%s\n' "$("$sl" --version 2>/dev/null | head -1)"
 yz=$(look yazi)
@@ -81,6 +89,7 @@ yz=$(look yazi)
 if [ -z "$yz" ] && [ -n "$sl" ] && [ -x "$(dirname "$sl")/yazi" ]; then
   yz="$(dirname "$sl")/yazi"
 fi
+runs "$yz" || yz=""
 [ -n "$yz" ] && printf 'yazi=%s\n' "$yz"
 for manager in brew apt-get dnf pacman apk; do
   if command -v "$manager" >/dev/null 2>&1; then printf 'package_manager=%s\n' "$manager"; break; fi
@@ -317,11 +326,17 @@ func InstallYazi(
 		if err := copyIn.Run(); err != nil {
 			return fmt.Errorf("copy %s to %s: %w", name, report.Host, err)
 		}
+		// Started once before it is called installed: a binary the host
+		// cannot run is not an installation, and finding that out here
+		// beats finding it out inside a popup that has already closed.
 		finish := transport.ShellCommand(ctx, fmt.Sprintf(
-			"set -e\nchmod 0755 %[1]q.new\nmv %[1]q.new %[1]q\n", destination))
+			"set -e\nchmod 0755 %[1]q.new\nmv %[1]q.new %[1]q\n%[1]q --version\n",
+			destination))
 		finish.Stdout, finish.Stderr = progress, progress
 		if err := finish.Run(); err != nil {
-			return fmt.Errorf("install %s on %s: %w", name, report.Host, err)
+			return fmt.Errorf(
+				"%s cannot run the %s just installed at %s: %w",
+				report.Host, name, destination, err)
 		}
 	}
 	return nil

--- a/internal/remote/setup_test.go
+++ b/internal/remote/setup_test.go
@@ -188,23 +188,36 @@ func TestYaziIsOnlySuggestedWhereItIsPackaged(t *testing.T) {
 	}
 }
 
-// TestYaziTriplesMatchWhatItPublishes: Rust names platforms a third way,
-// and musl is a different binary rather than a slower one.
-func TestYaziTriplesMatchWhatItPublishes(t *testing.T) {
+// TestLinuxAlwaysGetsTheStaticBuild: the gnu archive is linked against
+// whatever glibc built it — 2.39 — and will not start on anything older.
+// Amazon Linux 2023 has 2.34, so the build that matched its libc was the
+// one that could not run. The musl archive is statically linked and has
+// no opinion about the machine it lands on, which is the only useful
+// property when that machine is not this one.
+func TestLinuxAlwaysGetsTheStaticBuild(t *testing.T) {
 	for _, test := range []struct {
 		target Target
 		musl   bool
 		want   string
 	}{
-		{Target{"linux", "arm64"}, false, "aarch64-unknown-linux-gnu"},
-		{Target{"linux", "amd64"}, false, "x86_64-unknown-linux-gnu"},
+		{Target{"linux", "arm64"}, false, "aarch64-unknown-linux-musl"},
+		{Target{"linux", "amd64"}, false, "x86_64-unknown-linux-musl"},
 		{Target{"linux", "amd64"}, true, "x86_64-unknown-linux-musl"},
 		{Target{"darwin", "arm64"}, false, "aarch64-apple-darwin"},
+		{Target{"darwin", "amd64"}, false, "x86_64-apple-darwin"},
 	} {
 		got, ok := yaziTriple(test.target, test.musl)
 		if !ok || got != test.want {
 			t.Fatalf("%v musl=%v → %q, want %q", test.target, test.musl, got, test.want)
 		}
+	}
+	// What the host reports about its libc no longer decides anything on
+	// Linux, which is the point: it was the deciding input that produced
+	// an unrunnable binary.
+	withMusl, _ := yaziTriple(Target{"linux", "arm64"}, true)
+	withGlibc, _ := yaziTriple(Target{"linux", "arm64"}, false)
+	if withMusl != withGlibc {
+		t.Fatalf("libc should not change the answer: %q vs %q", withMusl, withGlibc)
 	}
 }
 
@@ -225,5 +238,31 @@ func TestScriptsDoNotDependOnTheLoginShell(t *testing.T) {
 	}
 	if command.Stdin == nil {
 		t.Fatal("the script travels on stdin")
+	}
+}
+
+// TestPresenceMeansItRuns: a binary built against a newer libc than the
+// host has exists, is executable, and fails before main. Reporting it
+// present is how a machine looks ready and then cannot browse.
+func TestPresenceMeansItRuns(t *testing.T) {
+	directory := t.TempDir()
+	broken := filepath.Join(directory, "stormlight")
+	if err := os.WriteFile(broken, []byte("#!/bin/sh\nexit 1\n"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	working := filepath.Join(directory, "yazi")
+	if err := os.WriteFile(working, []byte("#!/bin/sh\necho yazi 1.0\n"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+
+	// The probe script, run the way the host runs it.
+	transport := fakeSSH(t, `exec /bin/sh -s`)
+	transport.host.Bin = broken
+	report, err := Probe(context.Background(), transport)
+	if err != nil {
+		t.Fatalf("Probe: %v", err)
+	}
+	if report.Stormlight.Present() {
+		t.Fatal("a binary that will not start is not an installed program")
 	}
 }


### PR DESCRIPTION
Fixes #158 — the two parts of it that #160 did not.

The report was right on all three counts, so this is mostly its analysis carried
out.

## Linux gets the static build

Yazi's gnu archive is linked against whatever glibc built it — 2.39 — and
refuses to start on anything older. Amazon Linux 2023 ships 2.34, so the build
chosen *for matching that host's libc* was precisely the one it could not
execute.

Checked rather than assumed, since assuming is what produced the dnf bug:

```
gnu:  ELF 64-bit LSB pie executable, dynamically linked,
      interpreter /lib/ld-linux-aarch64.so.1, for GNU/Linux 3.7.0
musl: ELF 64-bit LSB executable, statically linked
```

So Linux gets the musl archive now, whatever the host's libc. Not because musl
is better — because it is static, and a static binary has no opinion about the
machine it lands on. That is the only useful property when the machine is not
this one and its libc was never asked about.

Detecting musl no longer decides anything on Linux, which is the point: it was
the deciding input that produced an unrunnable binary. The probe still reports
it; nothing acts on it.

## Presence means it starts

The probe found a path and called it installed — which is how the host reported
Yazi ready and then could not browse. Installing pushed a file and called it
done.

Both run the binary once now and treat a failure to start as absence. A machine
cannot be ready on the strength of a file that will not execute.

## The third part

The diagnostic defect the report identified — `handleOverlayExited` checking the
exit code before the recorded reason, replacing "yazi is not installed" with
"Yazi exited with status 1" — was fixed in #160, which is merged.

## Testing

`go test ./...` and `go vet ./...` green. New coverage: every Linux target
resolves to musl and the host's libc does not change the answer; a binary that
exits non-zero is reported absent rather than present.

**Against the real archives**: a fetch for a glibc host now returns a
statically linked ELF.

## Not covered

The install onto the affected host itself. Everything up to "static binary in
hand, verified static" is exercised here; whether Amazon Linux 2023 then runs it
is the thing only that machine can answer — and it now reports a failure to
start rather than claiming success.