### PR TITLE
Make the foreign-platform test runner-independent

### DIFF
--- a/internal/remote/setup_test.go
+++ b/internal/remote/setup_test.go
@@ -96,13 +96,19 @@ func TestAForeignPlatformGetsItsOwnBuild(t *testing.T) {
 	if !(Report{Platform: local}).CanCopyBinary() {
 		t.Fatal("the same platform should be copyable")
 	}
-	foreign := Report{Host: "devbox", Platform: "Linux aarch64"}
+	foreignPlatform := "Linux aarch64"
+	want := Target{OS: "linux", Arch: "arm64"}
+	if localTarget, ok := TargetFor(local); ok && localTarget == want {
+		foreignPlatform = "Darwin arm64"
+		want.OS = "darwin"
+	}
+	foreign := Report{Host: "devbox", Platform: foreignPlatform}
 	if foreign.CanCopyBinary() {
 		t.Fatal("a different platform must not be copied to")
 	}
 	target, ok := foreign.Target()
-	if !ok || target.OS != "linux" || target.Arch != "arm64" {
-		t.Fatalf("target = %+v, ok = %v", target, ok)
+	if !ok || target != want {
+		t.Fatalf("target = %+v, ok = %v, want %+v", target, ok, want)
 	}
 }
 


### PR DESCRIPTION
## Summary

- choose a supported foreign platform relative to the test runner
- keep asserting that same-platform binaries are copied and foreign builds are targeted correctly

## Root cause

`TestAForeignPlatformGetsItsOwnBuild` hardcoded `Linux aarch64` as foreign. On a Linux/arm64 runner, that is the local platform, so the test failed despite correct production behavior.

## Validation

- `go test ./internal/remote -run '^TestAForeignPlatformGetsItsOwnBuild$' -count=10 -v`\n- `CGO_ENABLED=1 go test -race ./...`\n- `go vet ./...`\n- `go build ./...`\n- `npm run build --prefix web`\n- `npm run check --prefix web`\n- `npm test --prefix web`