### PR TITLE
A host names the shell its providers live in

### DIFF
--- a/docs/config-design.md
+++ b/docs/config-design.md
@@ -117,9 +117,57 @@ provider = "claude"
 #                                       # non-interactive SSH shell often
 #                                       # has no ~/.local/bin
 # options      = ["-p", "2222"]    # extra ssh flags, before the destination
+# shell        = "/opt/homebrew/bin/fish"  # the shell whose environment
+#                                          # providers are found and run in;
+#                                          # defaults to the account's $SHELL
 # no_multiplex = false             # sharing is on: a dashboard opens
 #                                  # several connections per host
 ```
+
+### The host's execution shell
+
+`shell` is the one setting about a host that is not about reaching it. It
+names the login shell that defines what "installed" means there.
+
+The default is the account's own `$SHELL`, which is right whenever the shell
+someone works in is the shell their account records. It stops being right the
+moment those differ — an account whose `$SHELL` is `/bin/zsh` belonging to
+someone who has configured fish, whose `PATH` is the only one that finds
+`codex`. Nothing about the machine reveals which shell was meant, so the
+setting says it outright; Stormlight does not scan for installed shells and
+guess.
+
+The path must be absolute. The reason is the same one that makes the setting
+necessary: the `PATH` a non-interactive SSH session gets is exactly the `PATH`
+that will not find the shell by name.
+
+The shell is used for both halves of running a provider, because using it for
+only one is worse than using it for neither:
+
+- **Discovery.** "Is `codex` installed on this host" is asked of that shell,
+  so a provider present only on its `PATH` is found.
+- **Launch.** The provider is executed *through* that shell, so it inherits
+  the environment as well as the path. A provider found on a login shell's
+  `PATH` is regularly a shim — mise, asdf, a Homebrew wrapper — that needs
+  the rest of that shell's environment to work at all. Resolving it to an
+  absolute path and then running it under the daemon's bare environment
+  finds the right file and still fails.
+
+The launch is three `exec` calls and no wrapper process: the daemon starts
+`/bin/sh` with a fixed script, that script execs the host's shell, that shell
+execs `stormlight _exec`, and that becomes the provider. What the daemon
+supervises is the provider itself, so signals, exit status, and lifetime are
+untouched by the route taken to start it.
+
+The provider's argv never appears in shell text. It travels in an environment
+variable as JSON and is decoded on the far side, because task text and custom
+provider arguments are arbitrary input and the shell that would parse them is
+one this machine does not choose. The only shell syntax involved is a fixed
+string that `sh`, `bash`, `zsh`, `ksh`, and `fish` all read identically.
+
+A configured shell that is missing or not executable is reported as that —
+naming the setting and the host — rather than as every provider on the host
+having gone missing, which is what the symptom otherwise looks like.
 
 ## Wiring
 

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -43,6 +43,15 @@ type Host struct {
 	Bin string `toml:"bin"`
 	// Options are extra ssh flags, placed ahead of the destination.
 	Options []string `toml:"options"`
+	// Shell is the login shell that defines this host's execution
+	// environment: the one whose PATH finds the providers, and the one
+	// providers are launched under. Empty means the account's own
+	// $SHELL, which is right until the shell someone actually works in
+	// and the shell their account records are two different programs.
+	//
+	// Absolute, because the PATH a non-interactive SSH session gets is
+	// exactly the PATH that will not find it by name.
+	Shell string `toml:"shell"`
 	// NoMultiplex turns off SSH connection sharing, which is on by
 	// default because a dashboard opens several connections per host.
 	NoMultiplex bool `toml:"no_multiplex"`
@@ -183,6 +192,13 @@ func (c Config) normalize(path string) (Config, []string, error) {
 			warn("hosts.%s: a host name cannot contain spaces, colons, or quotes", name)
 			delete(c.Hosts, name)
 			continue
+		}
+		if shell := strings.TrimSpace(host.Shell); shell != "" && !strings.HasPrefix(shell, "/") {
+			// A bare name would be looked up on the very PATH that is
+			// the reason this setting exists.
+			warn("hosts.%s.shell: %q must be an absolute path", name, shell)
+			host.Shell = ""
+			c.Hosts[name] = host
 		}
 		if strings.TrimSpace(host.Destination) == "" && strings.Contains(name, "@") {
 			// A key like trent@devbox is already a destination; taking it

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -243,3 +243,41 @@ func TestAnUnusableHostNameIsRefused(t *testing.T) {
 		t.Fatalf("an unusable host must not be configured: %+v", cfg.Hosts)
 	}
 }
+
+// TestAHostsShellMustBeAbsolute: the setting exists because the PATH a
+// non-interactive SSH session gets does not find the shell by name, so a
+// bare name is the one thing it cannot be.
+func TestAHostsShellMustBeAbsolute(t *testing.T) {
+	path := writeConfig(t, `
+[hosts.good]
+shell = "/home/linuxbrew/.linuxbrew/bin/fish"
+
+[hosts.bare]
+shell = "fish"
+`)
+	cfg, warnings, err := loadFrom(path)
+	if err != nil {
+		t.Fatalf("loadFrom: %v", err)
+	}
+	if got := cfg.Hosts["good"].Shell; got != "/home/linuxbrew/.linuxbrew/bin/fish" {
+		t.Fatalf("an absolute shell should be kept: %q", got)
+	}
+	if got := cfg.Hosts["bare"].Shell; got != "" {
+		t.Fatalf("a bare shell name should be dropped: %q", got)
+	}
+	// Dropped silently would leave the host quietly using the wrong
+	// shell, which is the failure this setting was added to end.
+	said := false
+	for _, warning := range warnings {
+		if strings.Contains(warning, "hosts.bare.shell") {
+			said = true
+		}
+	}
+	if !said {
+		t.Fatalf("dropping it should say so: %q", warnings)
+	}
+	// And the host itself survives: only the unusable setting goes.
+	if _, ok := cfg.Hosts["bare"]; !ok {
+		t.Fatal("a bad shell should not remove the host")
+	}
+}

--- a/internal/picker/picker.go
+++ b/internal/picker/picker.go
@@ -13,6 +13,8 @@ import (
 	"os/exec"
 	"path/filepath"
 	"strings"
+
+	"github.com/trentkm/stormlight/internal/remote"
 )
 
 // Choose runs the chooser over the caller's own terminal and reports the
@@ -91,7 +93,13 @@ func findYazi() (string, error) {
 			return beside, nil
 		}
 	}
-	shell := os.Getenv("SHELL")
+	// The configured shell first: on a host whose account shell and
+	// working shell differ, the account's answer is the wrong one, and
+	// this is the same question dispatch asks.
+	shell := os.Getenv(remote.ShellEnv)
+	if shell == "" {
+		shell = os.Getenv("SHELL")
+	}
 	if shell == "" {
 		shell = "/bin/sh"
 	}

--- a/internal/remote/exec.go
+++ b/internal/remote/exec.go
@@ -1,0 +1,66 @@
+package remote
+
+import (
+	"encoding/json"
+	"fmt"
+	"os"
+	"os/exec"
+	"syscall"
+)
+
+// Exec becomes the provider, on the machine that runs it.
+//
+// It is the last link in a chain that exists to solve one problem: a
+// provider needs the environment of the shell its user actually works
+// in, and that shell's syntax is not something the dashboard's machine
+// may assume. The daemon spawns /bin/sh with ExecPrelude; that script
+// execs the host's login shell; that shell execs Stormlight here; this
+// becomes the provider. Every step is an exec, so the process the daemon
+// supervises is the provider itself — its signals, its exit status, its
+// lifetime, undisturbed by the route taken to start it.
+//
+// The argv arrives in ExecEnv, JSON-encoded, and that is the point of
+// the whole arrangement: no shell ever parses the task text or a custom
+// provider's arguments, so no shell's quoting rules can change them.
+// What was dispatched is what runs.
+func Exec() error {
+	argv, err := ExecArgv(os.Getenv(ExecEnv))
+	if err != nil {
+		return err
+	}
+	// Resolved here rather than carried here, because here is where the
+	// login shell's PATH is finally in effect. The dashboard's own
+	// lookup happens before dispatch, so that a provider the host does
+	// not have is reported rather than dispatched; this one is what
+	// actually decides.
+	path, err := exec.LookPath(argv[0])
+	if err != nil {
+		host, _ := os.Hostname()
+		return fmt.Errorf("%s on %s: %w", argv[0], host, err)
+	}
+	return syscall.Exec(path, argv, os.Environ())
+}
+
+// ExecArgv reads back what ExecEnv carried.
+func ExecArgv(encoded string) ([]string, error) {
+	if encoded == "" {
+		return nil, fmt.Errorf("%s is empty: nothing to run", ExecEnv)
+	}
+	var argv []string
+	if err := json.Unmarshal([]byte(encoded), &argv); err != nil {
+		return nil, fmt.Errorf("decode %s: %w", ExecEnv, err)
+	}
+	if len(argv) == 0 {
+		return nil, fmt.Errorf("%s names no program", ExecEnv)
+	}
+	return argv, nil
+}
+
+// ExecEnvFor is the environment entry that carries one argv across.
+func ExecEnvFor(argv []string) (string, error) {
+	encoded, err := json.Marshal(argv)
+	if err != nil {
+		return "", fmt.Errorf("encode provider argv: %w", err)
+	}
+	return ExecEnv + "=" + string(encoded), nil
+}

--- a/internal/remote/setup.go
+++ b/internal/remote/setup.go
@@ -54,9 +54,10 @@ func (r Report) Ready() bool { return r.Stormlight.Present() }
 // is often the bare system one, so a login shell is the difference
 // between "not installed" and "not on this particular PATH".
 const probeScript = `
+shell=${STORMLIGHT_SHELL:-$SHELL}
 look() {
   command -v "$1" 2>/dev/null && return 0
-  [ -n "$SHELL" ] && "$SHELL" -lc "command -v $1" 2>/dev/null && return 0
+  [ -n "$shell" ] && "$shell" -lc "command -v $1" 2>/dev/null && return 0
   return 1
 }
 # A file that will not start is not an installed program. A binary built
@@ -104,7 +105,7 @@ func Probe(ctx context.Context, transport *Transport) (Report, error) {
 	// The configured binary travels as an environment variable rather
 	// than spliced into the script: it is a path someone typed, and a
 	// script is not the place to find out it had a quote in it.
-	script := probeScript
+	script := transport.Host().shellAssignment() + probeScript
 	if bin := transport.Host().Bin; bin != "" {
 		script = "STORMLIGHT_CONFIGURED_BIN=" +
 			shellQuote([]string{bin}) + "\n" + script
@@ -353,27 +354,50 @@ func localPlatform() (string, error) {
 	return strings.TrimSpace(string(output)), nil
 }
 
-// LookPath finds a program on the host, the way a person would.
+// LookPath asks a host whether it has a program, in the environment that
+// would run it.
 //
 // A command run over ssh gets a non-interactive shell whose PATH is
-// often the bare system one, so the login shell is asked too — the
-// difference between finding a provider a machine plainly has and
-// reporting it absent. The binary is started once, because a name that
-// resolves to something that cannot run is not an answer.
+// often the bare system one, so what is asked is the host's login shell
+// — the configured one, or the account's own. That is the difference
+// between finding a provider a machine plainly has and reporting it
+// absent.
+//
+// This is a check, not a resolution: what the dispatch does with the
+// answer is report it. The path that actually runs is resolved on the
+// far side at launch, in that same shell, because that is the only
+// place the environment is real.
 func LookPath(ctx context.Context, transport *Transport, program string) (string, error) {
 	if strings.TrimSpace(program) == "" {
 		return "", fmt.Errorf("no program to look for")
 	}
-	host := transport.Host().Name
+	host := transport.Host()
 	// Ends with a plain exit 0: not finding the program is an answer,
 	// not a failure of the asking, and a script whose last command is a
 	// test would exit non-zero and be read as one.
-	script := "program=" + shellQuote([]string{program}) + `
-found=$(command -v "$program" 2>/dev/null)
-if [ -z "$found" ] && [ -n "$SHELL" ]; then
-  found=$("$SHELL" -lc "command -v $program" 2>/dev/null)
+	script := host.shellAssignment() +
+		"program=" + shellQuote([]string{program}) + `
+shell=${STORMLIGHT_SHELL:-$SHELL}
+if [ -n "$STORMLIGHT_SHELL" ] && [ ! -x "$STORMLIGHT_SHELL" ]; then
+  printf 'noshell=%s\n' "$STORMLIGHT_SHELL"
+  exit 0
 fi
-if [ -n "$found" ]; then printf '%s\n' "$found"; fi
+# The shell first, and not merely as a fallback. It is the environment
+# the provider will be launched in, so its answer is the true one — and
+# on a host where the bare SSH PATH holds a different build of the same
+# name, asking that one first is how the check passes and the launch
+# runs something else.
+found=""
+if [ -n "$shell" ]; then
+  found=$("$shell" -lc "command -v $program" 2>/dev/null)
+fi
+if [ -z "$found" ]; then
+  found=$(command -v "$program" 2>/dev/null)
+fi
+if [ -n "$found" ]; then printf 'found=%s\n' "$found"; fi
+# Named in the failure, so that "not installed" can point at the shell
+# that was asked rather than leaving that to be guessed at.
+printf 'asked=%s\n' "$shell"
 exit 0
 `
 	command := transport.ShellCommand(ctx, script)
@@ -385,15 +409,27 @@ exit 0
 			return "", ctx.Err()
 		}
 		if message := strings.TrimSpace(stderr.String()); message != "" {
-			return "", errors.New(Explain(host, message))
+			return "", errors.New(Explain(host.Name, message))
 		}
-		return "", fmt.Errorf("%s: %w", host, err)
+		return "", fmt.Errorf("%s: %w", host.Name, err)
 	}
-	found := strings.TrimSpace(stdout.String())
-	if found == "" {
+	answers := map[string]string{}
+	for _, line := range strings.Split(stdout.String(), "\n") {
+		if key, value, ok := strings.Cut(strings.TrimSpace(line), "="); ok {
+			answers[key] = value
+		}
+	}
+	// A configured shell that is not there is its own failure, and one
+	// worth naming: every provider on the host would otherwise be
+	// reported missing, which points at the wrong thing entirely.
+	if bad, ok := answers["noshell"]; ok {
 		return "", fmt.Errorf(
-			"%s is not installed on %s, or not on the PATH its login shell sets",
-			program, host)
+			"%s: shell = %q in [hosts.%s] is not an executable file there",
+			host.Name, bad, host.Name)
 	}
-	return found, nil
+	if found := answers["found"]; found != "" {
+		return found, nil
+	}
+	return "", fmt.Errorf("%s is not installed on %s, or not on the PATH %s sets.%s",
+		program, host.Name, host.shellDescription(answers["asked"]), host.shellHint())
 }

--- a/internal/remote/ssh.go
+++ b/internal/remote/ssh.go
@@ -41,6 +41,10 @@ type Host struct {
 	Bin string
 	// Options are extra ssh flags, spliced in ahead of the destination.
 	Options []string
+	// Shell is the login shell that defines this host's execution
+	// environment, absolute. Empty means the account's own $SHELL,
+	// resolved on the far side because that is where it is known.
+	Shell string
 	// SSHProgram is the client to run, for a host reached through a
 	// wrapper rather than the ssh on PATH.
 	SSHProgram string
@@ -70,6 +74,88 @@ func (h Host) bin() string {
 		return h.Bin
 	}
 	return defaultBin
+}
+
+// Env names the environment the far side reads. These are set on the
+// agent's process by the daemon there, so they are the one channel that
+// no shell parses: a value goes in as bytes and comes out as bytes,
+// whatever quoting rules the login shell has.
+const (
+	// ShellEnv names the login shell to run providers under, when a host
+	// has been configured with one.
+	ShellEnv = "STORMLIGHT_SHELL"
+	// ExecEnv carries the provider's argv, JSON-encoded, for `stormlight
+	// _exec` to decode and become.
+	ExecEnv = "STORMLIGHT_EXEC"
+)
+
+// ExecPrelude is what the daemon on a host actually spawns, with the
+// provider's argv waiting in ExecEnv.
+//
+// It is a POSIX script run by /bin/sh — the one shell every host has and
+// the only one whose syntax may be assumed — and its whole job is to
+// hand off to the shell that owns the host's environment. That shell
+// then execs Stormlight, which execs the provider. Three execs, one
+// process: what the daemon supervises is the provider itself, so signals,
+// exit status, and lifetime are unchanged by the detour.
+//
+// Nothing here is interpolated. The provider's argv never appears in
+// shell text at all — it travels in ExecEnv — because task text and
+// custom provider arguments are arbitrary input, and the shell that
+// would parse them is one this machine does not choose. The only
+// variable syntax used, "$VAR", means the same thing in sh, bash, zsh,
+// ksh, and fish alike.
+const ExecPrelude = `shell=${` + ShellEnv + `:-$SHELL}
+[ -n "$shell" ] || shell=/bin/sh
+if [ ! -x "$shell" ]; then
+  echo "stormlight: $shell is not an executable shell on $(hostname 2>/dev/null)" >&2
+  exit 127
+fi
+exec "$shell" -lc 'exec "$STORMLIGHT_BIN" _exec'
+`
+
+// shellAssignment prefixes a script with the shell this host runs things
+// under, for the scripts that ask questions about the host.
+//
+// It is an assignment rather than a substituted value because the
+// fallback is only knowable on the far side: $SHELL is that machine's
+// answer, and asking for it first would be a round trip to learn
+// something the script is about to be told anyway.
+func (h Host) shellAssignment() string {
+	if h.Shell == "" {
+		return ""
+	}
+	return ShellEnv + "=" + shellQuote([]string{h.Shell}) + "\n"
+}
+
+// shellHint is the sentence that turns "not installed" into something to
+// do about it.
+//
+// It is for the case that produced this setting: a provider that is
+// plainly there, on a host whose account shell is not the shell its
+// owner works in. Nothing about the machine reveals that, so the message
+// says the setting exists and lets the person say which. A host already
+// configured with a shell needs no hint — it has been told, and the
+// answer is that the provider really is not on that shell's PATH.
+func (h Host) shellHint() string {
+	if h.Shell != "" {
+		return ""
+	}
+	return fmt.Sprintf(
+		"\nIf providers live on another shell's PATH there, name it: "+
+			"shell = \"/path/to/shell\" under [hosts.%s]", h.Name)
+}
+
+// shellDescription names the shell in a sentence about it: the
+// configured one, or the account's own as the host reported it.
+func (h Host) shellDescription(asked string) string {
+	if h.Shell != "" {
+		return h.Shell
+	}
+	if asked != "" {
+		return asked
+	}
+	return "its login shell"
 }
 
 // Transport dials one host's daemon. It is the thing a windrunner client

--- a/internal/remote/ssh_test.go
+++ b/internal/remote/ssh_test.go
@@ -4,6 +4,7 @@ import (
 	"encoding/json"
 	"net"
 	"os/exec"
+	"slices"
 	"strings"
 	"testing"
 	"time"
@@ -195,4 +196,123 @@ func readFull(conn net.Conn, buffer []byte) (int, error) {
 		}
 	}
 	return total, nil
+}
+
+// TestTheProvidersArgvIsNeverShellText: the launch goes through a shell
+// this machine did not choose, and a task is arbitrary text someone
+// typed. The two never meet — the argv travels as an environment value,
+// which no shell parses — and this is the round trip that says so.
+func TestTheProvidersArgvIsNeverShellText(t *testing.T) {
+	argv := []string{
+		"codex",
+		"a task with spaces",
+		`it's got a quote`,
+		`"double" and $HOME and ${BRACED}`,
+		"semi; colon && amp | pipe",
+		"back`tick` and $(command sub)",
+		`back\slash`,
+		"star * and glob ?",
+		"new\nline",
+		"", // an empty argument is still an argument
+	}
+	entry, err := ExecEnvFor(argv)
+	if err != nil {
+		t.Fatalf("ExecEnvFor: %v", err)
+	}
+	name, value, ok := strings.Cut(entry, "=")
+	if !ok || name != ExecEnv {
+		t.Fatalf("ExecEnvFor should produce a %s entry: %q", ExecEnv, entry)
+	}
+	// An environment value cannot carry a NUL, and nothing else needs
+	// escaping on the way — but a newline inside one would end the
+	// wrong thing if this were ever a line-based format.
+	if strings.ContainsRune(value, 0) {
+		t.Fatal("an environment value cannot contain NUL")
+	}
+	back, err := ExecArgv(value)
+	if err != nil {
+		t.Fatalf("ExecArgv: %v", err)
+	}
+	if !slices.Equal(back, argv) {
+		t.Fatalf("argv did not survive the round trip:\n got %q\nwant %q", back, argv)
+	}
+}
+
+// TestNothingToRunIsAnError: an empty or malformed handoff must not be
+// read as "run something plausible".
+func TestNothingToRunIsAnError(t *testing.T) {
+	for _, value := range []string{"", "[]", "not json", "{}", `"a string"`} {
+		if _, err := ExecArgv(value); err == nil {
+			t.Fatalf("ExecArgv(%q) should have failed", value)
+		}
+	}
+}
+
+// TestTheExecPreludeIsShellAgnostic: the prelude is POSIX and runs under
+// /bin/sh, but the one line it asks another shell to run is text that
+// sh, bash, zsh, ksh, and fish all read the same way. Anything more
+// expressive would work on the author's machine and not on a host whose
+// login shell is fish.
+func TestTheExecPreludeIsShellAgnostic(t *testing.T) {
+	handoff := ""
+	for _, line := range strings.Split(ExecPrelude, "\n") {
+		if strings.HasPrefix(line, "exec \"$shell\" -lc ") {
+			handoff = strings.TrimPrefix(line, "exec \"$shell\" -lc ")
+		}
+	}
+	if handoff == "" {
+		t.Fatalf("the prelude should hand off to the host's shell:\n%s", ExecPrelude)
+	}
+	// Only "$VAR" and plain words: no command substitution, no
+	// arithmetic, no arrays, no $0/$@ — the places the shells differ.
+	for _, forbidden := range []string{"$(", "`", "${", "$@", "$*", "$0", "[[", "=("} {
+		if strings.Contains(handoff, forbidden) {
+			t.Fatalf("the handoff uses %q, which is not the same in every shell: %s",
+				forbidden, handoff)
+		}
+	}
+	// And the argv is not in it, which is the point.
+	if strings.Contains(ExecPrelude, ExecEnv) {
+		t.Fatalf("the argv must not be shell text:\n%s", ExecPrelude)
+	}
+}
+
+// TestAConfiguredShellReachesTheScripts: the host's setting has to arrive
+// as an assignment the script can read, quoted, because it is a path
+// someone typed.
+func TestAConfiguredShellReachesTheScripts(t *testing.T) {
+	plain := Host{Name: "h"}
+	if got := plain.shellAssignment(); got != "" {
+		t.Fatalf("an unconfigured host should say nothing about a shell: %q", got)
+	}
+	if got := plain.shellDescription(""); got != "its login shell" {
+		t.Fatalf("shellDescription = %q", got)
+	}
+	// When the host said which shell it asked, the message names it
+	// rather than describing it.
+	if got := plain.shellDescription("/bin/zsh"); got != "/bin/zsh" {
+		t.Fatalf("shellDescription = %q", got)
+	}
+	if !strings.Contains(plain.shellHint(), "[hosts.h]") {
+		t.Fatalf("an unconfigured host should be told the setting exists: %q", plain.shellHint())
+	}
+	configured := Host{Name: "h", Shell: "/home/linuxbrew/.linuxbrew/bin/fish"}
+	want := ShellEnv + "='/home/linuxbrew/.linuxbrew/bin/fish'\n"
+	if got := configured.shellAssignment(); got != want {
+		t.Fatalf("shellAssignment = %q, want %q", got, want)
+	}
+	// A configured shell wins over whatever the host reported, and needs
+	// no hint: it has been told, so the answer is that the provider
+	// really is not on that shell's PATH.
+	if got := configured.shellDescription("/bin/zsh"); got != configured.Shell {
+		t.Fatalf("shellDescription = %q", got)
+	}
+	if got := configured.shellHint(); got != "" {
+		t.Fatalf("a configured host needs no hint: %q", got)
+	}
+	// A path with a quote in it is a path, not an injection.
+	odd := Host{Name: "h", Shell: `/opt/it's here/fish`}
+	if !strings.Contains(odd.shellAssignment(), `'\''`) {
+		t.Fatalf("a quote in the path should be quoted: %q", odd.shellAssignment())
+	}
 }

--- a/internal/windrun/overlay.go
+++ b/internal/windrun/overlay.go
@@ -10,6 +10,7 @@ import (
 	"github.com/trentkm/windrunner/client"
 	"github.com/trentkm/windrunner/wire"
 
+	"github.com/trentkm/stormlight/internal/remote"
 	"github.com/trentkm/stormlight/internal/session"
 )
 
@@ -68,6 +69,13 @@ func (r *Runtime) StartOverlay(ctx context.Context, request session.OverlayReque
 	// its answer there. WINDRUNNER_SESSION names the session; this says
 	// which daemon to say it to.
 	spawn.EnvOverride = []string{"WINDRUNNER_DIR=" + socketDir}
+	// An overlay looks for its tools on the same host the providers run
+	// on, so it is told the same shell to look with.
+	if r.transport != nil {
+		if shell := r.transport.Host().Shell; shell != "" {
+			spawn.EnvOverride = append(spawn.EnvOverride, remote.ShellEnv+"="+shell)
+		}
+	}
 	info, err := r.client.Spawn(spawn)
 	if err != nil {
 		return nil, fmt.Errorf("spawn overlay %s: %w", command, err)

--- a/internal/windrun/remote_test.go
+++ b/internal/windrun/remote_test.go
@@ -33,6 +33,16 @@ const (
 // its stdio onto the socket; here the daemon is already running and the
 // splice is the part under test.
 func TestMain(m *testing.M) {
+	// The far side's Stormlight, as the launch prelude invokes it: the
+	// login shell execs `$STORMLIGHT_BIN _exec`, and on this harness
+	// that binary is this one.
+	if len(os.Args) > 1 && os.Args[1] == "_exec" {
+		if err := remote.Exec(); err != nil {
+			fmt.Fprintln(os.Stderr, "exec:", err)
+			os.Exit(127)
+		}
+		os.Exit(0)
+	}
 	if os.Getenv(helperSentinel) != "" {
 		hello := remote.Hello{
 			Protocol:  remote.Protocol,
@@ -48,6 +58,18 @@ func TestMain(m *testing.M) {
 		os.Exit(0)
 	}
 	os.Exit(m.Run())
+}
+
+// testBinary is this test binary, which the harness casts as the remote
+// host's Stormlight: the bridge reports it as $STORMLIGHT_BIN, and the
+// launch prelude runs it as `_exec`.
+func testBinary(t *testing.T) string {
+	t.Helper()
+	self, err := os.Executable()
+	if err != nil {
+		t.Fatalf("executable: %v", err)
+	}
+	return self
 }
 
 // remoteRuntime stands a daemon up, points a fake ssh at this binary's
@@ -88,7 +110,7 @@ func remoteRuntime(t *testing.T) *Runtime {
 for last; do :; done
 if [ "$last" = "-s" ]; then exec /bin/sh -s; fi
 %s=1 %s=%q %s=%q exec %q -test.run=TestMainBridgeHelperNeverRuns
-`, helperSentinel, helperEnv, socket, helperBinEnv, "/remote/bin/stormlight", self)
+`, helperSentinel, helperEnv, socket, helperBinEnv, self, self)
 	if err := os.WriteFile(fakeSSH, []byte(script), 0o755); err != nil {
 		t.Fatalf("write fake ssh: %v", err)
 	}
@@ -98,6 +120,60 @@ if [ "$last" = "-s" ]; then exec /bin/sh -s; fi
 		t.Fatalf("NewRemoteRuntime: %v", err)
 	}
 	return runtime
+}
+
+// withShell re-points a runtime's host at a configured login shell,
+// which is the one thing about a host that changes how its providers are
+// found and run.
+func withShell(t *testing.T, runtime *Runtime, shell string) *Runtime {
+	t.Helper()
+	host := runtime.transport.Host()
+	host.Shell = shell
+	replaced, err := NewRemoteRuntime(host)
+	if err != nil {
+		t.Fatalf("NewRemoteRuntime: %v", err)
+	}
+	return replaced
+}
+
+// fakeLoginShell stands in for the shell a host is configured with — a
+// fish, a Homebrew zsh, whatever the person there actually works in. It
+// does what such a shell does that matters here: it answers to -lc, and
+// it brings an environment of its own that the daemon did not have.
+func fakeLoginShell(t *testing.T, providerDir string) string {
+	t.Helper()
+	dir, err := os.MkdirTemp("", "sh")
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { os.RemoveAll(dir) })
+	path := filepath.Join(dir, "loginsh")
+	script := "#!/bin/sh\n" +
+		"PATH=" + providerDir + ":$PATH\n" +
+		"LOGIN_SHELL_ENV=only-this-shell-has-it\n" +
+		"export PATH LOGIN_SHELL_ENV\n" +
+		// -lc <command>: the one calling convention every shell shares.
+		"exec /bin/sh -c \"$2\"\n"
+	if err := os.WriteFile(path, []byte(script), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	return path
+}
+
+// providerOnly writes a provider that exists nowhere but the directory
+// returned, so that finding it proves which PATH was searched.
+func providerOnly(t *testing.T, name, body string) (dir, path string) {
+	t.Helper()
+	dir, err := os.MkdirTemp("", "prov")
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { os.RemoveAll(dir) })
+	path = filepath.Join(dir, name)
+	if err := os.WriteFile(path, []byte(body), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	return dir, path
 }
 
 // TestRemoteDispatchTellsTheAgentAboutItsOwnMachine is the whole point of
@@ -132,15 +208,19 @@ func TestRemoteDispatchTellsTheAgentAboutItsOwnMachine(t *testing.T) {
 	}
 
 	screen := waitForScreen(t, runtime, dispatched.ID, "end")
+	// The terminal is 80 columns and these values are longer, so what it
+	// printed is wrapped: the comparison is against the text, not the
+	// layout.
+	unwrapped := strings.NewReplacer("\r", "", "\n", "").Replace(screen)
 	for _, want := range []string{
 		"id=" + dispatched.ID,
 		// The bridge's answers, not this machine's.
-		"bin=/remote/bin/stormlight",
+		"bin=" + testBinary(t),
 		"dir=" + helperSocketDir,
 		// The daemon's own environment came through underneath.
 		"marker=from-the-far-side",
 	} {
-		if !strings.Contains(screen, want) {
+		if !strings.Contains(unwrapped, want) {
 			t.Fatalf("agent environment missing %q:\n%s", want, screen)
 		}
 	}
@@ -372,7 +452,10 @@ func TestTheProviderIsResolvedOnTheMachineThatRunsIt(t *testing.T) {
 
 	// A provider that exists on the far side under a path this machine
 	// has never had, dispatched with a local path that is nonsense there.
-	remoteOnly := filepath.Join(t.TempDir(), "codex")
+	// The name is its own: a provider anyone might actually have
+	// installed would make this pass or fail on the developer's machine
+	// rather than on the code.
+	remoteOnly := filepath.Join(t.TempDir(), "codex-under-test")
 	if err := os.WriteFile(remoteOnly, []byte(
 		"#!/bin/sh\nprintf 'ran %s\\nend\\n' \"$0\"; sleep 60\n"), 0o755); err != nil {
 		t.Fatal(err)
@@ -383,8 +466,8 @@ func TestTheProviderIsResolvedOnTheMachineThatRunsIt(t *testing.T) {
 		Provider: agent.Provider("codex"),
 		Cwd:      t.TempDir(),
 		Launch: session.Launch{
-			Path:    "/Users/someone/.toolbox/bin/codex",
-			Program: "codex",
+			Path:    "/Users/someone/.toolbox/bin/codex-under-test",
+			Program: "codex-under-test",
 		},
 	})
 	if err != nil {
@@ -432,10 +515,162 @@ func TestAProviderMissingThereSaysSo(t *testing.T) {
 // the machine the dashboard is on, where the path was already right.
 func TestLocalDispatchStillUsesTheResolvedPath(t *testing.T) {
 	local := &Runtime{}
-	path, err := local.providerPath(context.Background(), session.Launch{
-		Path: "/usr/local/bin/codex", Program: "codex",
+	command, args, err := local.launchCommand(context.Background(), session.Launch{
+		Path: "/usr/local/bin/codex", Program: "codex", Args: []string{"--go"},
 	})
-	if err != nil || path != "/usr/local/bin/codex" {
-		t.Fatalf("providerPath = %q, %v", path, err)
+	if err != nil || command != "/usr/local/bin/codex" {
+		t.Fatalf("launchCommand = %q, %v", command, err)
+	}
+	// No shell in the middle either: the dashboard's own machine is
+	// already the environment the provider wants.
+	if len(args) != 1 || args[0] != "--go" {
+		t.Fatalf("local args should be the provider's own: %q", args)
+	}
+}
+
+// TestAConfiguredShellFindsAndRunsTheProvider is the whole of #185 in
+// one test.
+//
+// The host's account shell knows nothing about the provider; the shell
+// the person there actually works in has it on PATH. Both halves have to
+// follow from naming that shell: it is what the lookup asks, so the
+// provider is found, and it is what the launch goes through, so the
+// provider runs with that shell's environment rather than the daemon's.
+func TestAConfiguredShellFindsAndRunsTheProvider(t *testing.T) {
+	dir, _ := providerOnly(t, "codex", "#!/bin/sh\n"+
+		`printf 'env=%s\nend\n' "$LOGIN_SHELL_ENV"; sleep 60`+"\n")
+	runtime := withShell(t, remoteRuntime(t), fakeLoginShell(t, dir))
+
+	dispatched, err := runtime.Dispatch(context.Background(), session.DispatchRequest{
+		Provider: agent.Provider("codex"),
+		Cwd:      t.TempDir(),
+		// A path from the dashboard's own machine, which is what the
+		// dashboard has and what the host has never had.
+		Launch: session.Launch{Path: "/Users/someone/.toolbox/bin/codex", Program: "codex"},
+	})
+	if err != nil {
+		t.Fatalf("a provider on the configured shell's PATH must dispatch: %v", err)
+	}
+	screen := waitForScreen(t, runtime, dispatched.ID, "end")
+	// Resolving it was never the whole job: a provider found on a login
+	// shell's PATH is regularly a shim that needs the rest of that
+	// shell's environment to work.
+	if !strings.Contains(screen, "env=only-this-shell-has-it") {
+		t.Fatalf("the provider should have the configured shell's environment:\n%s", screen)
+	}
+}
+
+// TestProviderArgumentsAreNotShellText: the launch goes through a shell,
+// and a task is arbitrary text someone typed. If the two ever meet, a
+// quote in a task becomes syntax on a machine whose shell this one does
+// not choose. They must not meet.
+func TestProviderArgumentsAreNotShellText(t *testing.T) {
+	// Echoes each argument on its own line, bracketed, so that a lost
+	// one, a split one, and a mangled one all look different.
+	dir, _ := providerOnly(t, "codex", "#!/bin/sh\n"+
+		`for a in "$@"; do printf '[%s]\n' "$a"; done; printf 'end\n'; sleep 60`+"\n")
+	runtime := withShell(t, remoteRuntime(t), fakeLoginShell(t, dir))
+
+	hostile := []string{
+		"a task with spaces",
+		`it's got a quote`,
+		`"double" and $HOME and ${BRACED}`,
+		"semi; colon && amp | pipe",
+		"back`tick` and $(command sub)",
+		`back\slash`,
+		"star * and glob ?",
+		"new\nline",
+	}
+	dispatched, err := runtime.Dispatch(context.Background(), session.DispatchRequest{
+		Provider: agent.Provider("codex"),
+		Cwd:      t.TempDir(),
+		Launch:   session.Launch{Program: "codex", Args: hostile},
+	})
+	if err != nil {
+		t.Fatalf("Dispatch: %v", err)
+	}
+	screen := waitForScreen(t, runtime, dispatched.ID, "end")
+	// The terminal wraps at 80 columns, and a newline inside an argument
+	// is a real line break in the output — so the comparison is against
+	// the run of characters, not the lines.
+	flat := strings.NewReplacer("\r", "", "\n", "").Replace(screen)
+	for _, arg := range hostile {
+		want := "[" + strings.ReplaceAll(arg, "\n", "") + "]"
+		if !strings.Contains(flat, want) {
+			t.Fatalf("argument %q did not arrive intact (wanted %q):\n%s", arg, want, screen)
+		}
+	}
+}
+
+// TestAShellThatIsNotThereSaysWhichSetting: with a bad shell configured,
+// every provider on the host looks missing. That points at the wrong
+// thing entirely, so the shell is named as the fault instead.
+func TestAShellThatIsNotThereSaysWhichSetting(t *testing.T) {
+	runtime := withShell(t, remoteRuntime(t), "/opt/nothing/here/fish")
+	_, err := runtime.Dispatch(context.Background(), session.DispatchRequest{
+		Provider: agent.Provider("codex"),
+		Cwd:      t.TempDir(),
+		Launch:   session.Launch{Program: "codex"},
+	})
+	if err == nil {
+		t.Fatal("a configured shell that is not there must not dispatch")
+	}
+	for _, want := range []string{"/opt/nothing/here/fish", "shell", "testhost"} {
+		if !strings.Contains(err.Error(), want) {
+			t.Fatalf("the error should name %q: %v", want, err)
+		}
+	}
+}
+
+// TestWithNoConfiguredShellTheAccountsOwnIsUsed: naming a shell is how a
+// host differs from its default, not a thing every host must do.
+func TestWithNoConfiguredShellTheAccountsOwnIsUsed(t *testing.T) {
+	dir, _ := providerOnly(t, "codex", "#!/bin/sh\n"+
+		`printf 'env=%s\nend\n' "$LOGIN_SHELL_ENV"; sleep 60`+"\n")
+	// $SHELL is what an unconfigured host falls back to, and here it is
+	// the same stand-in — reached by the other route.
+	t.Setenv("SHELL", fakeLoginShell(t, dir))
+
+	runtime := remoteRuntime(t)
+	dispatched, err := runtime.Dispatch(context.Background(), session.DispatchRequest{
+		Provider: agent.Provider("codex"),
+		Cwd:      t.TempDir(),
+		Launch:   session.Launch{Program: "codex"},
+	})
+	if err != nil {
+		t.Fatalf("the account's own shell should still be used: %v", err)
+	}
+	screen := waitForScreen(t, runtime, dispatched.ID, "end")
+	if !strings.Contains(screen, "env=only-this-shell-has-it") {
+		t.Fatalf("the account's shell should have supplied the environment:\n%s", screen)
+	}
+}
+
+// TestAMissingProviderPointsAtTheSetting: the message someone gets when
+// their provider is installed and Stormlight says it is not. It has to
+// carry the way out, because nothing about the machine reveals that the
+// shell it was asked about is not the shell its owner works in.
+func TestAMissingProviderPointsAtTheSetting(t *testing.T) {
+	t.Setenv("SHELL", "/bin/zsh")
+	runtime := remoteRuntime(t)
+	_, err := runtime.Dispatch(context.Background(), session.DispatchRequest{
+		Provider: agent.Provider("codex"),
+		Cwd:      t.TempDir(),
+		Launch:   session.Launch{Program: "a-provider-no-machine-has"},
+	})
+	if err == nil {
+		t.Fatal("a provider nothing has must not dispatch")
+	}
+	t.Logf("the message is:\n%s", err)
+	for _, want := range []string{
+		"a-provider-no-machine-has", // what
+		"testhost",                  // where
+		"/bin/zsh",                  // what was asked
+		"shell =",                   // and what to do about it
+		"[hosts.testhost]",
+	} {
+		if !strings.Contains(err.Error(), want) {
+			t.Fatalf("the message should carry %q:\n%s", want, err)
+		}
 	}
 }

--- a/internal/windrun/runtime.go
+++ b/internal/windrun/runtime.go
@@ -274,17 +274,28 @@ func (r *Runtime) Dispatch(ctx context.Context, request session.DispatchRequest)
 		// so the machinery is switched off rather than chased.
 		"CLAUDE_CODE_DISABLE_TERMINAL_TITLE=1",
 	}
-	// The provider is resolved where it will run. Launch.Path answers
-	// "where is it here", which for another machine is a path that
-	// machine has never had — a macOS toolbox path handed to a Linux
-	// daemon can only come back as no such file.
-	program, err := r.providerPath(ctx, request.Launch)
+	// The provider runs where it lives, which for another machine means
+	// neither the path nor the environment this one has. Launch.Path
+	// answers "where is it here", and a macOS toolbox path handed to a
+	// Linux daemon can only come back as no such file.
+	command, args, err := r.launchCommand(ctx, request.Launch)
 	if err != nil {
 		return agent.Agent{}, err
 	}
+	if r.transport != nil {
+		argv, err := remote.ExecEnvFor(
+			append([]string{providerName(request.Launch)}, request.Launch.Args...))
+		if err != nil {
+			return agent.Agent{}, err
+		}
+		overrides = append(overrides, argv)
+		if shell := r.transport.Host().Shell; shell != "" {
+			overrides = append(overrides, remote.ShellEnv+"="+shell)
+		}
+	}
 	spawn := wire.Request{
-		Command: program,
-		Args:    request.Launch.Args,
+		Command: command,
+		Args:    args,
 		Dir:     request.Cwd,
 		// Peer input is how the dashboard and CLI speak to an agent
 		// without an attachment — Send, Interrupt, `stormlight send` —
@@ -317,23 +328,40 @@ func (r *Runtime) Dispatch(ctx context.Context, request session.DispatchRequest)
 	return managedAgent, nil
 }
 
-// providerPath is the provider as the machine running it will find it.
+// launchCommand is what the daemon on the far side is asked to start.
 //
-// Locally that is the path already resolved. Remotely it is resolved
-// there, so a provider the host does not have is reported as missing
-// from that host by name, rather than as a path from this one that it
-// was never going to have.
-func (r *Runtime) providerPath(ctx context.Context, launch session.Launch) (string, error) {
+// Locally that is the provider, at the path already resolved here.
+// Remotely it is a POSIX script, because resolving the provider is only
+// half of running it: one found on a login shell's PATH is regularly a
+// shim — mise, asdf, a Homebrew wrapper — that needs the rest of that
+// shell's environment to work, and the daemon over there has whatever
+// environment it was started with instead. The script hands off to the
+// host's shell, which hands off to Stormlight, which becomes the
+// provider. The argv travels in the environment rather than through the
+// shell, so nothing about it is ever parsed as syntax.
+//
+// The check that the host has the provider at all happens here, before
+// an agent exists to be a corpse: a machine without it should say so in
+// the dashboard, not in a terminal nobody asked for.
+func (r *Runtime) launchCommand(ctx context.Context, launch session.Launch) (string, []string, error) {
 	if r.transport == nil {
-		return launch.Path, nil
+		return launch.Path, launch.Args, nil
 	}
-	program := launch.Program
-	if program == "" {
-		// A launch with no name to resolve — a custom spec from an older
-		// record — leaves nothing better than the path it carries.
-		program = launch.Path
+	if _, err := remote.LookPath(ctx, r.transport, providerName(launch)); err != nil {
+		return "", nil, err
 	}
-	return remote.LookPath(ctx, r.transport, program)
+	return "/bin/sh", []string{"-c", remote.ExecPrelude}, nil
+}
+
+// providerName is the provider as something to look up, rather than as a
+// path this machine happens to have resolved.
+func providerName(launch session.Launch) string {
+	if launch.Program != "" {
+		return launch.Program
+	}
+	// A launch with no name to resolve — a custom spec from an older
+	// record — leaves nothing better than the path it carries.
+	return launch.Path
 }
 
 // sessionIDFor maps an agent id to the daemon's session id.

--- a/main.go
+++ b/main.go
@@ -129,6 +129,7 @@ func newRootCommand() *cobra.Command {
 		newWindrunnerBridgeCommand(),
 		newResolveCommand(),
 		newReadCommand(),
+		newExecCommand(),
 		newPickCommand(),
 		newHistoryCommand(),
 		newBenchCommand(),
@@ -254,6 +255,19 @@ func newReadCommand() *cobra.Command {
 			defer file.Close()
 			_, err = io.Copy(cmd.OutOrStdout(), io.LimitReader(file, windrun.MaxAgentFile))
 			return err
+		},
+	}
+}
+
+// newExecCommand is the far side of a remote dispatch: the provider's
+// argv, decoded from the environment the daemon set, and become.
+func newExecCommand() *cobra.Command {
+	return &cobra.Command{
+		Use:    "_exec",
+		Hidden: true,
+		Args:   cobra.NoArgs,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			return remote.Exec()
 		},
 	}
 }
@@ -703,6 +717,7 @@ func remoteHostFrom(name string, host config.Host) remote.Host {
 		Destination: host.Destination,
 		Bin:         host.Bin,
 		Options:     host.Options,
+		Shell:       host.Shell,
 		NoMultiplex: host.NoMultiplex,
 	}
 }

--- a/site/docs/configuration.html
+++ b/site/docs/configuration.html
@@ -42,6 +42,7 @@
     <li><a href="#file-location">File location</a></li>
     <li><a href="#format">Format</a></li>
     <li><a href="#schema">Schema</a></li>
+    <li class="sub"><a href="#host-shell">The host&rsquo;s execution shell</a></li>
     <li><a href="#wiring">Wiring</a></li>
     <li><a href="#project-local">Project-local config</a></li>
     </ul></li>
@@ -143,6 +144,8 @@ provider = <span class="s">"claude"</span>
 <span class="c"># destination  = "trent@10.0.0.4"   # defaults to the key</span>
 <span class="c"># bin          = "/opt/bin/stormlight"  # when it is not on PATH</span>
 <span class="c"># options      = ["-p", "2222"]     # extra ssh flags</span>
+<span class="c"># shell        = "/opt/homebrew/bin/fish"  # the shell providers are</span>
+<span class="c">#                                          # found and run in</span>
 <span class="c"># no_multiplex = false              # sharing is on by default</span></code></pre>
     <p>A host joins the dashboard as another daemon: its agents appear in the same roster,
     its workspaces in the same pane, and <code>dispatch --host</code> starts agents there.
@@ -155,6 +158,36 @@ provider = <span class="s">"claude"</span>
     <code>destination</code> when the name is not what ssh should dial, <code>bin</code>
     when Stormlight is somewhere a non-interactive shell will not find it,
     <code>options</code> for extra flags.</p>
+    <h3 id="host-shell">The host&rsquo;s execution shell</h3>
+    <p><code>shell</code> is the one setting about a host that is not about reaching it. It
+    names the login shell that defines what &ldquo;installed&rdquo; means there.</p>
+    <p>The default is the account&rsquo;s own <code>$SHELL</code>, which is right whenever
+    the shell someone works in is the shell their account records. It stops being right the
+    moment those differ &mdash; an account whose <code>$SHELL</code> is <code>/bin/zsh</code>
+    belonging to someone who has configured fish, whose <code>PATH</code> is the only one
+    that finds <code>codex</code>. Nothing about the machine reveals which shell was meant,
+    so the setting says it outright; Stormlight does not scan for installed shells and
+    guess. The path must be absolute, for the same reason the setting exists: the
+    <code>PATH</code> a non-interactive SSH session gets is exactly the <code>PATH</code>
+    that will not find the shell by name.</p>
+    <p>The shell is used for both halves of running a provider, because using it for only
+    one is worse than using it for neither. <em>Discovery</em> &mdash; &ldquo;is
+    <code>codex</code> installed here&rdquo; &mdash; is asked of that shell, so a provider
+    present only on its <code>PATH</code> is found. <em>Launch</em> goes through it, so the
+    provider inherits the environment and not merely the path: a provider found on a login
+    shell&rsquo;s <code>PATH</code> is regularly a shim &mdash; mise, asdf, a Homebrew
+    wrapper &mdash; that needs the rest of that shell&rsquo;s environment to work at all.
+    Resolving it to an absolute path and then running it under the daemon&rsquo;s bare
+    environment finds the right file and still fails.</p>
+    <p>The launch is three <code>exec</code> calls and no wrapper process, so what the
+    daemon supervises is the provider itself &mdash; signals, exit status, and lifetime
+    untouched by the route taken to start it. The provider&rsquo;s argv never appears in
+    shell text: it travels in an environment variable as JSON and is decoded on the far
+    side, because task text and custom provider arguments are arbitrary input and the shell
+    that would parse them is one this machine does not choose.</p>
+    <p>A configured shell that is missing or not executable is reported as that &mdash;
+    naming the setting and the host &mdash; rather than as every provider on the host having
+    gone missing, which is what the symptom otherwise looks like.</p>
     <p>Custom providers appear in the New Agent picker and dispatch like any other.
     Lifecycle integration is the public contract: managed processes receive
     <code>STORMLIGHT_ID</code> and can report state with <code>stormlight event</code> from


### PR DESCRIPTION
Closes #185.

## The problem

A provider is installed on a host and works in the shell its owner uses there, and Stormlight reports it missing. The account's `$SHELL` is `/bin/zsh`; the shell they actually configured is fish; only fish's `PATH` has `codex`. Nothing about the machine reveals which shell was meant.

## The contract

```toml
[hosts.trentkm-cld2]
shell = "/home/linuxbrew/.linuxbrew/bin/fish"
```

Absolute — the `PATH` a non-interactive SSH session gets is exactly the `PATH` that cannot find the shell by name. Unset keeps the account's own `$SHELL`. No shell is scanned for or guessed at.

It governs **both** halves, because governing one is worse than governing neither:

- **Discovery** asks that shell — and asks it *first*, not as a fallback. A bare SSH `PATH` holding a different build of the same name is how a check passes and the launch runs something else.
- **Launch** goes through it, so the provider inherits the environment and not merely the path. A provider found on a login shell's `PATH` is regularly a shim (mise, asdf, a Homebrew wrapper) that needs the rest of that shell's environment; resolving it to an absolute path and running it under the daemon's bare environment finds the right file and still fails.

## How the launch works

The daemon spawns `/bin/sh` with a fixed script → execs the host's shell → execs `stormlight _exec` → becomes the provider. Three execs, no wrapper: what the daemon supervises is the provider itself, so signals, exit status and lifetime are untouched.

**The argv never becomes shell text.** It travels as JSON in an environment variable and is decoded on the far side. Task text and custom provider arguments are arbitrary input, and the shell that would parse them is one this machine does not choose — POSIX quoting is not fish quoting, and no amount of escaping makes it so. The only shell syntax involved is a fixed string that `sh`, `bash`, `zsh`, `ksh` and `fish` all read identically (asserted by a test).

## Verified on real hardware

Against a Mac mini over SSH (account `$SHELL` is fish), with a provider placed so that only the configured shell's `PATH` finds it:

```
ran-as=/Users/trent/sl185/bin/sl185-provider
MARKER=only-this-shell-has-it
PATH=/Users/trent/sl185/bin:/Users/trent/.local/bin:/usr/bin:...
argc=1
arg1=<it's $(whoami) `id` "quoted" && rm -rf / | pipe * ?glob>
```

The environment came from the configured shell, not just the path; and every metacharacter arrived verbatim as a **single** argument. The process table showed the provider parented directly by `stormlight _wrdaemon` with no wrapper shell surviving. Repeated with real fish (`/opt/homebrew/bin/fish`) as the configured shell — the provider ran under fish's own login `PATH`.

Failure modes, as seen from the CLI:

```
$ stormlight dispatch --host mini --provider sl185 ...      # nothing configured
Error: sl185-provider is not installed on mini, or not on the PATH /opt/homebrew/bin/fish sets.
If providers live on another shell's PATH there, name it: shell = "/path/to/shell" under [hosts.mini]

$ ...                                                        # shell = "/opt/homebrew/bin/nope"
Error: mini: shell = "/opt/homebrew/bin/nope" in [hosts.mini] is not an executable file there

$ ...                                                        # shell = "fish"
config.toml: hosts.mini.shell: "fish" must be an absolute path
```

The first is the message that produced this issue; it now names the shell that was asked and the setting that would change it. The second blames the shell rather than reporting every provider on the machine as missing.

## Acceptance checks

- [x] A host whose account has `SHELL=/bin/zsh` can configure an absolute Fish path
- [x] A provider present only on that shell's login `PATH` is discovered and dispatched
- [x] The provider receives the shell's environment, not merely an absolute path
- [x] Arguments with spaces, quotes, metacharacters and newlines arrive unchanged
- [x] With no configured shell, the account's `$SHELL` remains the default
- [x] A missing or non-executable configured shell produces a host-specific actionable error
- [x] `docs/config-design.md` and `site/docs/configuration.html` describe the field and its execution semantics

The remote picker's Yazi lookup uses the same shell, since it asks the same question about the same host.

## Noted, not fixed here

`providers.Resolve` does a **local** `exec.LookPath` before dispatch, so a provider that exists only on the remote host cannot be dispatched at all. Same family as #171, but a distinct change in a different layer — filed separately.