### PR TITLE
The provider is resolved where it will run, and lookalike workspaces are told apart

### DIFF
--- a/internal/provider/provider.go
+++ b/internal/provider/provider.go
@@ -110,7 +110,7 @@ func (a commandAdapter) launch(
 	if err != nil {
 		return Launch{}, err
 	}
-	return Launch{Path: path, Args: a.withExtra(args)}, nil
+	return Launch{Path: path, Program: a.binary, Args: a.withExtra(args)}, nil
 }
 
 // withExtra slots the user's extra args in just before the final argument.

--- a/internal/remote/install.go
+++ b/internal/remote/install.go
@@ -23,10 +23,20 @@ import (
 // checked here, rather than a URL handed to it to trust on its own.
 const releaseHost = "https://github.com/trentkm/stormlight/releases/download"
 
-// downloadTimeout bounds fetching one archive. They are tens of
-// megabytes; a minute is generous and a stall is not a thing to wait out
-// inside a popup.
-const downloadTimeout = 60 * time.Second
+// Fetching has two shapes and they want different patience. Asking a
+// release what it published is a couple of kilobytes: slow means broken.
+// Pulling an archive is tens of megabytes over whatever connection the
+// dashboard happens to be on, and a minute was optimistic enough that an
+// ordinary home network failed it — `context deadline exceeded` on a
+// download that was working.
+//
+// A total deadline is the wrong instrument for the second: it turns a
+// slow link into a failure rather than a wait. Generous is the right
+// setting when the alternative is refusing to install at all.
+const (
+	metadataTimeout = 30 * time.Second
+	archiveTimeout  = 10 * time.Minute
+)
 
 // Target is a platform in the naming published builds use.
 type Target struct {
@@ -86,7 +96,7 @@ func releaseBinary(ctx context.Context, version string, target Target) ([]byte, 
 	archive := fmt.Sprintf("stormlight_%s_%s_%s.tar.gz", number, target.OS, target.Arch)
 	base := fmt.Sprintf("%s/v%s", releaseHost, number)
 
-	sums, err := fetch(ctx, base+"/checksums.txt")
+	sums, err := fetch(ctx, base+"/checksums.txt", metadataTimeout)
 	if err != nil {
 		return nil, fmt.Errorf("read the release checksums: %w", err)
 	}
@@ -96,7 +106,7 @@ func releaseBinary(ctx context.Context, version string, target Target) ([]byte, 
 			"release v%s publishes nothing for %s", number, target)
 	}
 
-	payload, err := fetch(ctx, base+"/"+archive)
+	payload, err := fetch(ctx, base+"/"+archive, archiveTimeout)
 	if err != nil {
 		return nil, fmt.Errorf("download %s: %w", archive, err)
 	}
@@ -109,8 +119,8 @@ func releaseBinary(ctx context.Context, version string, target Target) ([]byte, 
 	return binaryFromArchive(payload)
 }
 
-func fetch(ctx context.Context, url string) ([]byte, error) {
-	ctx, cancel := context.WithTimeout(ctx, downloadTimeout)
+func fetch(ctx context.Context, url string, timeout time.Duration) ([]byte, error) {
+	ctx, cancel := context.WithTimeout(ctx, timeout)
 	defer cancel()
 	request, err := http.NewRequestWithContext(ctx, http.MethodGet, url, nil)
 	if err != nil {
@@ -221,7 +231,7 @@ func YaziBinaries(ctx context.Context, target Target, musl bool) (map[string][]b
 	if !ok {
 		return nil, fmt.Errorf("yazi publishes no build for %s", target)
 	}
-	metadata, err := fetch(ctx, yaziRelease)
+	metadata, err := fetch(ctx, yaziRelease, metadataTimeout)
 	if err != nil {
 		return nil, fmt.Errorf("ask what yazi has published: %w", err)
 	}
@@ -247,7 +257,7 @@ func YaziBinaries(ctx context.Context, target Target, musl bool) (map[string][]b
 		return nil, fmt.Errorf("yazi %s publishes no %s", release.Tag, want)
 	}
 
-	payload, err := fetch(ctx, url)
+	payload, err := fetch(ctx, url, archiveTimeout)
 	if err != nil {
 		return nil, fmt.Errorf("download %s: %w", want, err)
 	}

--- a/internal/remote/setup.go
+++ b/internal/remote/setup.go
@@ -3,6 +3,7 @@ package remote
 import (
 	"bytes"
 	"context"
+	"errors"
 	"fmt"
 	"io"
 	"os/exec"
@@ -350,4 +351,49 @@ func localPlatform() (string, error) {
 		return "", err
 	}
 	return strings.TrimSpace(string(output)), nil
+}
+
+// LookPath finds a program on the host, the way a person would.
+//
+// A command run over ssh gets a non-interactive shell whose PATH is
+// often the bare system one, so the login shell is asked too — the
+// difference between finding a provider a machine plainly has and
+// reporting it absent. The binary is started once, because a name that
+// resolves to something that cannot run is not an answer.
+func LookPath(ctx context.Context, transport *Transport, program string) (string, error) {
+	if strings.TrimSpace(program) == "" {
+		return "", fmt.Errorf("no program to look for")
+	}
+	host := transport.Host().Name
+	// Ends with a plain exit 0: not finding the program is an answer,
+	// not a failure of the asking, and a script whose last command is a
+	// test would exit non-zero and be read as one.
+	script := "program=" + shellQuote([]string{program}) + `
+found=$(command -v "$program" 2>/dev/null)
+if [ -z "$found" ] && [ -n "$SHELL" ]; then
+  found=$("$SHELL" -lc "command -v $program" 2>/dev/null)
+fi
+if [ -n "$found" ]; then printf '%s\n' "$found"; fi
+exit 0
+`
+	command := transport.ShellCommand(ctx, script)
+	var stdout, stderr bytes.Buffer
+	command.Stdout = &stdout
+	command.Stderr = &stderr
+	if err := command.Run(); err != nil {
+		if ctx.Err() != nil {
+			return "", ctx.Err()
+		}
+		if message := strings.TrimSpace(stderr.String()); message != "" {
+			return "", errors.New(Explain(host, message))
+		}
+		return "", fmt.Errorf("%s: %w", host, err)
+	}
+	found := strings.TrimSpace(stdout.String())
+	if found == "" {
+		return "", fmt.Errorf(
+			"%s is not installed on %s, or not on the PATH its login shell sets",
+			program, host)
+	}
+	return found, nil
 }

--- a/internal/remote/setup_test.go
+++ b/internal/remote/setup_test.go
@@ -6,6 +6,7 @@ import (
 	"path/filepath"
 	"strings"
 	"testing"
+	"time"
 )
 
 // fakeSSH stands in for the ssh client: whatever the script prints is
@@ -264,5 +265,21 @@ func TestPresenceMeansItRuns(t *testing.T) {
 	}
 	if report.Stormlight.Present() {
 		t.Fatal("a binary that will not start is not an installed program")
+	}
+}
+
+// TestAnArchiveGetsLongerThanAQuestion: asking a release what it
+// published is kilobytes, and slow means broken. Pulling the archive is
+// tens of megabytes over whatever connection the dashboard is on, and a
+// minute was optimistic enough that an ordinary home network failed a
+// download that was working.
+func TestAnArchiveGetsLongerThanAQuestion(t *testing.T) {
+	if archiveTimeout <= metadataTimeout {
+		t.Fatalf("an archive should get more patience than a question: %v vs %v",
+			archiveTimeout, metadataTimeout)
+	}
+	if archiveTimeout < 5*time.Minute {
+		t.Fatalf("archiveTimeout = %v; a slow link should be waited out, not failed",
+			archiveTimeout)
 	}
 }

--- a/internal/session/runtime.go
+++ b/internal/session/runtime.go
@@ -115,8 +115,17 @@ type DispatchRequest struct {
 }
 
 type Launch struct {
-	Path string   `json:"path"`
-	Args []string `json:"args"`
+	// Path is the provider resolved on this machine.
+	Path string `json:"path"`
+	// Program is the name it was resolved from — `codex`, `claude`, or
+	// whatever a custom provider spec names.
+	//
+	// Path answers "where is it here", which is the wrong question for a
+	// machine that is not here: /Users/someone/.toolbox/bin/codex is a
+	// macOS path, and a Linux daemon handed it can only report that no
+	// such file exists. The name is the part that travels.
+	Program string   `json:"program,omitempty"`
+	Args    []string `json:"args"`
 }
 
 type Update struct {

--- a/internal/ui/machine_test.go
+++ b/internal/ui/machine_test.go
@@ -6,6 +6,7 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/trentkm/stormlight/internal/agent"
 	"github.com/trentkm/stormlight/internal/workspace"
 )
 
@@ -367,5 +368,84 @@ func TestALateAnswerForAnotherMachineIsIgnored(t *testing.T) {
 		host: "somewhere-else", status: HostStatus{Ready: false}})
 	if got := updated.(Model).renderMachineStatus(70); got != before {
 		t.Fatalf("a late answer for another machine changed this one: %q", got)
+	}
+}
+
+// TestACatalogedParentAndItsNestedRepoAreTellable: a catalogued parent
+// directory and a Git repository inside it both end in the same
+// basename, so the pane showed two rows spelled identically with the
+// agents apparently on the wrong one. They are different workspaces —
+// the identities are right — so they have to be readable as different.
+func TestACatalogedParentAndItsNestedRepoAreTellable(t *testing.T) {
+	parent := workspace.Context{
+		Host: "cld2", ID: "cld2:directory:/home/t/workplace/MetaRepo-PFS",
+		Kind: "directory", Name: "MetaRepo-PFS",
+		Root:          "/home/t/workplace/MetaRepo-PFS",
+		ExecutionRoot: "/home/t/workplace/MetaRepo-PFS",
+	}
+	nested := workspace.Context{
+		Host: "cld2", ID: "cld2:git:/home/t/workplace/MetaRepo-PFS/src/MetaRepo-PFS/.git",
+		Kind: "git", Name: "MetaRepo-PFS",
+		Root:          "/home/t/workplace/MetaRepo-PFS/src/MetaRepo-PFS",
+		ExecutionRoot: "/home/t/workplace/MetaRepo-PFS/src/MetaRepo-PFS",
+	}
+
+	groups := buildWorkspaceGroups(
+		[]workspace.Context{parent},
+		[]agent.Agent{{ID: "aaa", Host: "cld2", Workspace: nested}},
+	)
+	if len(groups) != 2 {
+		t.Fatalf("both workspaces belong on screen: %+v", groups)
+	}
+	if groups[0].label == groups[1].label {
+		t.Fatalf("two rows spelled the same way: %q", groups[0].label)
+	}
+	if groups[0].label != "workplace/MetaRepo-PFS" ||
+		groups[1].label != "src/MetaRepo-PFS" {
+		t.Fatalf("labels = %q, %q", groups[0].label, groups[1].label)
+	}
+	// The agent stays where it was; nothing was merged or moved.
+	if len(groups[1].agents) != 1 || groups[1].context.ID != nested.ID {
+		t.Fatalf("the agent left its own workspace: %+v", groups[1])
+	}
+	if len(groups[0].agents) != 0 {
+		t.Fatalf("the catalogued parent gained an agent it never had: %+v", groups[0])
+	}
+
+	// And the distinguishing part survives the truncation a narrow pane
+	// does, because it arrives first.
+	model := Model{}
+	row := model.renderWorkspaceRow(groups[1], false, false, 28, false)
+	if !strings.Contains(row, "src/") {
+		t.Fatalf("row = %q", row)
+	}
+}
+
+// TestNamesThatDoNotCollideAreLeftAlone: growing every name would cost
+// the pane its readability for a problem most workspaces do not have.
+func TestNamesThatDoNotCollideAreLeftAlone(t *testing.T) {
+	groups := buildWorkspaceGroups([]workspace.Context{
+		{ID: "git:/a/api/.git", Kind: "git", Name: "api", Root: "/a/api"},
+		{ID: "git:/b/web/.git", Kind: "git", Name: "web", Root: "/b/web"},
+	}, nil)
+	if groups[0].label != "api" || groups[1].label != "web" {
+		t.Fatalf("labels = %q, %q", groups[0].label, groups[1].label)
+	}
+}
+
+// TestTwoMachinesSameNameStillCollide: the same repository checked out on
+// two machines is two rows, and the host marker alone does not spell them
+// apart when both names are equal.
+func TestTwoMachinesSameNameStillCollide(t *testing.T) {
+	groups := buildWorkspaceGroups([]workspace.Context{
+		{ID: "git:/srv/api/.git", Kind: "git", Name: "api", Root: "/srv/api"},
+		{Host: "devbox", ID: "devbox:git:/opt/api/.git", Kind: "git",
+			Name: "api", Root: "/opt/api"},
+	}, nil)
+	if groups[0].label == groups[1].label {
+		t.Fatalf("both spelled %q", groups[0].label)
+	}
+	if groups[0].label != "srv/api" || groups[1].label != "opt/api" {
+		t.Fatalf("labels = %q, %q", groups[0].label, groups[1].label)
 	}
 }

--- a/internal/ui/model.go
+++ b/internal/ui/model.go
@@ -130,6 +130,10 @@ const (
 type workspaceGroup struct {
 	context workspace.Context
 	agents  []agent.Agent
+	// label is the name as the pane shows it: the workspace's own name,
+	// grown leftward along its path when another group would otherwise
+	// be spelled the same way.
+	label string
 }
 
 // addWorkspaceTab is which half of the Add Workspace modal is showing.

--- a/internal/ui/state.go
+++ b/internal/ui/state.go
@@ -178,7 +178,66 @@ func buildWorkspaceGroups(
 		index := position - 1
 		groups[index].agents = append(groups[index].agents, managedAgent)
 	}
-	return groups
+	return labelWorkspaceGroups(groups)
+}
+
+// labelWorkspaceGroups gives each group a name that tells it from the
+// others on screen.
+//
+// Two workspaces can share a basename and be entirely different places: a
+// catalogued parent directory and a Git repository nested inside it both
+// end in MetaRepo-PFS, and the pane showed two rows spelled the same way
+// with the agents apparently on the wrong one. They are genuinely
+// different workspaces — the identities are right — so the fix is to say
+// which is which rather than to merge them.
+//
+// A colliding name grows leftward along its own path until it is unique:
+// workplace/MetaRepo-PFS against src/MetaRepo-PFS. Leftward because the
+// pane truncates from the right, so the part that distinguishes them has
+// to arrive first.
+func labelWorkspaceGroups(groups []workspaceGroup) []workspaceGroup {
+	for index := range groups {
+		groups[index].label = groups[index].context.Name
+	}
+	for {
+		counts := make(map[string]int, len(groups))
+		for _, group := range groups {
+			counts[group.label]++
+		}
+		grew := false
+		for index := range groups {
+			if counts[groups[index].label] < 2 {
+				continue
+			}
+			if longer, ok := growLabel(
+				groups[index].label, groups[index].context.Root,
+			); ok {
+				groups[index].label = longer
+				grew = true
+			}
+		}
+		// Names that cannot grow any further stay as they are: two rows
+		// spelled alike beats a row spelled wrong.
+		if !grew {
+			return groups
+		}
+	}
+}
+
+// growLabel prepends the next path segment to the left of what the label
+// already shows.
+func growLabel(label, root string) (string, bool) {
+	root = strings.TrimSuffix(filepath.Clean(root), "/")
+	if !strings.HasSuffix(root, label) {
+		// The label is not a tail of this path — a renamed workspace —
+		// so there is no next segment to reach for.
+		return "", false
+	}
+	remainder := strings.TrimSuffix(strings.TrimSuffix(root, label), "/")
+	if remainder == "" || remainder == "/" {
+		return "", false
+	}
+	return filepath.Base(remainder) + "/" + label, true
 }
 
 func appendWorkspace(values []workspace.Context, value workspace.Context) []workspace.Context {

--- a/internal/ui/workspaces.go
+++ b/internal/ui/workspaces.go
@@ -180,8 +180,12 @@ func (m Model) renderWorkspaceRow(
 	contentWidth := max(1, width-1)
 	// What the name actually asks for, floored so a long one still yields
 	// ground to the chips rather than shouldering them off the row.
+	displayName := group.label
+	if displayName == "" {
+		displayName = group.context.Name
+	}
 	nameNeed := min(
-		lipgloss.Width(group.context.Name),
+		lipgloss.Width(displayName),
 		min(10, max(1, contentWidth/2)),
 	)
 	chips := fitCountChips(
@@ -209,7 +213,7 @@ func (m Model) renderWorkspaceRow(
 		1,
 		contentWidth-lipgloss.Width(gutter)-lipgloss.Width(suffix)-1,
 	)
-	name := truncate(group.context.Name, nameWidth)
+	name := truncate(displayName, nameWidth)
 	gap := max(
 		1,
 		contentWidth-

--- a/internal/windrun/remote_test.go
+++ b/internal/windrun/remote_test.go
@@ -81,7 +81,12 @@ func remoteRuntime(t *testing.T) *Runtime {
 	// the "remote" program itself. Argv construction is asserted
 	// separately, in the remote package.
 	fakeSSH := filepath.Join(dir, "ssh")
+	// A stand-in for ssh. It answers two kinds of request the way a real
+	// host does: a script on stdin runs in a shell, and anything else is
+	// the remote Stormlight — here, this binary in bridge mode.
 	script := fmt.Sprintf(`#!/bin/sh
+for last; do :; done
+if [ "$last" = "-s" ]; then exec /bin/sh -s; fi
 %s=1 %s=%q %s=%q exec %q -test.run=TestMainBridgeHelperNeverRuns
 `, helperSentinel, helperEnv, socket, helperBinEnv, "/remote/bin/stormlight", self)
 	if err := os.WriteFile(fakeSSH, []byte(script), 0o755); err != nil {
@@ -356,4 +361,81 @@ func drainOverlay(t *testing.T, overlay session.Overlay, want string) string {
 		}
 	}
 	return collected
+}
+
+// TestTheProviderIsResolvedOnTheMachineThatRunsIt: the dashboard's own
+// path for a provider is a fact about the dashboard's machine.
+// /Users/someone/.toolbox/bin/codex handed to a Linux daemon can only
+// come back as no such file — which is exactly what it did.
+func TestTheProviderIsResolvedOnTheMachineThatRunsIt(t *testing.T) {
+	runtime := remoteRuntime(t)
+
+	// A provider that exists on the far side under a path this machine
+	// has never had, dispatched with a local path that is nonsense there.
+	remoteOnly := filepath.Join(t.TempDir(), "codex")
+	if err := os.WriteFile(remoteOnly, []byte(
+		"#!/bin/sh\nprintf 'ran %s\\nend\\n' \"$0\"; sleep 60\n"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	t.Setenv("PATH", filepath.Dir(remoteOnly)+":"+os.Getenv("PATH"))
+
+	dispatched, err := runtime.Dispatch(context.Background(), session.DispatchRequest{
+		Provider: agent.Provider("codex"),
+		Cwd:      t.TempDir(),
+		Launch: session.Launch{
+			Path:    "/Users/someone/.toolbox/bin/codex",
+			Program: "codex",
+		},
+	})
+	if err != nil {
+		t.Fatalf("Dispatch: %v", err)
+	}
+	screen := waitForScreen(t, runtime, dispatched.ID, "end")
+	// The terminal is 80 columns and a temporary path is longer, so the
+	// line it printed is wrapped: the comparison is against the text, not
+	// the layout.
+	unwrapped := strings.NewReplacer("\r", "", "\n", "").Replace(screen)
+	if !strings.Contains(unwrapped, "ran "+remoteOnly) {
+		t.Fatalf("the far side's own copy should have run:\n%s", screen)
+	}
+	// And nothing from this machine's filesystem was sent.
+	if strings.Contains(unwrapped, "/Users/someone") {
+		t.Fatalf("a dashboard path reached the remote spawn:\n%s", screen)
+	}
+}
+
+// TestAProviderMissingThereSaysSo: naming the host and the provider,
+// rather than a path from the machine that is not running it.
+func TestAProviderMissingThereSaysSo(t *testing.T) {
+	runtime := remoteRuntime(t)
+	_, err := runtime.Dispatch(context.Background(), session.DispatchRequest{
+		Provider: agent.Provider("nowhere"),
+		Cwd:      t.TempDir(),
+		Launch: session.Launch{
+			Path:    "/Users/someone/.toolbox/bin/nowhere-provider",
+			Program: "nowhere-provider-that-is-not-installed",
+		},
+	})
+	if err == nil {
+		t.Fatal("a provider the host does not have must not dispatch")
+	}
+	if !strings.Contains(err.Error(), "nowhere-provider-that-is-not-installed") ||
+		!strings.Contains(err.Error(), "testhost") {
+		t.Fatalf("the error should name the provider and the host: %v", err)
+	}
+	if strings.Contains(err.Error(), "/Users/someone") {
+		t.Fatalf("it should not name a path from this machine: %v", err)
+	}
+}
+
+// TestLocalDispatchStillUsesTheResolvedPath: nothing about this changes
+// the machine the dashboard is on, where the path was already right.
+func TestLocalDispatchStillUsesTheResolvedPath(t *testing.T) {
+	local := &Runtime{}
+	path, err := local.providerPath(context.Background(), session.Launch{
+		Path: "/usr/local/bin/codex", Program: "codex",
+	})
+	if err != nil || path != "/usr/local/bin/codex" {
+		t.Fatalf("providerPath = %q, %v", path, err)
+	}
 }

--- a/internal/windrun/runtime.go
+++ b/internal/windrun/runtime.go
@@ -274,8 +274,16 @@ func (r *Runtime) Dispatch(ctx context.Context, request session.DispatchRequest)
 		// so the machinery is switched off rather than chased.
 		"CLAUDE_CODE_DISABLE_TERMINAL_TITLE=1",
 	}
+	// The provider is resolved where it will run. Launch.Path answers
+	// "where is it here", which for another machine is a path that
+	// machine has never had — a macOS toolbox path handed to a Linux
+	// daemon can only come back as no such file.
+	program, err := r.providerPath(ctx, request.Launch)
+	if err != nil {
+		return agent.Agent{}, err
+	}
 	spawn := wire.Request{
-		Command: request.Launch.Path,
+		Command: program,
 		Args:    request.Launch.Args,
 		Dir:     request.Cwd,
 		// Peer input is how the dashboard and CLI speak to an agent
@@ -307,6 +315,25 @@ func (r *Runtime) Dispatch(ctx context.Context, request session.DispatchRequest)
 	managedAgent.PaneID = info.ID
 	managedAgent.WindowID = info.ID
 	return managedAgent, nil
+}
+
+// providerPath is the provider as the machine running it will find it.
+//
+// Locally that is the path already resolved. Remotely it is resolved
+// there, so a provider the host does not have is reported as missing
+// from that host by name, rather than as a path from this one that it
+// was never going to have.
+func (r *Runtime) providerPath(ctx context.Context, launch session.Launch) (string, error) {
+	if r.transport == nil {
+		return launch.Path, nil
+	}
+	program := launch.Program
+	if program == "" {
+		// A launch with no name to resolve — a custom spec from an older
+		// record — leaves nothing better than the path it carries.
+		program = launch.Path
+	}
+	return remote.LookPath(ctx, r.transport, program)
 }
 
 // sessionIDFor maps an agent id to the daemon's session id.


### PR DESCRIPTION
Fixes #171 and #172 — both from the same real host, both diagnosed precisely
enough that this is mostly the reports carried out.

## #171 — the provider path belonged to the wrong machine

`exec.LookPath` runs on the dashboard's machine, and its absolute answer was
sent to the daemon that would run it. A macOS dashboard dispatching Codex to
Linux sent `/Users/trentkm/.toolbox/bin/codex`, and the only thing that host
could say was that no such file exists — a true statement about a path it was
never going to have.

`session.Launch` now carries the *name* it was resolved from as well as the
path. Locally the path stands, unchanged. Remotely the name is resolved on the
destination — asking the login shell as well as the bare environment, since a
command over ssh gets a PATH that often has nothing on it.

A provider the host lacks is reported by provider and host:

```
codex is not installed on trentkm-cld2, or not on the PATH its login shell sets
```

Against the acceptance checks:
- a remote dispatch where local and remote paths differ — covered, and the far
  side's own copy is what runs
- no dashboard-host path reaches the remote spawn — asserted directly
- local dispatch unchanged — asserted
- provider and host named when it is absent — asserted, including that the
  dashboard's path does *not* appear

## #172 — two rows spelled the same way

A catalogued parent directory and a Git repository nested inside it both end in
`MetaRepo-PFS`, so the pane showed two identical-looking rows with the agents
apparently on the wrong one.

The identities are right and the distinction is real, so nothing is merged. A
name that collides grows leftward along its own path until unique —
`workplace/MetaRepo-PFS` against `src/MetaRepo-PFS`. Leftward because the pane
truncates from the right, so the distinguishing part has to arrive first; the
test asserts it survives a 28-column row.

Names that do not collide are untouched. A name that cannot grow further is left
alone — two rows spelled alike beats a row spelled wrong.

This also covers two checkouts of the same repository on different machines,
which the host marker alone could not spell apart.

## Testing

`go test ./...` and `go vet ./...` green. The remote-dispatch harness gained the
ability to act as a shell as well as a bridge, which is what let the provider
lookup be exercised at all.

**Non-regression**: the local dashboard renders byte-identically to `main` —
nothing collides there, so no name grows.

## Not covered

The dispatch onto `trentkm-cld2` itself. The resolution, the failure message,
and the "no local path is sent" guarantee are all exercised against a stand-in
host; whether Codex then starts there is that machine's to answer.