### PR TITLE
A daemon says what it can do, and is not asked for more

### DIFF
--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -113,6 +113,20 @@ to come up. The daemon outlives every dashboard: agents, their terminals,
 and their scrollback persist across dashboard restarts, and the daemon's
 sessions are the roster — there is no second record to reconcile.
 
+Outliving the dashboard means outliving the binary, so a daemon can be
+running code from a release nobody has installed for months. That is
+harmless until a dispatch needs the daemon to do something a daemon that
+old cannot: an unknown field in a spawn request is not refused, it is
+dropped, and the agent starts anyway — missing the environment its whole
+lifecycle depends on, and failing somewhere that never mentions the
+daemon. So `stormlight _wrdaemon` writes `daemon.json` beside its socket
+before it listens, naming what it can be asked to do and the process
+saying so, and removes it when it goes. `_wrbridge` reads that file
+rather than reporting its own version, because the daemon it splices onto
+is whatever was already listening. A daemon too old to carry an agent is
+refused a new one — and only a new one, since the agents it already holds
+list and attach perfectly well.
+
 The daemon never learns what an agent is; that is the library's boundary.
 Agent identity and state ride in the session's opaque metadata as one JSON
 document under the `stormlight_agent` key — the serialized `agent.Agent`:

--- a/internal/remote/remote.go
+++ b/internal/remote/remote.go
@@ -42,4 +42,24 @@ type Hello struct {
 	Bin       string `json:"bin"`
 	SocketDir string `json:"socket_dir"`
 	Hostname  string `json:"hostname"`
+	// DaemonCapability is what the daemon actually serving this socket
+	// can be asked to do — which is not what Version says, and is the
+	// difference that matters.
+	//
+	// The bridge is a fresh process of a known build, but the daemon
+	// behind it is whatever was already listening, started by whatever
+	// binary was installed at the time and outliving every upgrade
+	// since. Version describes the messenger. This describes the
+	// machine that will actually run the agent.
+	//
+	// Zero means the daemon predates saying so, which is an answer:
+	// nothing older can be asked, and nothing older honours the fields a
+	// dispatch depends on.
+	DaemonCapability int `json:"daemon_capability,omitempty"`
+	// DaemonVersion is the build that started that daemon, for a message
+	// that can say how far behind it is.
+	DaemonVersion string `json:"daemon_version,omitempty"`
+	// DaemonPID names the process to end, since ending it is the only
+	// way to replace it and there is no gentler instruction to give.
+	DaemonPID int `json:"daemon_pid,omitempty"`
 }

--- a/internal/windrun/remote_test.go
+++ b/internal/windrun/remote_test.go
@@ -25,6 +25,7 @@ const (
 	helperEnv       = "STORMLIGHT_BRIDGE_HELPER_SOCKET"
 	helperSentinel  = "STORMLIGHT_BRIDGE_HELPER"
 	helperBinEnv    = "STORMLIGHT_BRIDGE_HELPER_BIN"
+	helperStaleEnv  = "STORMLIGHT_BRIDGE_HELPER_STALE"
 	helperSocketDir = "/remote/state/windrunner"
 )
 
@@ -50,6 +51,18 @@ func TestMain(m *testing.M) {
 			Bin:       os.Getenv(helperBinEnv),
 			SocketDir: helperSocketDir,
 			Hostname:  "testhost",
+			// The daemon this harness serves is the one this test binary
+			// just started, so it can do what this build asks of it.
+			// Saying so is what the real bridge does by reading the
+			// stamp beside the socket.
+		}
+		// A daemon old enough to matter leaves no stamp at all — the
+		// mechanism postdates it — so the stale case reports nothing
+		// rather than reporting itself as old.
+		if os.Getenv(helperStaleEnv) == "" {
+			hello.DaemonCapability = Capability
+			hello.DaemonVersion = "v-remote"
+			hello.DaemonPID = os.Getpid()
 		}
 		if err := remote.Serve(os.Getenv(helperEnv), hello, os.Stdin, os.Stdout); err != nil {
 			fmt.Fprintln(os.Stderr, "bridge:", err)
@@ -109,8 +122,9 @@ func remoteRuntime(t *testing.T) *Runtime {
 	script := fmt.Sprintf(`#!/bin/sh
 for last; do :; done
 if [ "$last" = "-s" ]; then exec /bin/sh -s; fi
-%s=1 %s=%q %s=%q exec %q -test.run=TestMainBridgeHelperNeverRuns
-`, helperSentinel, helperEnv, socket, helperBinEnv, self, self)
+%s=1 %s=%q %s=%q %s=%q exec %q -test.run=TestMainBridgeHelperNeverRuns
+`, helperSentinel, helperEnv, socket, helperBinEnv, self,
+		helperStaleEnv, os.Getenv(helperStaleEnv), self)
 	if err := os.WriteFile(fakeSSH, []byte(script), 0o755); err != nil {
 		t.Fatalf("write fake ssh: %v", err)
 	}
@@ -672,5 +686,71 @@ func TestAMissingProviderPointsAtTheSetting(t *testing.T) {
 		if !strings.Contains(err.Error(), want) {
 			t.Fatalf("the message should carry %q:\n%s", want, err)
 		}
+	}
+}
+
+// TestADaemonThatCannotCarryAnAgentIsNotGivenOne is #144: a daemon older
+// than the field a dispatch depends on does not refuse the request, it
+// drops the field and starts the process anyway. What came back was an
+// agent with an empty environment, failing three layers from the cause
+// and never mentioning the daemon.
+func TestADaemonThatCannotCarryAnAgentIsNotGivenOne(t *testing.T) {
+	t.Setenv(helperStaleEnv, "1")
+	runtime := remoteRuntime(t)
+
+	_, err := runtime.Dispatch(context.Background(), session.DispatchRequest{
+		Provider: agent.Provider("claude"),
+		Cwd:      t.TempDir(),
+		Launch:   session.Launch{Path: "/bin/sh", Args: []string{"-c", "true"}},
+	})
+	if err == nil {
+		t.Fatal("a daemon that would drop the agent's environment must not be given one")
+	}
+	t.Logf("the message is:\n%s", err)
+	for _, want := range []string{
+		"daemon on testhost", // which machine, and that it is the daemon
+		"still list and attach",
+		// No stamp means no pid, so the only handle left is the pattern.
+		"pkill -f 'stormlight _wrdaemon'",
+	} {
+		if !strings.Contains(err.Error(), want) {
+			t.Fatalf("the refusal should carry %q:\n%v", want, err)
+		}
+	}
+}
+
+// TestARefusedDispatchLeavesNoAgentBehind: the point of refusing before
+// the spawn is that nothing is created. An agent recorded here would be
+// one the roster shows and nothing owns.
+func TestARefusedDispatchLeavesNoAgentBehind(t *testing.T) {
+	t.Setenv(helperStaleEnv, "1")
+	runtime := remoteRuntime(t)
+
+	if _, err := runtime.Dispatch(context.Background(), session.DispatchRequest{
+		Provider: agent.Provider("claude"),
+		Cwd:      t.TempDir(),
+		Launch:   session.Launch{Path: "/bin/sh", Args: []string{"-c", "sleep 60"}},
+	}); err == nil {
+		t.Fatal("this dispatch should have been refused")
+	}
+	agents, err := runtime.ListAgents(context.Background())
+	if err != nil {
+		t.Fatalf("ListAgents: %v", err)
+	}
+	if len(agents) != 0 {
+		t.Fatalf("a refused dispatch left something behind: %+v", agents)
+	}
+}
+
+// TestADaemonNamesTheProcessToEnd: an unstamped daemon can only be found
+// by pattern, but a stamped one that is merely behind names its pid — and
+// killing the right process matters when the wrong one is somebody's
+// afternoon.
+func TestADaemonNamesTheProcessToEnd(t *testing.T) {
+	if got := restartInstruction("mini", 4321); got != "ssh mini kill 4321" {
+		t.Fatalf("restartInstruction = %q", got)
+	}
+	if got := restartInstruction("mini", 0); !strings.Contains(got, "pkill") {
+		t.Fatalf("with no pid it should fall back to a pattern: %q", got)
 	}
 }

--- a/internal/windrun/runtime.go
+++ b/internal/windrun/runtime.go
@@ -224,6 +224,9 @@ func (r *Runtime) Dispatch(ctx context.Context, request session.DispatchRequest)
 	if err != nil {
 		return agent.Agent{}, err
 	}
+	if err := r.daemonCanCarryAnAgent(); err != nil {
+		return agent.Agent{}, err
+	}
 	managedAgent := agent.Agent{
 		ID:          id,
 		Provider:    request.Provider,
@@ -326,6 +329,56 @@ func (r *Runtime) Dispatch(ctx context.Context, request session.DispatchRequest)
 	managedAgent.PaneID = info.ID
 	managedAgent.WindowID = info.ID
 	return managedAgent, nil
+}
+
+// daemonCanCarryAnAgent refuses a dispatch the daemon over there cannot
+// honour, rather than making an agent that cannot work.
+//
+// A remote spawn puts the agent's identity, its Stormlight, its socket
+// directory and its provider's argv in EnvOverride, and a daemon older
+// than that field does not object — it drops it and starts the process
+// regardless. What comes back is an agent whose environment is empty:
+// before #188 that meant hooks that could never report, and since #188 it
+// means a launch that cannot resolve the provider at all. Neither
+// failure mentions the daemon, and the daemon is the whole cause.
+//
+// The refusal is here rather than at the handshake on purpose. The
+// daemon is serving real agents — the one that prompted this held four —
+// and they list, attach, and take input perfectly well. Only starting a
+// new one is broken, so only that is refused.
+func (r *Runtime) daemonCanCarryAnAgent() error {
+	if r.transport == nil {
+		// This machine's daemon is asked for Env, which every daemon
+		// that ever existed understands.
+		return nil
+	}
+	hello := r.transport.Hello()
+	if hello.DaemonCapability >= Capability {
+		return nil
+	}
+	host := r.transport.Host().Name
+	built := "a Stormlight older than this one"
+	if hello.DaemonVersion != "" {
+		built = "Stormlight " + hello.DaemonVersion
+	}
+	return fmt.Errorf(
+		"the windrunner daemon on %s was started by %s and drops the environment "+
+			"an agent needs, so a new agent there would start without one. "+
+			"Agents it already holds are unaffected — they still list and attach. "+
+			"Restarting it takes them with it:\n    %s",
+		host, built, restartInstruction(host, hello.DaemonPID))
+}
+
+// restartInstruction is the only way to replace a running daemon, so it
+// is spelled out rather than alluded to — including that there is no
+// gentle form of it.
+func restartInstruction(host string, pid int) string {
+	if pid > 0 {
+		return fmt.Sprintf("ssh %s kill %d", host, pid)
+	}
+	// An unstamped daemon named no process, which is itself how it was
+	// recognised as too old.
+	return fmt.Sprintf("ssh %s pkill -f 'stormlight _wrdaemon'", host)
 }
 
 // launchCommand is what the daemon on the far side is asked to start.

--- a/internal/windrun/stamp.go
+++ b/internal/windrun/stamp.go
@@ -1,0 +1,110 @@
+package windrun
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"syscall"
+)
+
+// A daemon outlives the binary that started it. That is the point of it —
+// agents survive the dashboard, the terminal, and the upgrade — and it is
+// also the one way a machine can be running code nobody chose.
+//
+// The gap it opens is not about versions but about capability. A dispatch
+// asks the daemon to do particular things with a spawn request, and a
+// daemon that predates one of them does not refuse: it drops the field
+// and starts the process anyway. What arrives is an agent missing the
+// environment its whole lifecycle depends on, reporting a failure three
+// layers from the cause — see #144, where a daemon two releases old cost
+// an afternoon and looked like two unrelated bugs.
+//
+// So the daemon says what it is when it starts, and the bridge reads that
+// rather than assuming the binary beside it is the one serving.
+
+// Capability is what a daemon started by this build can be asked to do.
+// It is not the version: two releases apart with nothing between them
+// that the daemon must honour differently share a capability, and only a
+// change in what a spawn request may contain moves it.
+//
+// 1: EnvOverride — the field a remote dispatch puts the agent's identity,
+// its binary, and its socket directory in. Since #188 the provider's argv
+// travels there too, so a daemon that drops it does not merely leave an
+// agent unable to report state; it leaves one that cannot start.
+const Capability = 1
+
+// Stamp is what a running daemon says about itself, left beside its
+// socket for whatever connects to it.
+type Stamp struct {
+	Capability int    `json:"capability"`
+	Version    string `json:"version"`
+	// PID is what makes the file evidence rather than a leftover: a
+	// daemon that died without cleaning up leaves a stamp that names a
+	// process no longer there, and an unowned stamp is worth exactly as
+	// much as no stamp at all.
+	PID int `json:"pid"`
+}
+
+// StampPath is where a daemon's stamp lives: beside its socket, because
+// what it describes is that socket rather than that machine, and a
+// scratch WINDRUNNER_DIR gets its own.
+func StampPath() string {
+	return filepath.Join(SocketDir(), "daemon.json")
+}
+
+// WriteStamp records what this daemon can do, before it can be connected
+// to. Written first and removed on failure rather than written after
+// listening: something that connects the instant the socket appears must
+// not find the socket without the stamp and conclude the daemon is old.
+func WriteStamp(version string) error {
+	encoded, err := json.Marshal(Stamp{
+		Capability: Capability,
+		Version:    version,
+		PID:        os.Getpid(),
+	})
+	if err != nil {
+		return err
+	}
+	if err := os.MkdirAll(SocketDir(), 0o700); err != nil {
+		return err
+	}
+	return os.WriteFile(StampPath(), encoded, 0o600)
+}
+
+// RemoveStamp clears the record when the daemon goes, so that the next
+// thing to look finds nothing rather than a claim about a dead process.
+func RemoveStamp() { os.Remove(StampPath()) }
+
+// ReadStamp is what the daemon behind this socket says about itself.
+//
+// Absence is an answer, and the important one: a daemon started before
+// stamps existed leaves none, which is precisely the daemon whose
+// capabilities cannot be asked about any other way.
+func ReadStamp() (Stamp, bool) {
+	raw, err := os.ReadFile(StampPath())
+	if err != nil {
+		return Stamp{}, false
+	}
+	var stamp Stamp
+	if err := json.Unmarshal(raw, &stamp); err != nil {
+		return Stamp{}, false
+	}
+	if !running(stamp.PID) {
+		return Stamp{}, false
+	}
+	return stamp, true
+}
+
+// running reports whether a process is there to be signalled. Signal 0 is
+// the ask-without-telling: it performs the permission and existence
+// checks and delivers nothing.
+func running(pid int) bool {
+	if pid <= 0 {
+		return false
+	}
+	process, err := os.FindProcess(pid)
+	if err != nil {
+		return false
+	}
+	return process.Signal(syscall.Signal(0)) == nil
+}

--- a/main.go
+++ b/main.go
@@ -147,6 +147,12 @@ func newWindrunnerDaemonCommand() *cobra.Command {
 		Hidden: true,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			path := windrun.SocketPath()
+			// Before the socket exists, so that nothing can connect to a
+			// daemon that has not yet said what it is.
+			if err := windrun.WriteStamp(version); err != nil {
+				return err
+			}
+			defer windrun.RemoveStamp()
 			os.Remove(path)
 			listener, err := net.Listen("unix", path)
 			if err != nil {
@@ -189,12 +195,19 @@ func newWindrunnerBridgeCommand() *cobra.Command {
 			}
 			c.Close()
 			hostname, _ := os.Hostname()
+			// Read rather than assumed: EnsureDaemon starts one only
+			// when none is listening, so the daemon this bridge is about
+			// to splice onto may be years older than this binary.
+			stamp, _ := windrun.ReadStamp()
 			return remote.Serve(windrun.SocketPath(), remote.Hello{
-				Protocol:  remote.Protocol,
-				Version:   version,
-				Bin:       binPath,
-				SocketDir: windrun.SocketDir(),
-				Hostname:  hostname,
+				Protocol:         remote.Protocol,
+				Version:          version,
+				Bin:              binPath,
+				SocketDir:        windrun.SocketDir(),
+				Hostname:         hostname,
+				DaemonCapability: stamp.Capability,
+				DaemonVersion:    stamp.Version,
+				DaemonPID:        stamp.PID,
 			}, os.Stdin, os.Stdout)
 		},
 	}

--- a/site/docs/architecture.html
+++ b/site/docs/architecture.html
@@ -150,6 +150,17 @@
     up. The daemon outlives every dashboard: agents, their terminals, and their scrollback
     persist across dashboard restarts, and the daemon's sessions are the roster — there is
     no second record to reconcile.</p>
+    <p>Outliving the dashboard means outliving the binary, so a daemon can be running code
+    from a release nobody has installed for months. That is harmless until a dispatch needs
+    the daemon to do something a daemon that old cannot: an unknown field in a spawn request
+    is not refused, it is dropped, and the agent starts anyway &mdash; missing the
+    environment its whole lifecycle depends on, and failing somewhere that never mentions
+    the daemon. So <code>stormlight _wrdaemon</code> writes <code>daemon.json</code> beside
+    its socket before it listens, naming what it can be asked to do and the process saying
+    so, and removes it when it goes. <code>_wrbridge</code> reads that file rather than
+    reporting its own version, because the daemon it splices onto is whatever was already
+    listening. A daemon too old to carry an agent is refused a new one &mdash; and only a
+    new one, since the agents it already holds list and attach perfectly well.</p>
     <p>The daemon never learns what an agent is; that is the library's boundary. Agent
     identity and state ride in the session's opaque metadata as one JSON document under the
     <code>stormlight_agent</code> key — the serialized <code>agent.Agent</code>: id,


### PR DESCRIPTION
Fixes #144. Blocks v0.11.3 — this is a live failure, reported from a real host.

## What #144 actually is

A daemon outlives the binary that started it. That is the point of it — agents survive the dashboard, the terminal, and the upgrade — and it is also the one way a machine ends up running code nobody has installed for months.

The gap is not about versions but **capability**. A spawn request carries fields, and a daemon predating one of them does not object: it drops the field and starts the process anyway.

- Before #188 that meant hooks that could never report state.
- **Since #188 the provider's argv rides there too**, so the launch cannot resolve anything and the agent dies with `exec: : not found`.

My own #188 work escalated this from "hooks are broken" to "the agent cannot start."

**Protocol 2 (#192) cannot catch it**, and the report says so correctly: the bridge is a fresh process of a known build and greets fine, then splices onto whatever daemon was already listening. Both bridge ends agree while the daemon behind one of them cannot honour the request. `Hello.Version` describes the messenger, not the machine that will run the agent.

## The fix

`_wrdaemon` writes a stamp beside its socket **before it listens** — capability, version, pid — and removes it when it goes. `_wrbridge` reads that file rather than reporting its own version.

**Absence is the answer that matters.** A daemon started before stamps existed leaves none, and that is precisely the daemon whose capabilities cannot be asked about any other way. The pid is what makes the file evidence rather than a leftover: a stamp naming a process that is gone is worth exactly what no stamp is worth.

The capability number is the general form the issue asks for — every future spawn field has this same failure mode against a daemon that outlives a release, and moving the number is how that gets declared.

## Refusing the right thing

The dispatch is refused before an agent exists to be broken. **Only the dispatch** — this was the part of the report I took most seriously:

> Restarting is not presently an acceptable recovery on this host: the stale daemon owns four live Codex agents, two working and two idle.

Those sessions list, attach, and take input perfectly well; nothing about them is affected. So the check lives in `Dispatch`, not in the handshake, and the message says so rather than leaving it to be feared:

```
Error: the windrunner daemon on mini was started by a Stormlight older than this one
and drops the environment an agent needs, so a new agent there would start without one.
Agents it already holds are unaffected — they still list and attach.
Restarting it takes them with it:
    ssh mini pkill -f 'stormlight _wrdaemon'
```

A stamped-but-behind daemon names its pid instead (`ssh mini kill 30725`), because killing the right process matters when the wrong one is somebody's afternoon. There is no gentler instruction to give, so the message does not imply one exists.

## Verified against a genuinely stale daemon

The mini's daemon had a socket and no stamp — it had outlived its binary, which is the exact condition:

1. Dispatch → refused with the message above, instead of an agent that dies three layers away.
2. `pkill` → fresh daemon stamps itself: `{"capability":1,"version":"dev","pid":30725}`, pid matching the live process.
3. Dispatch → real Claude agent, `working`.

Reverting the stamp in the test harness makes every remote test refuse, which is how I know the check is load-bearing rather than decorative.

## A note on process

I committed this to local `main` in the primary checkout by mistake — `cd` to the repo root to read the issue took me out of the worktree, and I did not notice. Caught before pushing: the commit was moved to this branch and `main` was reset to `origin/main`, which is now clean (`git log origin/main..main` is empty). Nothing was pushed to `main` and no work was lost.