### PR TITLE
A host says which of its shells can see the providers

### DIFF
--- a/docs/config-design.md
+++ b/docs/config-design.md
@@ -169,6 +169,30 @@ A configured shell that is missing or not executable is reported as that —
 naming the setting and the host — rather than as every provider on the host
 having gone missing, which is what the symptom otherwise looks like.
 
+`stormlight remote setup <host>` answers the question rather than leaving it
+to be discovered by failure. It asks the host which of its login shells can
+see the configured providers — the account's own, whatever `/etc/shells`
+registers, and a few names that may be installed without being registered —
+and prints the result side by side:
+
+```
+  providers, by the shell that can see them:
+  * /opt/homebrew/bin/fish             claude
+    /bin/bash                          claude codex
+    /bin/zsh                           claude
+  * the account's own shell, used unless [hosts.mini] names another
+```
+
+When the account's shell sees strictly fewer providers than another, setup
+records `shell` for that host and says so. This is evidence rather than a
+guess: the machine was asked, and it answered. A host whose account shell can
+see everything is left alone — a host that works is not improved by being
+configured — and a `shell` someone has already set by hand is never
+overwritten.
+
+The survey costs a login shell per candidate, so it runs only when there are
+providers to ask about. The dashboard's own reachability check skips it.
+
 ## Wiring
 
 - New `internal/config` package: `config.Load()` → `Config` struct with the

--- a/internal/provider/provider.go
+++ b/internal/provider/provider.go
@@ -30,6 +30,11 @@ type Adapter interface {
 	ID() agent.Provider
 	Label() string
 	Resolve(prompt string, mode agent.PermissionMode) (Launch, error)
+	// Binary is the program this provider runs, as a name to look up
+	// rather than a path some machine already resolved. It is what a
+	// host is asked about when the question is whether that machine can
+	// run this provider at all.
+	Binary() string
 	// CanResume reports whether this adapter has a resume path at all.
 	// Capability is a value, not a type: one adapter implementation serves
 	// every command-line provider, and whether a given one can be reopened
@@ -66,6 +71,10 @@ type commandAdapter struct {
 
 func (a commandAdapter) ID() agent.Provider {
 	return a.id
+}
+
+func (a commandAdapter) Binary() string {
+	return a.binary
 }
 
 func (a commandAdapter) Label() string {
@@ -334,6 +343,24 @@ func (r *Registry) Infos() []Info {
 		})
 	}
 	return infos
+}
+
+// Binaries are the programs the configured providers run, deduplicated
+// and in registration order. A host is asked about these — which of its
+// shells can see them is the question that decides whether it can host
+// an agent at all.
+func (r *Registry) Binaries() []string {
+	seen := make(map[string]bool, len(r.order))
+	binaries := make([]string, 0, len(r.order))
+	for _, id := range r.order {
+		binary := r.adapters[id].Binary()
+		if binary == "" || seen[binary] {
+			continue
+		}
+		seen[binary] = true
+		binaries = append(binaries, binary)
+	}
+	return binaries
 }
 
 func (r *Registry) IDs() []agent.Provider {

--- a/internal/remote/setup.go
+++ b/internal/remote/setup.go
@@ -7,6 +7,7 @@ import (
 	"fmt"
 	"io"
 	"os/exec"
+	"slices"
 	"strings"
 )
 
@@ -44,6 +45,78 @@ type Report struct {
 	// Musl says the host links against musl rather than glibc, which is
 	// a different binary rather than a slower one.
 	Musl bool
+	// AccountShell is the shell the host's account records — the default
+	// providers are looked for and launched under.
+	AccountShell string
+	// Shells is what each of the host's login shells can see, in a
+	// stable order with the account's own first. Empty when the probe
+	// was not asked about any providers.
+	Shells []ShellReport
+	// Asked are the providers the survey asked about, which is what
+	// "this shell sees everything" is measured against.
+	Asked []string
+}
+
+// ShellReport is one login shell on a host, and which of the providers
+// asked about its login PATH can find.
+//
+// It is evidence rather than advice. A machine cannot say which shell
+// its owner meant to work in — that is why [hosts.*].shell exists — but
+// it can say which shells can see the programs, and that turns an
+// unanswerable question into a list.
+type ShellReport struct {
+	Path string
+	// Finds are the providers this shell's login PATH can see, named as
+	// they were asked about.
+	Finds []string
+}
+
+// Sees reports whether this shell can find a provider.
+func (s ShellReport) Sees(program string) bool {
+	return slices.Contains(s.Finds, program)
+}
+
+// Account is the report for the shell this host's account records, which
+// is the one Stormlight uses when nothing says otherwise.
+func (r Report) Account() (ShellReport, bool) {
+	for _, shell := range r.Shells {
+		if shell.Path == r.AccountShell {
+			return shell, true
+		}
+	}
+	return ShellReport{}, false
+}
+
+// SuggestedShell is the shell worth naming in [hosts.*], if any.
+//
+// The rule is narrow on purpose. The account's own shell is the default
+// and stays the default whenever it can see everything — a host that
+// works is not improved by being configured. A suggestion is made only
+// when some other shell can see strictly more, which is the situation
+// the setting exists for and the one nothing else can diagnose: the
+// provider is installed, it works when its owner runs it, and the
+// account shell cannot find it.
+//
+// Nothing here decides anything. What it returns is the shell that saw
+// the most, for a caller to act on or offer.
+func (r Report) SuggestedShell() (ShellReport, bool) {
+	if len(r.Asked) == 0 || len(r.Shells) == 0 {
+		return ShellReport{}, false
+	}
+	account, known := r.Account()
+	if known && len(account.Finds) == len(r.Asked) {
+		return ShellReport{}, false
+	}
+	best := ShellReport{}
+	for _, shell := range r.Shells {
+		if shell.Path == r.AccountShell || len(shell.Finds) <= len(account.Finds) {
+			continue
+		}
+		if len(shell.Finds) > len(best.Finds) {
+			best = shell
+		}
+	}
+	return best, best.Path != ""
 }
 
 // Ready reports whether the host can host agents at all.
@@ -98,10 +171,60 @@ for manager in brew apt-get dnf pacman apk; do
 done
 `
 
+// shellSurveyScript asks the host which of its shells can see the
+// providers. It runs only when there are providers to ask about, because
+// it starts a login shell per candidate and a login shell is not cheap —
+// the dashboard's own reachability check has no use for the answer.
+//
+// Candidates are the account's own shell, whatever /etc/shells
+// registers, and a short list of names that may be installed without
+// being registered. Nothing here picks one: the answer is a list of
+// shells and what each can see, and choosing is somebody else's job.
+const shellSurveyScript = `
+NL='
+'
+shells="$NL"
+add_shell() {
+  [ -n "$1" ] || return 0
+  [ -x "$1" ] || return 0
+  case "$shells" in *"$NL$1$NL"*) return 0 ;; esac
+  shells="$shells$1$NL"
+}
+add_shell "$SHELL"
+if [ -r /etc/shells ]; then
+  while IFS= read -r line; do
+    case "$line" in ''|\#*) continue ;; esac
+    add_shell "$line"
+  done < /etc/shells
+fi
+for name in fish zsh bash ksh dash sh; do
+  add_shell "$(command -v "$name" 2>/dev/null)"
+done
+printf 'account_shell=%s\n' "$SHELL"
+# One invocation per shell, asking about every provider at once. The
+# query is "command -v x >/dev/null 2>&1 && echo ..." repeated, which is
+# the same program in sh, bash, zsh, ksh, and fish alike — a loop or an
+# if would not be.
+query=""
+for program in $providers; do
+  query="$query command -v $program >/dev/null 2>&1 && echo shell_found=$program;"
+done
+printf '%s' "$shells" | while IFS= read -r candidate; do
+  [ -n "$candidate" ] || continue
+  printf 'shell=%s\n' "$candidate"
+  [ -n "$query" ] || continue
+  # A login shell may greet, print a motd, or complain; only the lines
+  # this asked for are read, and the rest is noise by construction.
+  "$candidate" -lc "$query" 2>/dev/null | while IFS= read -r line; do
+    case "$line" in shell_found=*) printf '%s\n' "$line" ;; esac
+  done
+done
+`
+
 // Probe asks a host what it has. It is the first thing that touches a
 // machine, so its errors are the ones that have to be legible: an
 // unaccepted host key, a refused login, a name that does not resolve.
-func Probe(ctx context.Context, transport *Transport) (Report, error) {
+func Probe(ctx context.Context, transport *Transport, providers ...string) (Report, error) {
 	// The configured binary travels as an environment variable rather
 	// than spliced into the script: it is a path someone typed, and a
 	// script is not the place to find out it had a quote in it.
@@ -109,6 +232,13 @@ func Probe(ctx context.Context, transport *Transport) (Report, error) {
 	if bin := transport.Host().Bin; bin != "" {
 		script = "STORMLIGHT_CONFIGURED_BIN=" +
 			shellQuote([]string{bin}) + "\n" + script
+	}
+	// The survey costs a login shell per candidate, so it is asked for
+	// rather than assumed: the dashboard's reachability check wants an
+	// answer in a frame and has no use for this one.
+	asked := plainWords(providers)
+	if len(asked) > 0 {
+		script += "providers='" + strings.Join(asked, " ") + "'\n" + shellSurveyScript
 	}
 	command := transport.ShellCommand(ctx, script)
 	var stdout, stderr bytes.Buffer
@@ -121,12 +251,20 @@ func Probe(ctx context.Context, transport *Transport) (Report, error) {
 		return Report{}, fmt.Errorf("%s: %w", transport.Host().Name, err)
 	}
 
+	report := parseReport(stdout.String())
+	report.Host = transport.Host().Name
+	report.Asked = asked
+	return report, nil
+}
+
+// parseReport reads back what the probe printed: one key=value per line,
+// and for the survey a shell followed by what it found.
+func parseReport(answered string) Report {
 	report := Report{
-		Host:       transport.Host().Name,
 		Stormlight: Requirement{Name: "stormlight", Required: true},
 		Yazi:       Requirement{Name: "yazi"},
 	}
-	for _, line := range strings.Split(stdout.String(), "\n") {
+	for _, line := range strings.Split(answered, "\n") {
 		key, value, ok := strings.Cut(strings.TrimSpace(line), "=")
 		if !ok {
 			continue
@@ -146,9 +284,38 @@ func Probe(ctx context.Context, transport *Transport) (Report, error) {
 			report.PackageManager = value
 		case "libc":
 			report.Musl = value == "musl"
+		case "account_shell":
+			report.AccountShell = value
+		case "shell":
+			report.Shells = append(report.Shells, ShellReport{Path: value})
+		case "shell_found":
+			// Belongs to the shell most recently named: the survey walks
+			// one shell at a time and says so before it answers.
+			if last := len(report.Shells) - 1; last >= 0 {
+				report.Shells[last].Finds = append(report.Shells[last].Finds, value)
+			}
 		}
 	}
-	return report, nil
+	return report
+}
+
+// plainWords keeps the provider names that can be asked about without
+// quoting, and drops the rest.
+//
+// A name with a space or a quote in it would have to survive being read
+// by a shell this machine does not choose, and there is no spelling that
+// means the same thing in POSIX and in fish. Rather than guess, such a
+// provider is simply not surveyed — the host is still probed, and the
+// answer is silent about that one rather than wrong about it.
+func plainWords(names []string) []string {
+	plain := make([]string, 0, len(names))
+	for _, name := range names {
+		if name == "" || strings.ContainsAny(name, " \t\n\r'\"$`\\;&|<>()*?[]{}#~!") {
+			continue
+		}
+		plain = append(plain, name)
+	}
+	return plain
 }
 
 // InstallPath is where Stormlight puts itself on a host that has none.

--- a/internal/remote/setup_test.go
+++ b/internal/remote/setup_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"os"
 	"path/filepath"
+	"slices"
 	"strings"
 	"testing"
 	"time"
@@ -287,5 +288,123 @@ func TestAnArchiveGetsLongerThanAQuestion(t *testing.T) {
 	if archiveTimeout < 5*time.Minute {
 		t.Fatalf("archiveTimeout = %v; a slow link should be waited out, not failed",
 			archiveTimeout)
+	}
+}
+
+// TestTheSurveyIsOnlyAskedForWhenItIsWanted: it costs a login shell per
+// candidate, and the dashboard's reachability check has no use for the
+// answer.
+func TestTheSurveyIsOnlyAskedForWhenItIsWanted(t *testing.T) {
+	if strings.Contains(probeScript, "/etc/shells") {
+		t.Fatal("the survey must not be part of every probe")
+	}
+	if !strings.Contains(shellSurveyScript, "/etc/shells") {
+		t.Fatal("the survey should read the host's registered shells")
+	}
+}
+
+// TestTheSurveyAsksEveryShellTheSameWay: the query runs inside a shell
+// this machine did not choose, so it may only use syntax they all share.
+// A loop or an `if` would work everywhere except fish, which is the one
+// host this was written for.
+func TestTheSurveyAsksEveryShellTheSameWay(t *testing.T) {
+	query := ""
+	for _, line := range strings.Split(shellSurveyScript, "\n") {
+		if strings.Contains(line, `query="$query`) {
+			query = line
+		}
+	}
+	if query == "" {
+		t.Fatalf("the survey should build a query:\n%s", shellSurveyScript)
+	}
+	// What gets built is `command -v x >/dev/null 2>&1 && echo ...` —
+	// and nothing that any of sh, bash, zsh, ksh, or fish reads
+	// differently.
+	for _, forbidden := range []string{" if ", "for ", "[[", "$(", "`", "${", "$@", "$0"} {
+		if strings.Contains(query, forbidden) {
+			t.Fatalf("the query uses %q, which is not the same in every shell: %s",
+				forbidden, query)
+		}
+	}
+}
+
+// TestOnlyPlainProviderNamesAreSurveyed: a name with a quote in it would
+// have to survive a shell this machine does not choose, and there is no
+// spelling that means the same thing in POSIX and in fish. Such a
+// provider is left out rather than asked about wrongly.
+func TestOnlyPlainProviderNamesAreSurveyed(t *testing.T) {
+	got := plainWords([]string{
+		"codex", "claude", "", "my agent", `quote'd`, "semi;colon", "sub$(x)", "my-agent_2",
+	})
+	want := []string{"codex", "claude", "my-agent_2"}
+	if !slices.Equal(got, want) {
+		t.Fatalf("plainWords = %q, want %q", got, want)
+	}
+}
+
+// TestTheSurveyIsReadBackPerShell: the script names a shell and then
+// answers for it, so an answer belongs to whatever was named last.
+func TestTheSurveyIsReadBackPerShell(t *testing.T) {
+	report := parseReport(`platform=Darwin arm64
+account_shell=/opt/homebrew/bin/fish
+shell=/opt/homebrew/bin/fish
+shell_found=codex
+shell_found=claude
+shell=/bin/zsh
+shell=/bin/bash
+shell_found=claude
+`)
+	if report.AccountShell != "/opt/homebrew/bin/fish" {
+		t.Fatalf("account shell = %q", report.AccountShell)
+	}
+	if len(report.Shells) != 3 {
+		t.Fatalf("shells = %+v", report.Shells)
+	}
+	if !slices.Equal(report.Shells[0].Finds, []string{"codex", "claude"}) {
+		t.Fatalf("fish should see both: %+v", report.Shells[0])
+	}
+	// A shell that finds nothing is still reported. The absence is the
+	// finding — it is what says the account's shell is the problem.
+	if len(report.Shells[1].Finds) != 0 || report.Shells[1].Path != "/bin/zsh" {
+		t.Fatalf("zsh should be listed and empty: %+v", report.Shells[1])
+	}
+	if !report.Shells[2].Sees("claude") || report.Shells[2].Sees("codex") {
+		t.Fatalf("bash should see only claude: %+v", report.Shells[2])
+	}
+}
+
+// TestAShellIsSuggestedOnlyWhenItSeesMore: a host that works is not
+// improved by being configured.
+func TestAShellIsSuggestedOnlyWhenItSeesMore(t *testing.T) {
+	survey := func(account string, shells ...ShellReport) Report {
+		return Report{Asked: []string{"codex", "claude"}, AccountShell: account, Shells: shells}
+	}
+	fish := ShellReport{Path: "/opt/fish", Finds: []string{"codex", "claude"}}
+	zshBoth := ShellReport{Path: "/bin/zsh", Finds: []string{"codex", "claude"}}
+	zshNone := ShellReport{Path: "/bin/zsh"}
+	zshOne := ShellReport{Path: "/bin/zsh", Finds: []string{"claude"}}
+
+	// The account's shell sees everything: nothing to say.
+	if _, ok := survey("/bin/zsh", zshBoth, fish).SuggestedShell(); ok {
+		t.Fatal("a host that works should be left alone")
+	}
+	// It sees nothing and another sees everything: the case this exists for.
+	got, ok := survey("/bin/zsh", zshNone, fish).SuggestedShell()
+	if !ok || got.Path != "/opt/fish" {
+		t.Fatalf("SuggestedShell = %+v, %v", got, ok)
+	}
+	// It sees some: still worth naming the one that sees more.
+	got, ok = survey("/bin/zsh", zshOne, fish).SuggestedShell()
+	if !ok || got.Path != "/opt/fish" {
+		t.Fatalf("SuggestedShell = %+v, %v", got, ok)
+	}
+	// Nothing sees more than the account's shell, so there is no better
+	// answer — even though it cannot see everything.
+	if _, ok := survey("/bin/zsh", zshOne, ShellReport{Path: "/bin/sh"}).SuggestedShell(); ok {
+		t.Fatal("a shell that sees no more is not a suggestion")
+	}
+	// A probe that asked nothing suggests nothing.
+	if _, ok := (Report{AccountShell: "/bin/zsh", Shells: []ShellReport{fish}}).SuggestedShell(); ok {
+		t.Fatal("with nothing asked about there is nothing to conclude")
 	}
 }

--- a/main.go
+++ b/main.go
@@ -911,7 +911,11 @@ func newRemoteSetupCommand(cfg config.Config) *cobra.Command {
 			// read, and in a popup this process is the only thing holding
 			// the window open. So it reports, waits, and only then
 			// returns the error.
-			err := setUpHost(cmd.Context(), transport, args[0], out, install, withYazi)
+			// The providers this dashboard is configured for, which is
+			// what "can this machine run my agents" means.
+			providers := provider.NewRegistryWithSpecs(providerSpecs(cfg)).Binaries()
+			err := setUpHost(
+				cmd.Context(), transport, args[0], out, providers, install, withYazi)
 			if err != nil {
 				fmt.Fprintf(out, "\n%v\n", err)
 			}
@@ -935,9 +939,10 @@ func setUpHost(
 	transport *remote.Transport,
 	host string,
 	out io.Writer,
+	providers []string,
 	install, withYazi bool,
 ) error {
-	report, err := remote.Probe(ctx, transport)
+	report, err := remote.Probe(ctx, transport, providers...)
 	if err != nil {
 		return err
 	}
@@ -946,6 +951,10 @@ func setUpHost(
 		if !report.Ready() || !report.Yazi.Present() {
 			fmt.Fprintf(out, "\nRun with --install to fix this.\n")
 		}
+		// A host with nothing to install is the likeliest one to need
+		// this: everything is present, and the only thing wrong is which
+		// shell is being asked.
+		adviseHostShell(out, transport, host, report)
 		return nil
 	}
 
@@ -969,13 +978,108 @@ func setUpHost(
 			return err
 		}
 	}
-	fresh, err := remote.Probe(ctx, transport)
+	fresh, err := remote.Probe(ctx, transport, providers...)
 	if err != nil {
 		return err
 	}
 	fmt.Fprintln(out)
 	writeRemoteReport(out, fresh)
+	// Last, because it is the one thing here that depends on the machine
+	// being finished: a provider installed after the first probe is a
+	// provider the first survey could not have seen.
+	adviseHostShell(out, transport, host, fresh)
 	return nil
+}
+
+// adviseHostShell acts on the survey, when the survey found something to
+// act on and nobody has already answered the question by hand.
+func adviseHostShell(
+	out io.Writer, transport *remote.Transport, host string, report remote.Report,
+) {
+	suggested, ok := report.SuggestedShell()
+	if !ok {
+		return
+	}
+	if configured := transport.Host().Shell; configured != "" {
+		// Already answered. Saying so is still worth it: the person
+		// chose that shell, and this is the evidence about it.
+		if configured != suggested.Path {
+			fmt.Fprintf(out, "\n[hosts.%s] names %s, but %s can see more (%s).\n",
+				host, configured, suggested.Path, strings.Join(suggested.Finds, " "))
+		}
+		return
+	}
+	recordHostShell(out, host, suggested.Path)
+}
+
+// recordHostShell names the shell a host's providers actually live in.
+//
+// It is written rather than merely suggested because the alternative is
+// what produced the issue this came from: a provider that is plainly
+// installed, reported missing, and a setting discoverable only by
+// reading the failure carefully. The host has just been asked which of
+// its shells can see the providers, and one of them can see more than
+// the account's — that is evidence, not a guess, and acting on it is the
+// whole point of having asked.
+//
+// An existing setting is never touched. Someone who has already named a
+// shell has answered this question, and the answer is theirs.
+func recordHostShell(out io.Writer, host, shell string) {
+	path := config.Path()
+	if path == "" {
+		return
+	}
+	existing, err := os.ReadFile(path)
+	if err != nil && !errors.Is(err, fs.ErrNotExist) {
+		fmt.Fprintf(out, "\nSet shell = %q in [hosts.%s]: %v\n", shell, host, err)
+		return
+	}
+	updated, why := withHostShell(string(existing), host, shell)
+	if why != "" {
+		fmt.Fprintf(out, "\n%s\n", why)
+		return
+	}
+	if err := os.WriteFile(path, []byte(updated), 0o600); err != nil {
+		fmt.Fprintf(out, "\nAdd shell = %q to [hosts.%s] in %s: %v\n", shell, host, path, err)
+		return
+	}
+	fmt.Fprintf(out, "\nRecorded shell = %q in %s\n", shell, path)
+}
+
+// withHostShell adds the shell to a host's section, and says why not
+// when it does not.
+//
+// The file is edited as text rather than parsed and re-emitted: a config
+// someone wrote by hand carries comments and an ordering that round
+// tripping through a TOML encoder would quietly throw away.
+func withHostShell(existing, host, shell string) (updated, why string) {
+	entry := fmt.Sprintf("shell = %q", shell)
+	header := fmt.Sprintf("[hosts.%s]", host)
+	lines := strings.Split(existing, "\n")
+	start := slices.Index(lines, header)
+	if start < 0 {
+		section := "\n" + header + "\n" + entry + "\n"
+		if existing != "" && !strings.HasSuffix(existing, "\n") {
+			section = "\n" + section
+		}
+		return existing + section, ""
+	}
+	// The section runs to the next table header, and only within it does
+	// a `shell =` line belong to this host.
+	for _, line := range lines[start+1:] {
+		trimmed := strings.TrimSpace(line)
+		if strings.HasPrefix(trimmed, "[") {
+			break
+		}
+		if strings.HasPrefix(trimmed, "shell") &&
+			strings.HasPrefix(strings.TrimSpace(strings.TrimPrefix(trimmed, "shell")), "=") {
+			return "", fmt.Sprintf(
+				"[hosts.%s] already names a shell — leaving it alone. "+
+					"Providers were found by %s.", host, shell)
+		}
+	}
+	inserted := slices.Insert(slices.Clone(lines), start+1, entry)
+	return strings.Join(inserted, "\n"), ""
 }
 
 // recordHostBinary writes the installed path into the host's
@@ -1055,6 +1159,34 @@ func writeRemoteReport(out io.Writer, report remote.Report) {
 		yaziNote = "optional — " + report.YaziInstallCommand()
 	}
 	line(report.Yazi, yaziNote)
+	writeShellSurvey(out, report)
+}
+
+// writeShellSurvey prints what each of the host's shells can see, when
+// there was anything to ask about.
+//
+// Every shell is listed, including the ones that find nothing, because
+// the absence is the finding: seeing that the account's shell sees no
+// providers and another sees all of them is the entire diagnosis, and it
+// only reads that way side by side.
+func writeShellSurvey(out io.Writer, report remote.Report) {
+	if len(report.Asked) == 0 || len(report.Shells) == 0 {
+		return
+	}
+	fmt.Fprintf(out, "\n  providers, by the shell that can see them:\n")
+	for _, shell := range report.Shells {
+		found := "—"
+		if len(shell.Finds) > 0 {
+			found = strings.Join(shell.Finds, " ")
+		}
+		mark := " "
+		if shell.Path == report.AccountShell {
+			mark = "*"
+		}
+		fmt.Fprintf(out, "  %s %-34s %s\n", mark, shell.Path, found)
+	}
+	fmt.Fprintf(out, "  * the account's own shell, used unless [hosts.%s] names another\n",
+		report.Host)
 }
 
 func newWorkspaceCommand(cfg config.Config) *cobra.Command {

--- a/main_test.go
+++ b/main_test.go
@@ -239,3 +239,95 @@ func mustRead(t *testing.T, path string) []byte {
 	}
 	return content
 }
+
+// TestAShellIsAddedToTheSectionItBelongsTo: the file is edited as text,
+// so the edit has to land in the right table and nowhere else.
+func TestAShellIsAddedToTheSectionItBelongsTo(t *testing.T) {
+	existing := `[defaults]
+provider = "codex"
+
+# the one I actually use
+[hosts.mini]
+bin = "/Users/trent/.local/bin/stormlight"
+
+[hosts.other]
+bin = "/opt/stormlight"
+`
+	updated, why := withHostShell(existing, "mini", "/opt/homebrew/bin/fish")
+	if why != "" {
+		t.Fatalf("it should have written: %s", why)
+	}
+	want := `[defaults]
+provider = "codex"
+
+# the one I actually use
+[hosts.mini]
+shell = "/opt/homebrew/bin/fish"
+bin = "/Users/trent/.local/bin/stormlight"
+
+[hosts.other]
+bin = "/opt/stormlight"
+`
+	if updated != want {
+		t.Fatalf("got:\n%s\nwant:\n%s", updated, want)
+	}
+}
+
+// TestAnExistingShellIsNeverOverwritten: someone who has named a shell
+// has answered this question, and the answer is theirs.
+func TestAnExistingShellIsNeverOverwritten(t *testing.T) {
+	existing := `[hosts.mini]
+shell = "/bin/zsh"
+bin = "/opt/stormlight"
+`
+	updated, why := withHostShell(existing, "mini", "/opt/homebrew/bin/fish")
+	if why == "" {
+		t.Fatal("an existing setting must not be replaced")
+	}
+	if updated != "" {
+		t.Fatalf("nothing should have been rewritten: %q", updated)
+	}
+	if !strings.Contains(why, "already names a shell") {
+		t.Fatalf("it should say why: %s", why)
+	}
+}
+
+// TestAnotherHostsShellIsNotThisHostsShell: a `shell` line belongs to the
+// table it is under, and a text edit that forgets that would read the
+// neighbour's setting as this one's.
+func TestAnotherHostsShellIsNotThisHostsShell(t *testing.T) {
+	existing := `[hosts.mini]
+bin = "/opt/stormlight"
+
+[hosts.other]
+shell = "/bin/zsh"
+`
+	updated, why := withHostShell(existing, "mini", "/opt/homebrew/bin/fish")
+	if why != "" {
+		t.Fatalf("the neighbour's setting is not this host's: %s", why)
+	}
+	if !strings.Contains(updated, "[hosts.mini]\nshell = \"/opt/homebrew/bin/fish\"") {
+		t.Fatalf("it should have been added to mini:\n%s", updated)
+	}
+	// And the neighbour is untouched.
+	if strings.Count(updated, `shell = "/bin/zsh"`) != 1 {
+		t.Fatalf("the other host changed:\n%s", updated)
+	}
+}
+
+// TestAHostWithNoSectionGetsOne: naming a host is enough to use it, so
+// the first thing ever recorded about one may have nowhere to go yet.
+func TestAHostWithNoSectionGetsOne(t *testing.T) {
+	for _, existing := range []string{"", "[defaults]\nprovider = \"codex\"\n", "no trailing newline"} {
+		updated, why := withHostShell(existing, "mini", "/opt/homebrew/bin/fish")
+		if why != "" {
+			t.Fatalf("it should have written: %s", why)
+		}
+		if !strings.Contains(updated, "[hosts.mini]\nshell = \"/opt/homebrew/bin/fish\"\n") {
+			t.Fatalf("a section should have been added:\n%q", updated)
+		}
+		if existing != "" && !strings.HasPrefix(updated, existing) {
+			t.Fatalf("what was there should be kept:\n%q", updated)
+		}
+	}
+}

--- a/site/docs/configuration.html
+++ b/site/docs/configuration.html
@@ -188,6 +188,23 @@ provider = <span class="s">"claude"</span>
     <p>A configured shell that is missing or not executable is reported as that &mdash;
     naming the setting and the host &mdash; rather than as every provider on the host having
     gone missing, which is what the symptom otherwise looks like.</p>
+    <p><code>stormlight remote setup &lt;host&gt;</code> answers the question rather than
+    leaving it to be discovered by failure. It asks the host which of its login shells can
+    see the configured providers &mdash; the account&rsquo;s own, whatever
+    <code>/etc/shells</code> registers, and a few names that may be installed without being
+    registered &mdash; and prints the result side by side:</p>
+<pre><code>  providers, by the shell that can see them:
+  * /opt/homebrew/bin/fish             claude
+    /bin/bash                          claude codex
+    /bin/zsh                           claude
+  * the account&#39;s own shell, used unless [hosts.mini] names another</code></pre>
+    <p>When the account&rsquo;s shell sees strictly fewer providers than another, setup
+    records <code>shell</code> for that host and says so. This is evidence rather than a
+    guess: the machine was asked, and it answered. A host whose account shell can see
+    everything is left alone &mdash; a host that works is not improved by being configured
+    &mdash; and a <code>shell</code> someone has already set by hand is never overwritten.
+    The survey costs a login shell per candidate, so it runs only when there are providers
+    to ask about; the dashboard&rsquo;s own reachability check skips it.</p>
     <p>Custom providers appear in the New Agent picker and dispatch like any other.
     Lifecycle integration is the public contract: managed processes receive
     <code>STORMLIGHT_ID</code> and can report state with <code>stormlight event</code> from


### PR DESCRIPTION
Closes #190. Follow-up to #185.

#185 gave a host a way to name the shell its providers live in, and left discovery of that setting to a carefully read error message. But a host has a finite set of shells, and whether each can see `codex` is a question with a definite answer — and Stormlight already runs a script on that machine during setup. So it asks.

## What it looks like

```
$ stormlight remote setup mini
mini	Darwin arm64
  stormlight  ok       /Users/trent/.local/bin/stormlight  stormlight version dev
  yazi        ok       /Users/trent/.local/bin/yazi

  providers, by the shell that can see them:
  * /opt/homebrew/bin/fish             claude
    /bin/bash                          claude sl190-provider
    /bin/csh                           —
    /bin/dash                          claude
    /bin/ksh                           claude
    /bin/sh                            claude
    /bin/tcsh                          —
    /bin/zsh                           claude
  * the account's own shell, used unless [hosts.mini] names another

Recorded shell = "/bin/bash" in /Users/trent/.config/stormlight/config.toml
```

Every candidate is listed, including the ones that find nothing, because **the absence is the finding** — an account shell seeing nothing beside another seeing everything is the entire diagnosis, and it only reads that way side by side.

## This is not "scan and guess"

#185 ruled out scanning for and guessing among installed shells, and that still holds. Nothing silently picks a shell. The machine was *asked* and *answered*; acting on the answer is why it was asked.

- The account's `$SHELL` stays the default, and a host whose account shell sees everything is left alone — a host that works is not improved by being configured.
- A `shell` set by hand is **never** overwritten; that question has been answered by the only person who can. If the configured shell sees less than another, it says so and changes nothing.
- A suggestion is made only when some other shell sees *strictly more*.

## Details

**Shell-agnostic query.** Per candidate, one `-lc` invocation of `command -v x >/dev/null 2>&1 && echo …` repeated — no loop, no `if`, no `$(`, nothing that fish reads differently. A test enforces it.

**Opt-in.** The survey starts a login shell per candidate, so `Probe` only runs it when given providers. The dashboard's reachability check passes none and stays fast.

**Providers come from configuration**, so `[providers.*]` entries are surveyed beside the built-ins. A provider whose name couldn't survive an unknown shell's quoting is left out rather than asked about wrongly.

**The config is edited as text.** A hand-written file carries comments and ordering that round tripping through a TOML encoder would discard, so the key is inserted into the section it belongs to. Tests cover: the neighbouring `[hosts.*]` table's `shell` is not mistaken for this one's, an existing setting is refused, a missing section is created, and comments/ordering survive.

**No new UI.** The Remote tab's setup action already runs `remote setup <host> --install --yazi --wait` in an overlay, so it inherits this.

## Verified on real hardware

Against the Mac mini, reproducing #185's exact shape — a provider on a login `PATH` that only `/bin/bash` has, invisible to the account's fish:

1. Survey correctly reported `bash` seeing `claude sl190-provider` and fish seeing only `claude`.
2. `setup` recorded `shell = "/bin/bash"`, leaving the comment, the `bin` line and the `[providers.*]` table intact.
3. **Dispatch then succeeded with no further intervention** — agent `completed`.
4. A second `setup` wrote nothing.

The one-round-trip survey of 8 shells took ~2.5s wall clock. Everything staged on the mini was removed afterwards, including a `~/.bash_profile` I created to produce the divergence; their `~/.zshrc` was never touched.

Testing also caught a real gap in an earlier draft: the recording sat after the `--install` branch, so `setup` without `--install` diagnosed and then did nothing — precisely the case where a host is already installed and merely can't see the providers. Fixed; both paths now advise.

## ⚠️ Separate finding about #188

While testing I found that a dashboard carrying #188 **fails obscurely against a remote host running an older Stormlight**: the launch prelude runs `$STORMLIGHT_BIN _exec`, an old binary has no such subcommand, and the agent dies with `Error: not a directory: _exec`. Reproduced and confirmed on the mini (old binary → `failed`; current binary → `completed`).

The bridge `Protocol` was not bumped in #188, so the handshake accepts a peer that can no longer serve a dispatch. Raising separately — see the issue linked in a comment below.