### PR TITLE
The seed says what size it was rendered at

### DIFF
--- a/bench.go
+++ b/bench.go
@@ -169,7 +169,13 @@ func newBenchStream(attachment *client.Attachment) benchStream {
 	return stream
 }
 
-func (b benchStream) Seed() []byte               { return b.attachment.Snapshot().ANSI }
+func (b benchStream) Seed() pty.Message {
+	snapshot := b.attachment.Snapshot()
+	return pty.Message{
+		Resync: snapshot.ANSI,
+		Resize: &pty.Size{Cols: snapshot.Cols, Rows: snapshot.Rows},
+	}
+}
 func (b benchStream) Output() <-chan pty.Message { return b.output }
 func (b benchStream) Write(p []byte) error       { return b.attachment.Write(p) }
 func (b benchStream) Resize(_ context.Context, cols, rows int) error {

--- a/internal/api/server_test.go
+++ b/internal/api/server_test.go
@@ -88,8 +88,9 @@ func (f *fakeRuntime) AttachTerminal(
 // fakeStream is one attached terminal: a seed, a channel the test pushes
 // output onto, and a record of what came back the other way.
 type fakeStream struct {
-	seed   []byte
-	output chan pty.Message
+	seed     []byte
+	seedSize *pty.Size
+	output   chan pty.Message
 
 	mu         sync.Mutex
 	written    []byte
@@ -101,7 +102,9 @@ type fakeStream struct {
 	closed  bool
 }
 
-func (f *fakeStream) Seed() []byte               { return f.seed }
+func (f *fakeStream) Seed() pty.Message {
+	return pty.Message{Resync: f.seed, Resize: f.seedSize}
+}
 func (f *fakeStream) Output() <-chan pty.Message { return f.output }
 func (f *fakeStream) Write(p []byte) error {
 	f.mu.Lock()
@@ -684,6 +687,33 @@ func TestTerminalRelayCarriesBytesBothWays(t *testing.T) {
 	runtime.mu.Unlock()
 	if len(streamed) != 1 || streamed[0] != "agent-one" {
 		t.Fatalf("attached to %#v", streamed)
+	}
+}
+
+// A client that named no size of its own — because its pane had not been
+// laid out, and a shared terminal is not a thing to reflow on a guess —
+// has no other way to learn the geometry its seed was wrapped for. The
+// size leads the state it belongs to.
+func TestTheSeedCarriesTheSizeItWasRenderedAt(t *testing.T) {
+	server, runtime := startAPI(t)
+	runtime.stream.seedSize = &pty.Size{Cols: 132, Rows: 43}
+
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+	address := "ws" + strings.TrimPrefix(server.URL, "http") +
+		"/api/agents/agent-one/terminal?token=" + testToken
+	conn, _, err := websocket.Dial(ctx, address, nil)
+	if err != nil {
+		t.Fatalf("dial: %v", err)
+	}
+	defer conn.CloseNow()
+
+	if notice := readControl(t, ctx, conn); notice.Type != controlResize ||
+		notice.Cols != 132 || notice.Rows != 43 {
+		t.Fatalf("first message = %#v, want the seed's 132x43", notice)
+	}
+	if notice := readControl(t, ctx, conn); notice.Type != controlSeed {
+		t.Fatalf("second message = %#v, want a seed notice", notice)
 	}
 }
 

--- a/internal/api/terminal.go
+++ b/internal/api/terminal.go
@@ -75,8 +75,11 @@ func (s *Server) terminal(w http.ResponseWriter, r *http.Request) {
 
 	// The daemon's snapshot is state, not output: it replaces whatever the
 	// replica had. Say so before sending it, so a reconnecting client
-	// never appends a screen to the one it was already showing.
-	if err := writeSeed(ctx, conn, transport.Seed()); err != nil {
+	// never appends a screen to the one it was already showing — and send
+	// the size it was rendered at first, because a client that named no
+	// geometry of its own has no other way to learn what these bytes were
+	// wrapped for.
+	if err := writeState(ctx, conn, transport.Seed()); err != nil {
 		return
 	}
 
@@ -97,29 +100,10 @@ func (s *Server) terminal(w http.ResponseWriter, r *http.Request) {
 				// resize branch below would otherwise swallow it.
 				//
 				// This viewer fell behind and the daemon sent state
-				// instead of the bytes it missed. Same shape as the
-				// opening seed, and for the same reason: the client
-				// replaces its replica rather than appending to it. The
-				// size goes first so the client sizes the replica it is
-				// about to fill — while a viewer is in debt the daemon
-				// sends nothing else, so this is the only place it can
-				// learn the terminal moved.
-				// Sent every time rather than only on a change. Tracking
-				// what the client last heard means tracking three things
-				// that move it — this branch, the resize branch, and the
-				// client resizing itself — and getting that wrong
-				// suppresses a size the browser actually needed. A few
-				// extra control frames cost nothing next to that.
-				if message.Resize != nil {
-					if err := writeControl(ctx, conn, controlMessage{
-						Type: controlResize,
-						Cols: message.Resize.Cols,
-						Rows: message.Resize.Rows,
-					}); err != nil {
-						return
-					}
-				}
-				if err := writeSeed(ctx, conn, message.Resync); err != nil {
+				// instead of the bytes it missed — the same shape as the
+				// opening seed, and written by the same function, because
+				// they are the same thing at different moments.
+				if err := writeState(ctx, conn, message); err != nil {
 					return
 				}
 				continue
@@ -226,11 +210,26 @@ func keepalive(ctx context.Context, cancel context.CancelFunc, conn *websocket.C
 	}
 }
 
-func writeSeed(ctx context.Context, conn *websocket.Conn, seed []byte) error {
+// writeState sends terminal state — the attach seed, or a resync — as the
+// size it was rendered at, then the notice, then the bytes.
+//
+// The size leads because the client has to size the replica it is about
+// to fill; the notice is what tells it these bytes replace rather than
+// extend.
+func writeState(ctx context.Context, conn *websocket.Conn, state pty.Message) error {
+	if state.Resize != nil {
+		if err := writeControl(ctx, conn, controlMessage{
+			Type: controlResize,
+			Cols: state.Resize.Cols,
+			Rows: state.Resize.Rows,
+		}); err != nil {
+			return err
+		}
+	}
 	if err := writeControl(ctx, conn, controlMessage{Type: controlSeed}); err != nil {
 		return err
 	}
-	return conn.Write(ctx, websocket.MessageBinary, seed)
+	return conn.Write(ctx, websocket.MessageBinary, state.Resync)
 }
 
 func writeControl(ctx context.Context, conn *websocket.Conn, message controlMessage) error {

--- a/internal/pty/terminal.go
+++ b/internal/pty/terminal.go
@@ -130,7 +130,11 @@ func New(transport Transport, gate *Gate, cols, rows int) Model {
 		cols: cols, rows: rows, termCols: cols, termRows: rows,
 		viewDirty: true,
 	}
-	s.replaceReplica(transport.Seed(), nil)
+	seed := transport.Seed()
+	// The seed names the size it was rendered at when the transport knows
+	// it, which is what lets a viewer that asserted no geometry of its own
+	// still paint the snapshot at the width it was wrapped for.
+	s.replaceReplica(seed.Resync, seed.Resize)
 	model := Model{id: lastID.Add(1), state: s}
 	go s.pump(model)
 	return model

--- a/internal/pty/terminal.go
+++ b/internal/pty/terminal.go
@@ -158,13 +158,21 @@ func (s *state) replaceReplica(seed []byte, size *Size) {
 	cols, rows := s.termCols, s.termRows
 	generation := s.sizeGeneration
 	s.mu.Unlock()
-	if size != nil {
+	if size != nil && size.Cols >= 2 && size.Rows >= 2 {
 		// The snapshot's bytes were rendered at this size, and the two
 		// are one thing: replaying them at any other width wraps them
 		// wrongly on purpose. An older size corrects itself, because
 		// every snapshot carries the daemon's live one and a viewer in
 		// debt receives one every interval until it catches up.
-		cols, rows = max(2, size.Cols), max(2, size.Rows)
+		//
+		// Refused rather than clamped when it names a size no terminal
+		// can be. Rounding a zero up to 2x2 is not a correction, it is a
+		// pane collapsed to a ribbon, and a Transport is free to build a
+		// size without the guard the daemon-backed one applies.
+		//
+		// The standalone resize below still clamps, so the two halves of
+		// this loop disagree; see #166.
+		cols, rows = size.Cols, size.Rows
 	}
 
 	// Built before the lock is taken. Parsing a full snapshot is tens of

--- a/internal/pty/terminal_test.go
+++ b/internal/pty/terminal_test.go
@@ -462,3 +462,54 @@ func goroutinesAtRest() int {
 	}
 	return runtime.NumGoroutine()
 }
+
+// The seed names the size its bytes were wrapped for, and the replica has
+// to be that size or it renders a snapshot mangled before it arrived.
+// This is the case the size exists for: a viewer that asserted no
+// geometry of its own, because its pane had not been laid out and the
+// terminal is shared with a dashboard that had.
+func TestTheSeedsSizeIsAdopted(t *testing.T) {
+	transport := newFakeTransport("wrapped for a wide terminal")
+	transport.seedSize = &Size{Cols: 132, Rows: 43}
+
+	terminal := New(transport, NewGate(), 80, 24)
+	defer terminal.Close()
+
+	if cols, rows := terminal.TerminalSize(); cols != 132 || rows != 43 {
+		t.Fatalf("emulator is %dx%d, want the seed's 132x43", cols, rows)
+	}
+	// The box belongs to the pane, not to the seed: View clips or pads
+	// the difference.
+	if cols, rows := terminal.Size(); cols != 80 || rows != 24 {
+		t.Fatalf("box became %dx%d; the pane owns the box", cols, rows)
+	}
+}
+
+// A transport that cannot say — one with no daemon behind it to ask —
+// must leave the caller's size alone rather than have one invented.
+func TestASeedWithNoSizeKeepsTheCallersOwn(t *testing.T) {
+	transport := newFakeTransport("no size to report")
+
+	terminal := New(transport, NewGate(), 100, 30)
+	defer terminal.Close()
+
+	if cols, rows := terminal.TerminalSize(); cols != 100 || rows != 30 {
+		t.Fatalf("emulator is %dx%d, want the caller's 100x30", cols, rows)
+	}
+}
+
+// A size no terminal can be is refused, not corrected. Clamping a zero
+// into a legal 2x2 is how a pane collapses to a ribbon: the rest of this
+// codebase refuses such sizes rather than rounding them up, and the seed
+// is the last place a bad one can enter.
+func TestADegenerateSeedSizeIsIgnored(t *testing.T) {
+	transport := newFakeTransport("state from somewhere confused")
+	transport.seedSize = &Size{Cols: 0, Rows: 0}
+
+	terminal := New(transport, NewGate(), 120, 40)
+	defer terminal.Close()
+
+	if cols, rows := terminal.TerminalSize(); cols != 120 || rows != 40 {
+		t.Fatalf("a 0x0 seed size produced a %dx%d replica", cols, rows)
+	}
+}

--- a/internal/pty/terminal_test.go
+++ b/internal/pty/terminal_test.go
@@ -12,16 +12,19 @@ import (
 )
 
 type fakeTransport struct {
-	seed   []byte
-	output chan Message
-	writes [][]byte
+	seed     []byte
+	seedSize *Size
+	output   chan Message
+	writes   [][]byte
 }
 
 func newFakeTransport(seed string) *fakeTransport {
 	return &fakeTransport{seed: []byte(seed), output: make(chan Message)}
 }
 
-func (t *fakeTransport) Seed() []byte                           { return t.seed }
+func (t *fakeTransport) Seed() Message {
+	return Message{Resync: t.seed, Resize: t.seedSize}
+}
 func (t *fakeTransport) Output() <-chan Message                 { return t.output }
 func (t *fakeTransport) Write(data []byte) error                { t.writes = append(t.writes, data); return nil }
 func (t *fakeTransport) Resize(context.Context, int, int) error { return nil }

--- a/internal/pty/transport.go
+++ b/internal/pty/transport.go
@@ -4,7 +4,19 @@ import "context"
 
 // Transport supplies a terminal snapshot, its live stream, and I/O.
 type Transport interface {
-	Seed() []byte
+	// Seed is the terminal's exact state at attach time, carrying the
+	// size it was rendered at.
+	//
+	// The size is not decoration. A viewer that attaches without naming
+	// one — because it has not been laid out, and a terminal shared with
+	// other viewers is not a thing to reflow on a guess — has no other
+	// way to learn the geometry those bytes were wrapped for. Painting
+	// them at its own assumption is how a snapshot arrives pre-mangled.
+	//
+	// It is a Message because that is what it is: a seed and a resync are
+	// the same thing arriving at different moments, and giving them one
+	// shape means a consumer that handles either handles both.
+	Seed() Message
 	Output() <-chan Message
 	Write([]byte) error
 	Resize(context.Context, int, int) error

--- a/internal/ui/overlay_test.go
+++ b/internal/ui/overlay_test.go
@@ -48,7 +48,9 @@ func newFakeOverlaySession(seed string) *fakeOverlaySession {
 	}
 }
 
-func (f *fakeOverlaySession) Seed() []byte               { return []byte(f.seed) }
+func (f *fakeOverlaySession) Seed() pty.Message {
+	return pty.Message{Resync: []byte(f.seed)}
+}
 func (f *fakeOverlaySession) Output() <-chan pty.Message { return f.output }
 func (f *fakeOverlaySession) Exited() <-chan int         { return f.exited }
 func (f *fakeOverlaySession) Write(p []byte) error {

--- a/internal/windrun/remote_test.go
+++ b/internal/windrun/remote_test.go
@@ -187,8 +187,8 @@ func TestRemoteRosterAndTerminalCrossTheBridge(t *testing.T) {
 		t.Fatalf("AttachTerminal: %v", err)
 	}
 	defer stream.Close()
-	if !strings.Contains(string(stream.Seed()), "heard:over the bridge") {
-		t.Fatalf("attachment seed lost the story:\n%s", stream.Seed())
+	if !strings.Contains(string(stream.Seed().Resync), "heard:over the bridge") {
+		t.Fatalf("attachment seed lost the story:\n%s", stream.Seed().Resync)
 	}
 
 	if err := runtime.Delete(context.Background(), dispatched.ID); err != nil {
@@ -337,7 +337,7 @@ func answerTheOverlay(t *testing.T, runtime *Runtime, answer string) {
 
 func drainOverlay(t *testing.T, overlay session.Overlay, want string) string {
 	t.Helper()
-	collected := string(overlay.Seed())
+	collected := string(overlay.Seed().Resync)
 	deadline := time.After(10 * time.Second)
 	for !strings.Contains(collected, want) {
 		select {

--- a/internal/windrun/stream.go
+++ b/internal/windrun/stream.go
@@ -96,8 +96,12 @@ type terminalStream struct {
 	closeOnce sync.Once
 }
 
-func (t *terminalStream) Seed() []byte {
-	return t.attachment.Snapshot().ANSI
+func (t *terminalStream) Seed() pty.Message {
+	snapshot := t.attachment.Snapshot()
+	return pty.Message{
+		Resync: snapshot.ANSI,
+		Resize: snapshotSize(&snapshot),
+	}
 }
 
 // relay carries the daemon's stream across into the widget's, preserving

--- a/internal/windrun/stream_test.go
+++ b/internal/windrun/stream_test.go
@@ -171,6 +171,47 @@ func TestAttachWithoutASizeLeavesTheTerminalAlone(t *testing.T) {
 	}
 }
 
+// The snapshot's bytes are wrapped for a width, and the seed has to say
+// which — otherwise a viewer that asserted no geometry paints them at its
+// own assumption, which is how a snapshot arrives pre-mangled.
+func TestTheSeedNamesTheSizeItWasRenderedAt(t *testing.T) {
+	runtime := remoteRuntime(t)
+
+	dispatched, err := runtime.Dispatch(context.Background(), session.DispatchRequest{
+		Provider: agent.Provider("claude"),
+		Name:     "seeded",
+		Task:     "hold a terminal",
+		Cwd:      t.TempDir(),
+		Launch:   session.Launch{Path: "/bin/sh", Args: []string{"-c", "sleep 60"}},
+	})
+	if err != nil {
+		t.Fatalf("Dispatch: %v", err)
+	}
+
+	sized, err := runtime.AttachTerminal(context.Background(), dispatched.ID, 132, 43)
+	if err != nil {
+		t.Fatalf("AttachTerminal: %v", err)
+	}
+	defer sized.Close()
+	waitForSize(t, runtime, dispatched.ID, 132, 43)
+
+	// A second viewer, naming nothing — the case the size exists for.
+	blind, err := runtime.AttachTerminal(context.Background(), dispatched.ID, 0, 0)
+	if err != nil {
+		t.Fatalf("AttachTerminal without a size: %v", err)
+	}
+	defer blind.Close()
+
+	seed := blind.Seed()
+	if seed.Resize == nil {
+		t.Fatal("the seed named no size, so a viewer has nothing to paint it at")
+	}
+	if seed.Resize.Cols != 132 || seed.Resize.Rows != 43 {
+		t.Fatalf("seed size = %dx%d, want the terminal's 132x43",
+			seed.Resize.Cols, seed.Resize.Rows)
+	}
+}
+
 func sessionSize(t *testing.T, runtime *Runtime, id string) (int, int) {
 	t.Helper()
 	sessionID, err := runtime.sessionIDFor(id)

--- a/web/src/lib/terminal.test.ts
+++ b/web/src/lib/terminal.test.ts
@@ -147,12 +147,17 @@ describe("state and output", () => {
     const { term, socket } = setup({ laidOut: false });
     socket().open();
 
+    // Output first, so the size has something to be ordered against: a
+    // resize applied in front of the queue would reflow this, and the
+    // assertion would see it land before rather than after.
+    socket().deliverBytes("from the old size");
     socket().deliverControl({ type: "resize", cols: 132, rows: 43 });
     socket().deliverControl({ type: "seed" });
     socket().deliverBytes("wrapped for 132 columns");
     term.drain();
 
     expect(term.calls).toEqual([
+      'write:"from the old size"',
       "resize:132x43",
       'write:"\\u001bc"',
       'write:"wrapped for 132 columns"',

--- a/web/src/lib/terminal.test.ts
+++ b/web/src/lib/terminal.test.ts
@@ -140,6 +140,25 @@ describe("attaching", () => {
 });
 
 describe("state and output", () => {
+  // A viewer that named no size has no other way to learn what its seed
+  // was wrapped for. The size arrives just ahead of the state, and the
+  // replica has to be that size before those bytes land in it.
+  test("a seed is sized before it is painted", () => {
+    const { term, socket } = setup({ laidOut: false });
+    socket().open();
+
+    socket().deliverControl({ type: "resize", cols: 132, rows: 43 });
+    socket().deliverControl({ type: "seed" });
+    socket().deliverBytes("wrapped for 132 columns");
+    term.drain();
+
+    expect(term.calls).toEqual([
+      "resize:132x43",
+      'write:"\\u001bc"',
+      'write:"wrapped for 132 columns"',
+    ]);
+  });
+
   test("a seed replaces the replica rather than extending it", () => {
     const { term, socket } = setup();
     socket().open();

--- a/web/src/lib/terminal.ts
+++ b/web/src/lib/terminal.ts
@@ -139,6 +139,10 @@ export function attach(
           // this the next fit() measures the same grid, compares it to a
           // stale record, and quietly snaps the replica back to a size
           // nobody else is using.
+          //
+          // This is also how a viewer that asserted nothing learns the
+          // geometry its seed was wrapped for: the size arrives just
+          // ahead of the state it belongs to.
           announced = { cols, rows };
         }
         return;


### PR DESCRIPTION
Fixes #142. Prerequisite for the wall in #152.

A viewer that names no geometry — because its pane has not been laid out, and a terminal shared with other viewers is not a thing to reflow on a guess (#155) — had no way to learn the width its snapshot was wrapped for. It painted those bytes at its own assumption, which is a snapshot arriving pre-mangled.

`pty.Transport.Seed()` returns a `Message` now, because that is what a seed is: a seed and a resync are the same thing arriving at different moments, and giving them one shape means a consumer that handles either handles both. The API writes both through one `writeState` — size, then the notice, then the bytes — which also removed a duplicated resize the previous shape had grown.

**Why now:** this is what the wall needs. Cells there must attach *without* asserting a size, or a grid of small panes reflows the entire fleet — and that only works if the seed carries the geometry they declined to ask for.

## Verification

Four new tests, each validated by reverting its fix:
- `windrun`: a second viewer attaching with no size still gets a seed naming the terminal's real 132x43 (against a real daemon).
- `api`: the attach sends resize-then-seed when the seed has a size.
- `web`: a seed is sized before it is painted (the replica must be that size before those bytes land in it).
- Plus the existing 15 frontend tests and the Go suite.

`go test -race ./...`, `npm test`, `npm run check` all green.

TUI non-regression per CLAUDE.md, since this changes `internal/pty`: built this branch and `main`, ran both in the tmux harness with a live agent streaming into the Spanreed pane, and diffed captures — identical. Then opened the Yazi picker on both and diffed again — also identical. (The overlay check is there because a dead picker is exactly what a previous transport change broke, invisibly, in #136.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)