### PR TITLE
A host too old to run an agent is turned away at the door

### DIFF
--- a/internal/remote/remote.go
+++ b/internal/remote/remote.go
@@ -20,7 +20,15 @@ package remote
 // the framing around the tunnel changes — a new handshake field that
 // matters, a different splice — never for an ordinary release, so hosts
 // on adjacent versions keep working.
-const Protocol = 1
+//
+// 2: a remote dispatch launches the provider through the host's login
+// shell, which reaches the provider by way of `stormlight _exec` on that
+// machine. A binary without that subcommand cannot serve a dispatch, and
+// nothing else in the greeting reveals it — so an older host has to be
+// refused here, where the failure can name both versions and the way
+// out, rather than per dispatch as an agent that dies complaining about
+// a directory.
+const Protocol = 2
 
 // Hello is the one line a bridge writes before it becomes a byte pipe.
 // It answers the questions dispatch would otherwise have to guess at from

--- a/internal/remote/ssh.go
+++ b/internal/remote/ssh.go
@@ -89,6 +89,13 @@ const (
 	ExecEnv = "STORMLIGHT_EXEC"
 )
 
+// ExecSubcommand is what the prelude runs on the far side. It is named
+// once, here, because the prelude is shell text: a rename that missed it
+// would leave a launch invoking a subcommand nothing registers, and the
+// only report of that would be an agent dying with whatever the root
+// command says about an argument it does not know.
+const ExecSubcommand = "_exec"
+
 // ExecPrelude is what the daemon on a host actually spawns, with the
 // provider's argv waiting in ExecEnv.
 //
@@ -111,7 +118,7 @@ if [ ! -x "$shell" ]; then
   echo "stormlight: $shell is not an executable shell on $(hostname 2>/dev/null)" >&2
   exit 127
 fi
-exec "$shell" -lc 'exec "$STORMLIGHT_BIN" _exec'
+exec "$shell" -lc 'exec "$STORMLIGHT_BIN" ` + ExecSubcommand + `'
 `
 
 // shellAssignment prefixes a script with the shell this host runs things
@@ -187,7 +194,7 @@ func (t *Transport) Dial() (net.Conn, error) {
 	if err != nil {
 		return nil, fmt.Errorf("reach %s: %w", t.host.Name, err)
 	}
-	hello, err := Handshake(conn)
+	hello, err := Handshake(conn, t.host.Name)
 	if err != nil {
 		conn.Close()
 		return nil, fmt.Errorf("reach %s: %w", t.host.Name, err)
@@ -328,18 +335,51 @@ func shellQuote(args []string) string {
 // Handshake is the client half of Serve: it reads the bridge's greeting
 // and decides whether the two ends can talk. Everything after the line it
 // consumes belongs to windrunner.
-func Handshake(conn net.Conn) (Hello, error) {
+func Handshake(conn net.Conn, host string) (Hello, error) {
 	hello, err := readHello(conn)
 	if err != nil {
 		return Hello{}, err
 	}
 	if hello.Protocol != Protocol {
-		return Hello{}, fmt.Errorf(
-			"it speaks bridge protocol %d, this one speaks %d — stormlight %s "+
-				"there, %s here; upgrade the older side",
-			hello.Protocol, Protocol, hello.Version, localVersion)
+		return Hello{}, mismatch(host, hello)
 	}
 	return hello, nil
+}
+
+// mismatch says which of the two machines is behind, and what to do
+// about that one.
+//
+// Which side is older is the whole of what the reader needs and the one
+// thing the numbers alone do not say. "Upgrade the older side" leaves
+// them to work out which that is, from two version strings that may both
+// read "dev" — and then to remember that a host is updated by a command
+// on this machine, not on that one.
+func mismatch(host string, hello Hello) error {
+	if host == "" {
+		host = "that machine"
+	}
+	if hello.Protocol < Protocol {
+		return fmt.Errorf(
+			"%s runs an older Stormlight (%s) than this dashboard (%s): it speaks "+
+				"bridge protocol %d and this one speaks %d. Update it with "+
+				"`stormlight remote setup %s --install`",
+			host, describeVersion(hello.Version), describeVersion(localVersion),
+			hello.Protocol, Protocol, host)
+	}
+	return fmt.Errorf(
+		"%s runs a newer Stormlight (%s) than this dashboard (%s): it speaks "+
+			"bridge protocol %d and this one speaks %d. Update this machine",
+		host, describeVersion(hello.Version), describeVersion(localVersion),
+		hello.Protocol, Protocol)
+}
+
+// describeVersion keeps an unbuilt binary from being reported as a
+// version anybody could look up.
+func describeVersion(version string) string {
+	if version == "" {
+		return "unknown"
+	}
+	return version
 }
 
 // Explain turns ssh's own diagnostics into something with a next step.

--- a/internal/remote/ssh_test.go
+++ b/internal/remote/ssh_test.go
@@ -121,7 +121,7 @@ func TestHandshakeLeavesTheProtocolAlone(t *testing.T) {
 		far.Write([]byte("the first protocol frame"))
 	}()
 
-	hello, err := Handshake(near)
+	hello, err := Handshake(near, "devbox")
 	if err != nil {
 		t.Fatalf("Handshake: %v", err)
 	}
@@ -146,16 +146,63 @@ func TestHandshakeRefusesAnotherProtocol(t *testing.T) {
 		far.Write(append(encoded, '\n'))
 	}()
 
-	_, err := Handshake(near)
+	_, err := Handshake(near, "devbox")
 	if err == nil {
 		t.Fatal("a mismatched protocol must not connect")
 	}
 	// The message has to name both sides: the whole failure is that two
 	// machines disagree, and only one of them is in front of the user.
-	for _, want := range []string{"v9.9.9", localVersion} {
+	for _, want := range []string{"v9.9.9", localVersion, "devbox"} {
 		if !strings.Contains(err.Error(), want) {
-			t.Fatalf("error should name both versions, got: %v", err)
+			t.Fatalf("error should name both versions and the host, got: %v", err)
 		}
+	}
+	// This host is ahead, so the machine to fix is this one — and the
+	// remote setup command would be advice pointing the wrong way.
+	if !strings.Contains(err.Error(), "Update this machine") {
+		t.Fatalf("a newer host should send the user to this machine: %v", err)
+	}
+	if strings.Contains(err.Error(), "remote setup") {
+		t.Fatalf("nothing on the host needs updating: %v", err)
+	}
+}
+
+// TestAnOlderHostIsToldHowToBeUpdated is the failure #188 introduced and
+// #192 is about: a dashboard whose hosts still run a Stormlight that
+// cannot serve a dispatch. Refusing at the handshake is only worth it if
+// the refusal carries the way out.
+func TestAnOlderHostIsToldHowToBeUpdated(t *testing.T) {
+	near, far := net.Pipe()
+	defer near.Close()
+	go func() {
+		encoded, _ := json.Marshal(Hello{Protocol: Protocol - 1, Version: "v0.11.2"})
+		far.Write(append(encoded, '\n'))
+	}()
+
+	_, err := Handshake(near, "mini")
+	if err == nil {
+		t.Fatal("a host that cannot serve a dispatch must not connect")
+	}
+	// Which side is behind is the one thing the numbers do not say, and
+	// the command runs here rather than there.
+	for _, want := range []string{
+		"mini runs an older Stormlight",
+		"v0.11.2",
+		"stormlight remote setup mini --install",
+	} {
+		if !strings.Contains(err.Error(), want) {
+			t.Fatalf("the refusal should carry %q, got: %v", want, err)
+		}
+	}
+}
+
+// TestAVersionlessGreetingIsNotReportedAsAVersion: a binary built
+// without its version stamped says nothing, and "Stormlight ()" reads
+// like a bug in the message rather than a fact about the host.
+func TestAVersionlessGreetingIsNotReportedAsAVersion(t *testing.T) {
+	err := mismatch("mini", Hello{Protocol: Protocol - 1})
+	if !strings.Contains(err.Error(), "unknown") {
+		t.Fatalf("an unstamped build should be described, not blank: %v", err)
 	}
 }
 
@@ -171,7 +218,7 @@ func TestHandshakeReportsWhatAnsweredInstead(t *testing.T) {
 		far.Close()
 	}()
 
-	_, err := Handshake(near)
+	_, err := Handshake(near, "devbox")
 	if err == nil || !strings.Contains(err.Error(), "command not found") {
 		t.Fatalf("want the far side's own complaint, got: %v", err)
 	}

--- a/main.go
+++ b/main.go
@@ -263,7 +263,7 @@ func newReadCommand() *cobra.Command {
 // argv, decoded from the environment the daemon set, and become.
 func newExecCommand() *cobra.Command {
 	return &cobra.Command{
-		Use:    "_exec",
+		Use:    remote.ExecSubcommand,
 		Hidden: true,
 		Args:   cobra.NoArgs,
 		RunE: func(cmd *cobra.Command, args []string) error {
@@ -898,6 +898,7 @@ func newRemoteSetupCommand(cfg config.Config) *cobra.Command {
 	var install bool
 	var withYazi bool
 	var wait bool
+	var force bool
 	command := &cobra.Command{
 		Use:   "setup <host>",
 		Short: "Report what a machine is missing, and optionally install it",
@@ -915,7 +916,7 @@ func newRemoteSetupCommand(cfg config.Config) *cobra.Command {
 			// what "can this machine run my agents" means.
 			providers := provider.NewRegistryWithSpecs(providerSpecs(cfg)).Binaries()
 			err := setUpHost(
-				cmd.Context(), transport, args[0], out, providers, install, withYazi)
+				cmd.Context(), transport, args[0], out, providers, install, withYazi, force)
 			if err != nil {
 				fmt.Fprintf(out, "\n%v\n", err)
 			}
@@ -929,6 +930,8 @@ func newRemoteSetupCommand(cfg config.Config) *cobra.Command {
 		"also install yazi, using the host's own package manager")
 	command.Flags().BoolVar(&wait, "wait", false,
 		"hold the terminal open at the end, for a popup nobody else closes")
+	command.Flags().BoolVar(&force, "force", false,
+		"replace the host's Stormlight even when it reports the same version")
 	return command
 }
 
@@ -940,7 +943,7 @@ func setUpHost(
 	host string,
 	out io.Writer,
 	providers []string,
-	install, withYazi bool,
+	install, withYazi, force bool,
 ) error {
 	report, err := remote.Probe(ctx, transport, providers...)
 	if err != nil {
@@ -958,7 +961,10 @@ func setUpHost(
 		return nil
 	}
 
-	if !report.Stormlight.Present() {
+	if why, needed := stormlightNeeded(report, version, force); needed {
+		if why != "" {
+			fmt.Fprintf(out, "\n%s\n", why)
+		}
 		binary, err := selfpath.Resolve()
 		if err != nil {
 			return err
@@ -1010,6 +1016,45 @@ func adviseHostShell(
 		return
 	}
 	recordHostShell(out, host, suggested.Path)
+}
+
+// stormlightNeeded says whether this host's Stormlight has to be put
+// there or replaced, and why.
+//
+// Absent is the obvious case. The other one is a host whose binary is
+// older than this dashboard: the two speak the bridge across a version
+// boundary, and since #192 a host too old to serve a dispatch is refused
+// outright. Setup is where that gets fixed, so "already has one" cannot
+// be the whole test — a stale binary is precisely the thing the refusal
+// tells people to come here and mend.
+//
+// Two dev builds report the same version and are left alone, because
+// nothing distinguishes them. That is what force is for.
+func stormlightNeeded(report remote.Report, local string, force bool) (why string, needed bool) {
+	if !report.Stormlight.Present() {
+		return "", true
+	}
+	if force {
+		return "Replacing " + report.Host + "'s Stormlight.", true
+	}
+	there := reportedVersion(report.Stormlight.Version)
+	if there == "" || local == "" || there == local {
+		return "", false
+	}
+	return fmt.Sprintf(
+		"%s runs Stormlight %s and this dashboard is %s — replacing it, "+
+			"because a host older than its dashboard cannot serve a dispatch.",
+		report.Host, there, local), true
+}
+
+// reportedVersion pulls the version out of what `stormlight --version`
+// prints, which is a sentence rather than a number.
+func reportedVersion(reported string) string {
+	fields := strings.Fields(reported)
+	if len(fields) == 0 {
+		return ""
+	}
+	return fields[len(fields)-1]
 }
 
 // recordHostShell names the shell a host's providers actually live in.

--- a/main_test.go
+++ b/main_test.go
@@ -9,6 +9,7 @@ import (
 	"testing"
 
 	"github.com/trentkm/stormlight/internal/agent"
+	"github.com/trentkm/stormlight/internal/remote"
 	"github.com/trentkm/stormlight/internal/workspace"
 )
 
@@ -328,6 +329,85 @@ func TestAHostWithNoSectionGetsOne(t *testing.T) {
 		}
 		if existing != "" && !strings.HasPrefix(updated, existing) {
 			t.Fatalf("what was there should be kept:\n%q", updated)
+		}
+	}
+}
+
+// TestTheLaunchPreludeInvokesACommandThatExists: a remote dispatch runs
+// `$STORMLIGHT_BIN <subcommand>` from inside shell text, so nothing about
+// a rename would fail to compile. What it would do instead is launch
+// agents that die reporting whatever the root command says about an
+// argument it does not recognise — on another machine, where the message
+// is least likely to be read.
+func TestTheLaunchPreludeInvokesACommandThatExists(t *testing.T) {
+	if !strings.Contains(remote.ExecPrelude, remote.ExecSubcommand) {
+		t.Fatalf("the prelude should invoke %q:\n%s",
+			remote.ExecSubcommand, remote.ExecPrelude)
+	}
+	found := false
+	for _, command := range newRootCommand().Commands() {
+		if command.Name() == remote.ExecSubcommand {
+			found = true
+		}
+	}
+	if !found {
+		t.Fatalf("nothing registers %q, which every remote dispatch runs",
+			remote.ExecSubcommand)
+	}
+}
+
+// TestAStaleHostIsReplacedRatherThanLeftAlone: since #192 a host older
+// than its dashboard is refused at the handshake, and the refusal sends
+// people to `remote setup --install`. If that command treats "already has
+// one" as "nothing to do", the advice is a loop.
+func TestAStaleHostIsReplacedRatherThanLeftAlone(t *testing.T) {
+	present := func(version string) remote.Report {
+		return remote.Report{
+			Host:       "mini",
+			Stormlight: remote.Requirement{Name: "stormlight", Path: "/x", Version: version},
+		}
+	}
+	// Older than this dashboard: the case the refusal is about.
+	why, needed := stormlightNeeded(present("stormlight version v0.11.2"), "v0.11.3", false)
+	if !needed {
+		t.Fatal("a stale host must be replaced, or the advice goes nowhere")
+	}
+	for _, want := range []string{"v0.11.2", "v0.11.3", "mini"} {
+		if !strings.Contains(why, want) {
+			t.Fatalf("it should say what it is replacing and why: %q", why)
+		}
+	}
+	// Matching: a host that is already right is not reinstalled over.
+	if _, needed := stormlightNeeded(present("stormlight version v0.11.3"), "v0.11.3", false); needed {
+		t.Fatal("a host on this version should be left alone")
+	}
+	// Absent: the original reason this branch exists.
+	if _, needed := stormlightNeeded(remote.Report{Host: "mini"}, "v0.11.3", false); !needed {
+		t.Fatal("a host with no Stormlight needs one")
+	}
+	// Two dev builds are indistinguishable, so nothing is assumed —
+	// which is what --force is for.
+	if _, needed := stormlightNeeded(present("stormlight version dev"), "dev", false); needed {
+		t.Fatal("identical versions say nothing about staleness")
+	}
+	if _, needed := stormlightNeeded(present("stormlight version dev"), "dev", true); !needed {
+		t.Fatal("--force should replace it anyway")
+	}
+	// A host that answered with nothing useful is not guessed about.
+	if _, needed := stormlightNeeded(present(""), "v0.11.3", false); needed {
+		t.Fatal("an unreadable version is not evidence of staleness")
+	}
+}
+
+func TestTheReportedVersionIsPulledOutOfTheSentence(t *testing.T) {
+	for reported, want := range map[string]string{
+		"stormlight version v0.11.2": "v0.11.2",
+		"v0.11.2":                    "v0.11.2",
+		"  stormlight version dev  ": "dev",
+		"":                           "",
+	} {
+		if got := reportedVersion(reported); got != want {
+			t.Fatalf("reportedVersion(%q) = %q, want %q", reported, got, want)
 		}
 	}
 }


### PR DESCRIPTION
Fixes #192. Blocks v0.11.3 — without it the release breaks every un-upgraded host.

## The regression

#188 changed what a remote host must be able to do. A dispatch now launches the provider through that machine's login shell, which reaches it by way of `stormlight _exec` on that machine. A binary predating #188 has no such subcommand, and nothing in the greeting reveals that — so the handshake accepted the host and each dispatch died in its own terminal with:

```
Error: not a directory: _exec
```

That is exactly what `remote.Protocol` exists for, and it should have moved with #188. It moves now.

## The refusal says which side is behind

```
$ stormlight dispatch --host mini --provider claude ...
Error: reach mini: mini runs an older Stormlight (dev) than this dashboard (dev):
it speaks bridge protocol 1 and this one speaks 2.
Update it with `stormlight remote setup mini --install`
```

Which machine is behind is the one thing the numbers don't say, and the whole of what the reader needs. The old wording — "upgrade the older side" — left them to work that out from two version strings that may both read `dev`, and then to remember that a host is mended by a command run *here*, not there.

## The advertised recovery had to actually work — it didn't

`remote setup --install` treated "already has some Stormlight" as "nothing to do", so the command the refusal points at was a no-op on precisely the hosts it was pointing at. A loop.

It now replaces a binary older than the dashboard and says what it is replacing and why. Two dev builds report the same version and are genuinely indistinguishable, so they're left alone; `--force` is the lever for that case.

## A guard for the failure mode that caused this

The subcommand the prelude runs lives inside shell text, where a rename compiles perfectly and fails only on another machine, in a terminal, as an error about an argument. It is now named once (`remote.ExecSubcommand`) and a test asserts the root command registers it. Reverting the rename makes that test fail:

```
--- FAIL: TestTheLaunchPreludeInvokesACommandThatExists
    nothing registers "_exec", which every remote dispatch runs
```

**Honest limitation:** no unit test can catch a *missing* protocol bump, because nothing in-process knows that a far-side requirement changed. The mitigation is the constant's doc comment, which now records what each version demands of the far side.

## Verified against a genuinely old host

The Mac mini was still running its pre-#188 binary, which made it the natural experiment:

1. Dispatch to it → refused at connect with the message above, instead of a dead agent.
2. `remote setup mini --install --force` → replaced the binary.
3. Dispatch again → real Claude agent, `working`.

## Found on the way — filed separately

**#195**: `remote setup --install` installs to `~/.local/bin/stormlight` and ignores the host's configured `bin`. It confounded step 2 above: setup reported success while the bridge went on running the old binary at the configured path. Usually invisible, because `recordHostBinary` writes `bin` to whatever it just installed to — the two only disagree when someone set `bin` by hand, which is the case that setting exists for.

**Note on your mini:** because of #195, step 2 replaced `~/.local/bin/stormlight` rather than the scratch copy I had pointed `bin` at. It is now a dev build of this branch — working, but not a release. Worth re-running `stormlight remote setup mini --install` once v0.11.3 is out to put a real release binary there.