### PR TITLE
A resize during a resync is noticed from the first byte

### DIFF
--- a/internal/pty/terminal.go
+++ b/internal/pty/terminal.go
@@ -151,12 +151,25 @@ func New(transport Transport, gate *Gate, cols, rows int) Model {
 func (s *state) replaceReplica(seed []byte, size *Size) {
 	// A windrunner snapshot has already passed through x/vt once. Normalize
 	// its reversed OSC 8 fields before replaying it through this second x/vt.
+	// Sampled before a byte of the seed is touched, because the window a
+	// resize has to be noticed in starts here rather than at the parse.
+	// The two passes below are a pass each over the whole snapshot —
+	// hundreds of kilobytes for a viewer deep in debt — and a resize
+	// landing in that prefix was invisible to the check further down:
+	// this read the already-moved generation, found it unmoved at the
+	// end, and installed the snapshot's stale size over it. Reading it
+	// early can only over-report movement, and over-reporting is the
+	// safe direction — the answer to it is to adopt the terminal's
+	// current size, which is what a viewer that just resized wants.
+	s.mu.Lock()
+	generation := s.sizeGeneration
+	s.mu.Unlock()
+
 	seed = []byte(repairVTHyperlinks(string(seed)))
 	s.observeModes(seed)
 
 	s.mu.Lock()
 	cols, rows := s.termCols, s.termRows
-	generation := s.sizeGeneration
 	s.mu.Unlock()
 	if size != nil && size.Cols >= 2 && size.Rows >= 2 {
 		// The snapshot's bytes were rendered at this size, and the two


### PR DESCRIPTION
Fixes #203.

The window a resize has to be seen in opened at the parse, and it starts earlier than that.

`replaceReplica` makes two passes over the whole snapshot before it samples `sizeGeneration` — repairing hyperlinks and observing modes, each a pass over hundreds of kilobytes for a viewer deep enough in debt to be resynced at all. A resize landing in that prefix was invisible: it sampled the already-moved generation, found it unmoved at the end, and installed the snapshot's own stale size on top of it.

That is the exact state the guard was written to prevent, reached by walking in front of it. The replica paints bytes wrapped for one width into an emulator of another, and nothing in the refresh loop corrects it, because the box size never changed.

## The change

Sample the generation before a byte of the seed is touched. Reading it early can only over-report movement, and over-reporting is the safe direction — the answer to it is to adopt the terminal's current size, which is what a viewer that just resized wants anyway.

One hunk, `internal/pty/terminal.go`.

## Why it looked like a flaky test

`TestResizeDuringAResyncIsNotLost` already described this bug. It aims a resize at the middle of the parse with a 5ms sleep, and has been landing it in the *prefix* instead whenever those two passes run long — a big seed, `-race`, a loaded runner. So its failure rate tracked machine speed rather than anything about the code under test, which is what made it read as flake.

Same machine, 100 runs under `-race`:

| | result |
|---|---|
| `main` before this | 2 failures |
| with this | 100 pass |

150 `-race` runs pass on this branch, and `go test ./... -count=1` is clean. The CI failure on #202 was this, not that PR — `go list -deps ./internal/pty` has no windrunner in it at all.

## Why now rather than after the release

goreleaser runs `go test ./...` in its before-hooks, so this flake can abort a release run before any asset is built. Landing it first keeps it out of the v0.12.2 pipeline.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014zjBTnFKtag9WkBpeLaUaU

---
_Generated by [Claude Code](https://claude.ai/code/session_014zjBTnFKtag9WkBpeLaUaU)_