### PR TITLE
Terminal-themed site with light/dark from the product palettes

### DIFF
--- a/site/assets/docs.css
+++ b/site/assets/docs.css
@@ -41,8 +41,8 @@
 }
 .side > ul > li > a:hover { color: var(--cyan); background: var(--hover-bg); text-decoration: none; }
 .side > ul > li.current > a {
-  color: var(--cyan-deep);
-  background: rgba(98, 174, 239, 0.12);
+  color: var(--cyan-bright);
+  background: var(--code-bg);
   font-weight: 500;
 }
 
@@ -61,8 +61,8 @@
 }
 .side .sections li a:hover { color: var(--cyan); text-decoration: none; }
 .side .sections li a.active {
-  color: var(--cyan-deep);
-  border-left-color: var(--cyan-deep);
+  color: var(--cyan-bright);
+  border-left-color: var(--cyan-bright);
 }
 .side .sections li.sub a { padding-left: 2.2rem; font-size: 0.72rem; }
 
@@ -70,15 +70,15 @@
 
 .doc { padding: 2.8rem 0 2rem; min-width: 0; }
 
-.doc-title { font-size: clamp(1.9rem, 4vw, 2.6rem); color: var(--heading); margin: 0.5rem 0 0.8rem; }
-.doc-lede { color: var(--ink-dim); font-size: 1.08rem; max-width: 40em; }
+.doc-title { font-size: clamp(1.35rem, 3vw, 1.9rem); color: var(--heading); margin: 0.5rem 0 0.8rem; }
+.doc-lede { color: var(--ink-dim); font-size: 0.95rem; max-width: 40em; }
 
 article { padding-top: 1.8rem; max-width: 46rem; }
 
 article h2, article h3, article h4 { scroll-margin-top: 2rem; }
 
 article h2 {
-  font-size: 1.5rem;
+  font-size: 1.2rem;
   color: var(--heading);
   margin: 3rem 0 1rem;
   padding-top: 1.5rem;
@@ -167,7 +167,7 @@ article td {
   padding: 1.6rem 1.8rem;
   transition: border-color 0.2s, background 0.2s;
 }
-.doc-card:hover { border-color: rgba(38, 121, 157, 0.35); background: var(--hover-bg); text-decoration: none; }
-.doc-card h3 { font-size: 1.25rem; font-weight: 400; color: var(--heading); margin-bottom: 0.4rem; font-family: var(--serif); }
+.doc-card:hover { border-color: var(--card-line-hover); background: var(--hover-bg); text-decoration: none; }
+.doc-card h3 { font-size: 1.05rem; font-weight: 600; color: var(--heading); margin-bottom: 0.4rem; }
 .doc-card p { color: var(--ink-dim); font-size: 0.95rem; }
-.doc-card .go { font-family: var(--mono); font-size: 0.72rem; color: var(--cyan-deep); }
+.doc-card .go { font-family: var(--mono); font-size: 0.72rem; color: var(--cyan-bright); }

--- a/site/assets/style.css
+++ b/site/assets/style.css
@@ -6,6 +6,10 @@
    before first paint by the boot script in each page's head. */
 
 :root {
+  /* Tells the UA which chrome to draw — scrollbars in code blocks,
+     the overscroll canvas. Without it dark pages get light scrollbars
+     on every platform that draws classic ones. */
+  color-scheme: light;
   /* internal/theme Light: Text #24323A, Muted #70808A, Working #26799D,
      Waiting #A86600, Done #257A4A, Accent #62AEEF, Band #B9D9EF,
      Code #0E7C6B, PortalInk #0F2338, Border #AAB3B9 */
@@ -19,10 +23,8 @@
   --ink-faint: #8ba1b4;
   --cyan: #26799d;
   --cyan-bright: #1d6485;
-  --ice: #0f2338;
   --amber: #a86600;
   --amber-deep: #8f5800;
-  --green: #257a4a;
   --heading: #17262e;
   --lit: #0f2338;
   --prose: #35485a;
@@ -52,6 +54,7 @@
 }
 
 [data-theme="dark"] {
+  color-scheme: dark;
   /* web/src/lib/theme.ts, verbatim where a slot exists: bg #171C20,
      raised #1B2126, sunken #14181D, border #2A3138 / #3A4046,
      text #D7DEE5 / #F3F5F6, muted #74818B, working #61AFEF,
@@ -67,10 +70,8 @@
   --ink-faint: #74818b;
   --cyan: #61afef;
   --cyan-bright: #7dcfff;
-  --ice: #7dcfff;
   --amber: #e5c07b;
   --amber-deep: #e5c07b;
-  --green: #72c087;
   --heading: #f3f5f6;
   --lit: #c6e9ff;
   --prose: #b7c3cd;

--- a/site/assets/style.css
+++ b/site/assets/style.css
@@ -1,8 +1,14 @@
-/* Stormlight site — light trapped in ice.
-   Values from internal/theme's Light pairs: Text #24323A, Muted #70808A,
-   Working #26799D, Waiting #A86600, Accent #62AEEF, Band #B9D9EF,
-   Code #0E7C6B, PortalInk #0F2338 */
+/* Stormlight site — the terminal, published.
+   One family of type (the visitor's own terminal face), two palettes
+   from the product itself: light from internal/theme's Light pairs,
+   dark from web/src/lib/theme.ts — the dashboard's exact colors.
+   Light is the default; [data-theme="dark"] on <html> flips it, set
+   before first paint by the boot script in each page's head. */
+
 :root {
+  /* internal/theme Light: Text #24323A, Muted #70808A, Working #26799D,
+     Waiting #A86600, Done #257A4A, Accent #62AEEF, Band #B9D9EF,
+     Code #0E7C6B, PortalInk #0F2338, Border #AAB3B9 */
   --bg: #f2f6fa;
   --bg-raised: #ffffff;
   --bg-panel: #fbfdff;
@@ -12,10 +18,11 @@
   --ink-dim: #59707f;
   --ink-faint: #8ba1b4;
   --cyan: #26799d;
-  --cyan-deep: #1d6485;
+  --cyan-bright: #1d6485;
   --ice: #0f2338;
   --amber: #a86600;
   --amber-deep: #8f5800;
+  --green: #257a4a;
   --heading: #17262e;
   --lit: #0f2338;
   --prose: #35485a;
@@ -24,14 +31,67 @@
   --code-ink: #0e7c6b;
   --str: #a86600;
   --hover-bg: #eef4f9;
-  --sel-bg: #e1e9f0;
-  --sweep-hi: #26799d;
-  --sweep-hi-sel: #0f2338;
-  --term-ink: #3d5468;
-  --tool-ink: #7c93ab;
-  --ok-ink: #257a4a;
-  --serif: "Newsreader", "Iowan Old Style", Georgia, serif;
-  --mono: "Geist Mono", "SFMono-Regular", Menlo, Consolas, monospace;
+  --sel-bg: rgba(98, 174, 239, 0.3);
+  --sel-ink: #0f2338;
+  --code-bg: rgba(38, 121, 157, 0.07);
+  --code-line: rgba(38, 121, 157, 0.16);
+  --kbd-line: rgba(38, 121, 157, 0.22);
+  --glow: rgba(98, 174, 239, 0.4);
+  --glow-soft: rgba(98, 174, 239, 0.16);
+  --band-soft: rgba(185, 217, 239, 0.45);
+  --amber-soft: rgba(168, 102, 0, 0.05);
+  --amber-line: rgba(168, 102, 0, 0.3);
+  --shadow-ink: rgba(15, 35, 56, 0.06);
+  --shadow-deep: rgba(15, 35, 56, 0.28);
+  --card-line-hover: rgba(38, 121, 157, 0.35);
+  /* The terminal's own face, wherever the page is read: SF Mono on a
+     Mac, Consolas/Cascadia on Windows, whatever ui-monospace means
+     locally. No webfont — a terminal does not download its type. */
+  --mono: ui-monospace, "SF Mono", "Cascadia Mono", Consolas, Menlo,
+    "DejaVu Sans Mono", monospace;
+}
+
+[data-theme="dark"] {
+  /* web/src/lib/theme.ts, verbatim where a slot exists: bg #171C20,
+     raised #1B2126, sunken #14181D, border #2A3138 / #3A4046,
+     text #D7DEE5 / #F3F5F6, muted #74818B, working #61AFEF,
+     waiting #E5C07B, done #72C087, band #C6E9FF, ice #7DCFFF,
+     code #8FDCCB */
+  --bg: #14181d;
+  --bg-raised: #1b2126;
+  --bg-panel: #171c20;
+  --line: #2a3138;
+  --line-soft: #232a31;
+  --ink: #d7dee5;
+  --ink-dim: #9aa8b2;
+  --ink-faint: #74818b;
+  --cyan: #61afef;
+  --cyan-bright: #7dcfff;
+  --ice: #7dcfff;
+  --amber: #e5c07b;
+  --amber-deep: #e5c07b;
+  --green: #72c087;
+  --heading: #f3f5f6;
+  --lit: #c6e9ff;
+  --prose: #b7c3cd;
+  --dot: #3a4046;
+  --pre-ink: #c9d4dd;
+  --code-ink: #8fdccb;
+  --str: #e5c07b;
+  --hover-bg: #1f262d;
+  --sel-bg: rgba(198, 233, 255, 0.25);
+  --sel-ink: #f3f5f6;
+  --code-bg: rgba(143, 220, 203, 0.08);
+  --code-line: rgba(143, 220, 203, 0.2);
+  --kbd-line: rgba(97, 175, 239, 0.35);
+  --glow: rgba(97, 175, 239, 0.35);
+  --glow-soft: rgba(97, 175, 239, 0.08);
+  --band-soft: rgba(125, 207, 255, 0.06);
+  --amber-soft: rgba(229, 192, 123, 0.04);
+  --amber-line: rgba(229, 192, 123, 0.35);
+  --shadow-ink: rgba(0, 0, 0, 0.3);
+  --shadow-deep: rgba(0, 0, 0, 0.55);
+  --card-line-hover: rgba(125, 207, 255, 0.4);
 }
 
 * { margin: 0; padding: 0; box-sizing: border-box; }
@@ -41,14 +101,14 @@ html { scroll-behavior: smooth; }
 body {
   background: var(--bg);
   color: var(--ink);
-  font-family: var(--serif);
-  font-size: 18px;
-  line-height: 1.65;
+  font-family: var(--mono);
+  font-size: 15px;
+  line-height: 1.75;
   -webkit-font-smoothing: antialiased;
   overflow-x: hidden;
 }
 
-::selection { background: rgba(98, 174, 239, 0.3); color: #0f2338; }
+::selection { background: var(--sel-bg); color: var(--sel-ink); }
 
 a { color: var(--cyan); text-decoration: none; }
 a:hover { text-decoration: underline; text-underline-offset: 3px; }
@@ -60,9 +120,9 @@ a:hover { text-decoration: underline; text-underline-offset: 3px; }
   inset: 0;
   z-index: -2;
   background:
-    radial-gradient(60rem 40rem at 85% -10%, rgba(98, 174, 239, 0.16), transparent 60%),
-    radial-gradient(50rem 36rem at -10% 20%, rgba(185, 217, 239, 0.45), transparent 60%),
-    radial-gradient(40rem 30rem at 70% 110%, rgba(168, 102, 0, 0.05), transparent 60%),
+    radial-gradient(60rem 40rem at 85% -10%, var(--glow-soft), transparent 60%),
+    radial-gradient(50rem 36rem at -10% 20%, var(--band-soft), transparent 60%),
+    radial-gradient(40rem 30rem at 70% 110%, var(--amber-soft), transparent 60%),
     var(--bg);
 }
 
@@ -75,6 +135,7 @@ a:hover { text-decoration: underline; text-underline-offset: 3px; }
   pointer-events: none;
   background-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='140' height='140'%3E%3Cfilter id='n'%3E%3CfeTurbulence type='fractalNoise' baseFrequency='0.9' numOctaves='2'/%3E%3CfeColorMatrix values='0 0 0 0 1 0 0 0 0 1 0 0 0 0 1 0 0 0 0.028 0'/%3E%3C/filter%3E%3Crect width='140' height='140' filter='url(%23n)'/%3E%3C/svg%3E");
 }
+[data-theme="dark"] .grain { filter: none; opacity: 0.5; }
 
 /* ---------- layout ---------- */
 
@@ -88,7 +149,6 @@ a:hover { text-decoration: underline; text-underline-offset: 3px; }
   align-items: baseline;
   justify-content: space-between;
   padding: 1.6rem 0;
-  font-family: var(--mono);
   font-size: 0.78rem;
 }
 
@@ -105,25 +165,52 @@ a:hover { text-decoration: underline; text-underline-offset: 3px; }
 .nav-links a { color: var(--ink-dim); letter-spacing: 0.08em; }
 .nav-links a:hover { color: var(--cyan); text-decoration: none; }
 
+/* The theme switch, dressed as what it is: a flag. */
+.mode {
+  font-family: var(--mono);
+  font-size: 0.78rem;
+  letter-spacing: 0.08em;
+  background: none;
+  border: none;
+  color: var(--ink-dim);
+  cursor: pointer;
+  padding: 0;
+}
+.mode:hover { color: var(--cyan); }
+
 /* ---------- type ---------- */
 
-h1, h2, h3 { font-weight: 400; letter-spacing: -0.01em; }
+h1, h2, h3 { font-weight: 600; letter-spacing: -0.01em; }
 
+/* Kickers read as comments — the one line of a terminal that talks
+   about the rest. */
 .kicker {
-  font-family: var(--mono);
   font-size: 0.72rem;
   letter-spacing: 0.3em;
   text-transform: uppercase;
-  color: var(--cyan-deep);
+  color: var(--cyan-bright);
   margin-bottom: 1.2rem;
 }
+.kicker::before { content: "# "; color: var(--ink-faint); letter-spacing: 0; }
 .kicker.amber { color: var(--amber-deep); }
 
 em.lit {
-  font-style: italic;
+  font-style: normal;
   color: var(--lit);
-  text-shadow: 0 0 24px rgba(98, 174, 239, 0.4);
+  text-shadow: 0 0 24px var(--glow);
 }
+
+/* The block cursor, resting where the shell would leave it. */
+.cursor {
+  display: inline-block;
+  width: 0.55em;
+  height: 1em;
+  margin-left: 0.12em;
+  vertical-align: -0.08em;
+  background: var(--cyan);
+  animation: blink 1.1s steps(1) infinite;
+}
+@keyframes blink { 50% { opacity: 0; } }
 
 /* ---------- buttons / install ---------- */
 
@@ -131,11 +218,10 @@ em.lit {
   display: inline-flex;
   align-items: center;
   gap: 0.9rem;
-  font-family: var(--mono);
   font-size: 0.85rem;
   background: var(--bg-raised);
   border: 1px solid var(--line);
-  border-radius: 8px;
+  border-radius: 6px;
   padding: 0.75rem 1.1rem;
   color: var(--ink);
 }
@@ -146,25 +232,24 @@ em.lit {
   letter-spacing: 0.08em;
   background: none;
   border: 1px solid var(--line);
-  border-radius: 5px;
+  border-radius: 4px;
   color: var(--ink-dim);
   padding: 0.25rem 0.55rem;
   cursor: pointer;
   transition: color 0.15s, border-color 0.15s;
 }
-.install button:hover { color: var(--cyan); border-color: var(--cyan-deep); }
+.install button:hover { color: var(--cyan); border-color: var(--cyan-bright); }
 
 /* ---------- terminal chrome ---------- */
 
 .term {
   background: var(--bg-panel);
   border: 1px solid var(--line);
-  border-radius: 10px;
+  border-radius: 8px;
   box-shadow:
-    0 1px 2px rgba(15, 35, 56, 0.06),
-    0 24px 60px -24px rgba(15, 35, 56, 0.28),
-    0 0 90px -30px rgba(98, 174, 239, 0.4);
-  font-family: var(--mono);
+    0 1px 2px var(--shadow-ink),
+    0 24px 60px -24px var(--shadow-deep),
+    0 0 90px -30px var(--glow);
   overflow: hidden;
 }
 
@@ -186,22 +271,20 @@ em.lit {
 /* ---------- code blocks (docs + landing) ---------- */
 
 pre {
-  font-family: var(--mono);
   font-size: 0.8rem;
   line-height: 1.7;
   background: var(--bg-raised);
   border: 1px solid var(--line);
-  border-radius: 8px;
+  border-radius: 6px;
   padding: 1rem 1.2rem;
   overflow-x: auto;
   color: var(--pre-ink);
 }
 code {
-  font-family: var(--mono);
-  font-size: 0.85em;
+  font-size: 0.9em;
   color: var(--code-ink);
-  background: rgba(38, 121, 157, 0.07);
-  border: 1px solid rgba(38, 121, 157, 0.16);
+  background: var(--code-bg);
+  border: 1px solid var(--code-line);
   border-radius: 4px;
   padding: 0.08em 0.35em;
 }
@@ -209,8 +292,8 @@ pre code { background: none; border: none; padding: 0; color: inherit; font-size
 kbd {
   font-family: var(--mono);
   color: var(--cyan);
-  background: rgba(38, 121, 157, 0.07);
-  border: 1px solid rgba(38, 121, 157, 0.22);
+  background: var(--code-bg);
+  border: 1px solid var(--kbd-line);
   border-radius: 4px;
   padding: 0.05em 0.45em;
   font-size: 0.8em;
@@ -226,7 +309,6 @@ pre .s { color: var(--str); }
   border-top: 1px solid var(--line-soft);
   margin-top: 8rem;
   padding: 3rem 0 4rem;
-  font-family: var(--mono);
   font-size: 0.78rem;
   color: var(--ink-faint);
 }
@@ -241,11 +323,12 @@ pre .s { color: var(--str); }
 
 @media (prefers-reduced-motion: reduce) {
   .reveal { opacity: 1; transform: none; transition: none; }
+  .cursor { animation: none; }
   * { animation-duration: 0.01ms !important; animation-iteration-count: 1 !important; }
 }
 
 @media (max-width: 640px) {
-  body { font-size: 16px; }
+  body { font-size: 14px; }
   .wrap, .wrap-narrow { padding: 0 1.1rem; }
   .nav { flex-wrap: wrap; row-gap: 0.7rem; }
   .nav-links { gap: 1rem; flex-wrap: wrap; row-gap: 0.5rem; }

--- a/site/assets/theme.js
+++ b/site/assets/theme.js
@@ -12,6 +12,9 @@
       "aria-label",
       dark ? "Switch to light theme" : "Switch to dark theme"
     );
+    btn.setAttribute("aria-pressed", dark ? "true" : "false");
+    var chrome = document.querySelector('meta[name="theme-color"]');
+    if (chrome) chrome.content = dark ? "#14181d" : "#f2f6fa";
   }
   btn.addEventListener("click", function () {
     var next =

--- a/site/assets/theme.js
+++ b/site/assets/theme.js
@@ -1,0 +1,28 @@
+/* The theme toggle. The boot script in each page's head has already
+   set data-theme before first paint; this only flips it and remembers.
+   Light is the default — the stored value is only ever read back as
+   "dark" or "light", anything else falls through to light. */
+(function () {
+  var btn = document.getElementById("mode");
+  if (!btn) return;
+  function paint() {
+    var dark = document.documentElement.dataset.theme === "dark";
+    btn.textContent = dark ? "[ light ]" : "[ dark ]";
+    btn.setAttribute(
+      "aria-label",
+      dark ? "Switch to light theme" : "Switch to dark theme"
+    );
+  }
+  btn.addEventListener("click", function () {
+    var next =
+      document.documentElement.dataset.theme === "dark" ? "light" : "dark";
+    document.documentElement.dataset.theme = next;
+    try {
+      localStorage.setItem("stormlight-theme", next);
+    } catch (e) {
+      /* a theme that cannot persist still applies for the visit */
+    }
+    paint();
+  });
+  paint();
+})();

--- a/site/docs/architecture.html
+++ b/site/docs/architecture.html
@@ -3,6 +3,7 @@
 <head>
 <meta charset="utf-8">
 <meta name="viewport" content="width=device-width, initial-scale=1">
+<meta name="theme-color" content="#f2f6fa">
 <title>Architecture · Stormlight</title>
 <meta name="description" content="How Stormlight separates agent semantics from terminal and process ownership.">
 <link rel="icon" href="../assets/favicon.svg" type="image/svg+xml">
@@ -15,7 +16,10 @@
 (function () {
   var theme;
   try { theme = localStorage.getItem("stormlight-theme"); } catch (e) {}
-  document.documentElement.dataset.theme = theme === "dark" ? "dark" : "light";
+  var dark = theme === "dark";
+  document.documentElement.dataset.theme = dark ? "dark" : "light";
+  var chrome = document.querySelector('meta[name="theme-color"]');
+  if (chrome) chrome.content = dark ? "#14181d" : "#f2f6fa";
 })();
 </script>
 </head>

--- a/site/docs/architecture.html
+++ b/site/docs/architecture.html
@@ -8,11 +8,16 @@
 <link rel="icon" href="../assets/favicon.svg" type="image/svg+xml">
 <link rel="icon" href="../assets/favicon-32.png" type="image/png" sizes="32x32">
 <link rel="apple-touch-icon" href="../assets/apple-touch-icon.png">
-<link rel="preconnect" href="https://fonts.googleapis.com">
-<link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
-<link href="https://fonts.googleapis.com/css2?family=Newsreader:ital,opsz,wght@0,6..72,300..600;1,6..72,300..600&family=Geist+Mono:wght@300..600&display=swap" rel="stylesheet">
 <link rel="stylesheet" href="../assets/style.css">
 <link rel="stylesheet" href="../assets/docs.css">
+<script>
+/* Theme, before first paint: light unless dark was chosen here before. */
+(function () {
+  var theme;
+  try { theme = localStorage.getItem("stormlight-theme"); } catch (e) {}
+  document.documentElement.dataset.theme = theme === "dark" ? "dark" : "light";
+})();
+</script>
 </head>
 <body>
 <div class="storm"></div>
@@ -25,6 +30,7 @@
     <a href="../#windrunner">windrunner</a>
     <a href="./">docs</a>
     <a href="https://github.com/trentkm/stormlight">github</a>
+    <button class="mode" id="mode" type="button">[ dark ]</button>
   </nav>
 </header>
 
@@ -448,5 +454,6 @@
   </div>
 </footer>
 <script src="../assets/docs.js"></script>
+<script src="../assets/theme.js"></script>
 </body>
 </html>

--- a/site/docs/configuration.html
+++ b/site/docs/configuration.html
@@ -8,11 +8,16 @@
 <link rel="icon" href="../assets/favicon.svg" type="image/svg+xml">
 <link rel="icon" href="../assets/favicon-32.png" type="image/png" sizes="32x32">
 <link rel="apple-touch-icon" href="../assets/apple-touch-icon.png">
-<link rel="preconnect" href="https://fonts.googleapis.com">
-<link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
-<link href="https://fonts.googleapis.com/css2?family=Newsreader:ital,opsz,wght@0,6..72,300..600;1,6..72,300..600&family=Geist+Mono:wght@300..600&display=swap" rel="stylesheet">
 <link rel="stylesheet" href="../assets/style.css">
 <link rel="stylesheet" href="../assets/docs.css">
+<script>
+/* Theme, before first paint: light unless dark was chosen here before. */
+(function () {
+  var theme;
+  try { theme = localStorage.getItem("stormlight-theme"); } catch (e) {}
+  document.documentElement.dataset.theme = theme === "dark" ? "dark" : "light";
+})();
+</script>
 </head>
 <body>
 <div class="storm"></div>
@@ -25,6 +30,7 @@
     <a href="../#windrunner">windrunner</a>
     <a href="./">docs</a>
     <a href="https://github.com/trentkm/stormlight">github</a>
+    <button class="mode" id="mode" type="button">[ dark ]</button>
   </nav>
 </header>
 
@@ -198,5 +204,6 @@ provider = <span class="s">"claude"</span>
   </div>
 </footer>
 <script src="../assets/docs.js"></script>
+<script src="../assets/theme.js"></script>
 </body>
 </html>

--- a/site/docs/configuration.html
+++ b/site/docs/configuration.html
@@ -3,6 +3,7 @@
 <head>
 <meta charset="utf-8">
 <meta name="viewport" content="width=device-width, initial-scale=1">
+<meta name="theme-color" content="#f2f6fa">
 <title>Configuration · Stormlight</title>
 <meta name="description" content="The design rationale behind Stormlight's config.toml: zero-config defaults, one precedence rule, custom providers.">
 <link rel="icon" href="../assets/favicon.svg" type="image/svg+xml">
@@ -15,7 +16,10 @@
 (function () {
   var theme;
   try { theme = localStorage.getItem("stormlight-theme"); } catch (e) {}
-  document.documentElement.dataset.theme = theme === "dark" ? "dark" : "light";
+  var dark = theme === "dark";
+  document.documentElement.dataset.theme = dark ? "dark" : "light";
+  var chrome = document.querySelector('meta[name="theme-color"]');
+  if (chrome) chrome.content = dark ? "#14181d" : "#f2f6fa";
 })();
 </script>
 </head>

--- a/site/docs/index.html
+++ b/site/docs/index.html
@@ -3,6 +3,7 @@
 <head>
 <meta charset="utf-8">
 <meta name="viewport" content="width=device-width, initial-scale=1">
+<meta name="theme-color" content="#f2f6fa">
 <title>Docs · Stormlight</title>
 <meta name="description" content="Stormlight documentation: architecture, workspace resolvers, configuration.">
 <link rel="icon" href="../assets/favicon.svg" type="image/svg+xml">
@@ -15,7 +16,10 @@
 (function () {
   var theme;
   try { theme = localStorage.getItem("stormlight-theme"); } catch (e) {}
-  document.documentElement.dataset.theme = theme === "dark" ? "dark" : "light";
+  var dark = theme === "dark";
+  document.documentElement.dataset.theme = dark ? "dark" : "light";
+  var chrome = document.querySelector('meta[name="theme-color"]');
+  if (chrome) chrome.content = dark ? "#14181d" : "#f2f6fa";
 })();
 </script>
 </head>

--- a/site/docs/index.html
+++ b/site/docs/index.html
@@ -8,11 +8,16 @@
 <link rel="icon" href="../assets/favicon.svg" type="image/svg+xml">
 <link rel="icon" href="../assets/favicon-32.png" type="image/png" sizes="32x32">
 <link rel="apple-touch-icon" href="../assets/apple-touch-icon.png">
-<link rel="preconnect" href="https://fonts.googleapis.com">
-<link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
-<link href="https://fonts.googleapis.com/css2?family=Newsreader:ital,opsz,wght@0,6..72,300..600;1,6..72,300..600&family=Geist+Mono:wght@300..600&display=swap" rel="stylesheet">
 <link rel="stylesheet" href="../assets/style.css">
 <link rel="stylesheet" href="../assets/docs.css">
+<script>
+/* Theme, before first paint: light unless dark was chosen here before. */
+(function () {
+  var theme;
+  try { theme = localStorage.getItem("stormlight-theme"); } catch (e) {}
+  document.documentElement.dataset.theme = theme === "dark" ? "dark" : "light";
+})();
+</script>
 </head>
 <body>
 <div class="storm"></div>
@@ -25,6 +30,7 @@
     <a href="../#windrunner">windrunner</a>
     <a href="./">docs</a>
     <a href="https://github.com/trentkm/stormlight">github</a>
+    <button class="mode" id="mode" type="button">[ dark ]</button>
   </nav>
 </header>
 
@@ -82,5 +88,6 @@
     </span>
   </div>
 </footer>
+<script src="../assets/theme.js"></script>
 </body>
 </html>

--- a/site/docs/workspace-resolvers.html
+++ b/site/docs/workspace-resolvers.html
@@ -8,11 +8,16 @@
 <link rel="icon" href="../assets/favicon.svg" type="image/svg+xml">
 <link rel="icon" href="../assets/favicon-32.png" type="image/png" sizes="32x32">
 <link rel="apple-touch-icon" href="../assets/apple-touch-icon.png">
-<link rel="preconnect" href="https://fonts.googleapis.com">
-<link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
-<link href="https://fonts.googleapis.com/css2?family=Newsreader:ital,opsz,wght@0,6..72,300..600;1,6..72,300..600&family=Geist+Mono:wght@300..600&display=swap" rel="stylesheet">
 <link rel="stylesheet" href="../assets/style.css">
 <link rel="stylesheet" href="../assets/docs.css">
+<script>
+/* Theme, before first paint: light unless dark was chosen here before. */
+(function () {
+  var theme;
+  try { theme = localStorage.getItem("stormlight-theme"); } catch (e) {}
+  document.documentElement.dataset.theme = theme === "dark" ? "dark" : "light";
+})();
+</script>
 </head>
 <body>
 <div class="storm"></div>
@@ -25,6 +30,7 @@
     <a href="../#windrunner">windrunner</a>
     <a href="./">docs</a>
     <a href="https://github.com/trentkm/stormlight">github</a>
+    <button class="mode" id="mode" type="button">[ dark ]</button>
   </nav>
 </header>
 
@@ -153,5 +159,6 @@
   </div>
 </footer>
 <script src="../assets/docs.js"></script>
+<script src="../assets/theme.js"></script>
 </body>
 </html>

--- a/site/docs/workspace-resolvers.html
+++ b/site/docs/workspace-resolvers.html
@@ -3,6 +3,7 @@
 <head>
 <meta charset="utf-8">
 <meta name="viewport" content="width=device-width, initial-scale=1">
+<meta name="theme-color" content="#f2f6fa">
 <title>Workspace resolvers · Stormlight</title>
 <meta name="description" content="How Stormlight resolves directories into workspace groups, and the executable resolver protocol.">
 <link rel="icon" href="../assets/favicon.svg" type="image/svg+xml">
@@ -15,7 +16,10 @@
 (function () {
   var theme;
   try { theme = localStorage.getItem("stormlight-theme"); } catch (e) {}
-  document.documentElement.dataset.theme = theme === "dark" ? "dark" : "light";
+  var dark = theme === "dark";
+  document.documentElement.dataset.theme = dark ? "dark" : "light";
+  var chrome = document.querySelector('meta[name="theme-color"]');
+  if (chrome) chrome.content = dark ? "#14181d" : "#f2f6fa";
 })();
 </script>
 </head>

--- a/site/index.html
+++ b/site/index.html
@@ -3,6 +3,7 @@
 <head>
 <meta charset="utf-8">
 <meta name="viewport" content="width=device-width, initial-scale=1">
+<meta name="theme-color" content="#f2f6fa">
 <title>Stormlight</title>
 <meta name="description" content="A control surface for coding agents. Stormlight dispatches Claude, Codex, and custom agent CLIs onto a daemon that owns each agent's PTY and terminal, with a dashboard that runs in yours.">
 <meta property="og:title" content="Stormlight">
@@ -16,7 +17,10 @@
 (function () {
   var theme;
   try { theme = localStorage.getItem("stormlight-theme"); } catch (e) {}
-  document.documentElement.dataset.theme = theme === "dark" ? "dark" : "light";
+  var dark = theme === "dark";
+  document.documentElement.dataset.theme = dark ? "dark" : "light";
+  var chrome = document.querySelector('meta[name="theme-color"]');
+  if (chrome) chrome.content = dark ? "#14181d" : "#f2f6fa";
 })();
 </script>
 <style>

--- a/site/index.html
+++ b/site/index.html
@@ -10,27 +10,32 @@
 <link rel="icon" href="assets/favicon.svg" type="image/svg+xml">
 <link rel="icon" href="assets/favicon-32.png" type="image/png" sizes="32x32">
 <link rel="apple-touch-icon" href="assets/apple-touch-icon.png">
-<link rel="preconnect" href="https://fonts.googleapis.com">
-<link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
-<link href="https://fonts.googleapis.com/css2?family=Newsreader:ital,opsz,wght@0,6..72,300..600;1,6..72,300..600&family=Geist+Mono:wght@300..600&display=swap" rel="stylesheet">
 <link rel="stylesheet" href="assets/style.css">
+<script>
+/* Theme, before first paint: light unless dark was chosen here before. */
+(function () {
+  var theme;
+  try { theme = localStorage.getItem("stormlight-theme"); } catch (e) {}
+  document.documentElement.dataset.theme = theme === "dark" ? "dark" : "light";
+})();
+</script>
 <style>
 /* ---------- hero ---------- */
 
 .hero { padding-top: 6rem; padding-bottom: 4rem; }
 
 .hero h1 {
-  font-size: clamp(2.6rem, 6.5vw, 4.6rem);
-  line-height: 1.08;
-  max-width: 18em;
-  font-weight: 300;
+  font-size: clamp(1.7rem, 4.2vw, 2.8rem);
+  line-height: 1.2;
+  max-width: 24em;
+  font-weight: 600;
   color: var(--heading);
 }
 
 .hero .sub {
   margin-top: 1.6rem;
-  max-width: 36em;
-  font-size: 1.12rem;
+  max-width: 42em;
+  font-size: 0.95rem;
   color: var(--ink-dim);
 }
 .hero .sub strong { font-weight: 500; color: var(--ink); }
@@ -66,15 +71,15 @@ video.demo { display: block; width: 100%; height: auto; }
 section.wrap { padding-top: 6.5rem; }
 
 .section-head h2 {
-  font-size: clamp(1.9rem, 4vw, 2.7rem);
+  font-size: clamp(1.35rem, 3vw, 1.9rem);
   color: var(--heading);
-  max-width: 20em;
+  max-width: 26em;
 }
 .section-head p.lede {
   margin-top: 1.1rem;
   max-width: 38em;
   color: var(--ink-dim);
-  font-size: 1.08rem;
+  font-size: 0.95rem;
 }
 
 /* principle cards */
@@ -128,9 +133,9 @@ section.wrap { padding-top: 6.5rem; }
   display: block;
   margin-bottom: 0.7rem;
 }
-.signal.working .tag { color: var(--cyan-deep); text-shadow: 0 0 14px rgba(98,174,239,0.5); }
+.signal.working .tag { color: var(--cyan-bright); text-shadow: 0 0 14px var(--glow); }
 .signal.waiting .tag { color: var(--amber); }
-.signal.urgent { border-color: rgba(168, 102, 0, 0.3); }
+.signal.urgent { border-color: var(--amber-line); }
 .signal.urgent .tag { color: var(--amber); font-weight: 600; }
 @media (max-width: 900px) { .signals { grid-template-columns: 1fr; } }
 
@@ -140,7 +145,7 @@ section.wrap { padding-top: 6.5rem; }
   border: 1px solid var(--line);
   border-radius: 12px;
   background:
-    radial-gradient(40rem 20rem at 110% -30%, rgba(98, 174, 239, 0.14), transparent 60%),
+    radial-gradient(40rem 20rem at 110% -30%, var(--glow-soft), transparent 60%),
     var(--bg-raised);
   padding: 3rem;
   display: grid;
@@ -148,20 +153,20 @@ section.wrap { padding-top: 6.5rem; }
   gap: 3rem;
 }
 .engine h3 {
-  font-size: 1.7rem;
+  font-size: 1.25rem;
   color: var(--heading);
   margin-bottom: 1rem;
 }
 .engine p { color: var(--ink-dim); margin-bottom: 1rem; font-size: 1rem; }
 .engine .points { list-style: none; font-size: 0.92rem; color: var(--ink-dim); }
 .engine .points li { padding: 0.55rem 0; border-bottom: 1px solid var(--line-soft); }
-.engine .points li::before { content: "— "; color: var(--cyan-deep); }
+.engine .points li::before { content: "— "; color: var(--cyan-bright); }
 .engine .repo-link { font-family: var(--mono); font-size: 0.8rem; }
 @media (max-width: 900px) { .engine { grid-template-columns: 1fr; padding: 2rem 1.5rem; } }
 
 /* closing */
 .closing { text-align: center; padding-top: 8rem; }
-.closing h2 { font-size: clamp(2rem, 5vw, 3.2rem); color: var(--heading); }
+.closing h2 { font-size: clamp(1.4rem, 3.5vw, 2.1rem); color: var(--heading); }
 .closing .hero-actions { justify-content: center; }
 .closing .docrow {
   margin-top: 2.2rem;
@@ -185,13 +190,14 @@ section.wrap { padding-top: 6.5rem; }
     <a href="#windrunner">windrunner</a>
     <a href="docs/">docs</a>
     <a href="https://github.com/trentkm/stormlight">github</a>
+    <button class="mode" id="mode" type="button">[ dark ]</button>
   </nav>
 </header>
 
 <main>
   <div class="wrap hero">
     <p class="kicker">workspace-native · terminal-native</p>
-    <h1>A control surface for <em class="lit">coding agents</em>.</h1>
+    <h1>A control surface for <em class="lit">coding agents</em>.<span class="cursor" aria-hidden="true"></span></h1>
     <p class="sub">Dispatches <strong>Claude</strong>, <strong>Codex</strong>, and any agent CLI
     onto a daemon that owns each agent's PTY and terminal. The dashboard runs in yours.</p>
     <div class="hero-actions">
@@ -332,5 +338,6 @@ if (matchMedia("(prefers-reduced-motion: reduce)").matches) {
   document.querySelectorAll("video.demo").forEach(v => { v.removeAttribute("autoplay"); v.pause(); });
 }
 </script>
+<script src="assets/theme.js"></script>
 </body>
 </html>


### PR DESCRIPTION
The public site (stormlight.sh) now dresses as what it sells. Everything is monospace — the visitor's own terminal face (`ui-monospace` → SF Mono / Cascadia / Consolas / Menlo), with the Google-Fonts serif and its three network requests gone entirely.

Two themes, both taken from the product rather than invented for the page:

- **Light (default)**: `internal/theme`'s Light pairs, as the old site already derived — now the only palette without serif type.
- **Dark**: the dashboard's `web/src/lib/theme.ts`, verbatim where a slot exists — `#14181D` ground, `#61AFEF` working-cyan, `#E5C07B` amber, `#C6E9FF` band glow. The demo recording (a dark TUI) finally sits on a page that matches it.

`[ dark ]` in the nav toggles; localStorage remembers; a boot script in each page's head applies the stored choice before first paint, so a returning dark visitor never gets a light flash. Light is the explicit default — no `prefers-color-scheme` override, per the design decision that the page leads light.

Mechanically: every hard-coded rgba moved behind a custom property so both palettes own the entire page (glows, selection, code chips, storm gradients, grain — inverted in light, straight in dark); a dangling-variable audit of all five pages against the stylesheet passes; the type scale came down to monospace-headline proportions; kickers render as `#` comments and the hero ends in a blinking block cursor that respects `prefers-reduced-motion`.

Verified live in Chromium: landing and docs pages in both themes, toggle persistence across navigations.

Pure `site/` change — no code, no build step; `pages.yml` deploys it on merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)