### PR TITLE
A trackpad flick costs one frame, not one per tick

### DIFF
--- a/internal/pty/terminal.go
+++ b/internal/pty/terminal.go
@@ -3,6 +3,7 @@ package pty
 
 import (
 	"context"
+	"errors"
 	"io"
 	"net/url"
 	"strings"
@@ -13,13 +14,28 @@ import (
 	tea "charm.land/bubbletea/v2"
 	"github.com/charmbracelet/x/ansi"
 	"github.com/charmbracelet/x/vt"
+	"github.com/trentkm/stormlight/internal/diagnostic"
 )
 
 const (
 	framePeriod       = 33 * time.Millisecond
 	scrollBurstPeriod = framePeriod
 	DefaultScrollback = 2000
+	// writeQueue is how many unsent chunks a terminal will hold for a
+	// transport that is not draining them. It is the same order as the
+	// stream buffer in the other direction, and it is the whole of the
+	// backpressure: input is produced by a human at a keyboard or a
+	// trackpad, so a queue this deep is only ever reached by a transport
+	// that has stopped moving.
+	writeQueue = 256
 )
+
+// ErrWriteQueueFull is a write refused because the terminal already holds
+// writeQueue chunks the transport has not taken. Refusing is the point:
+// the alternative to a bounded queue is a goroutine per keystroke waiting
+// on a socket that is not answering, which is how a stalled attachment
+// used to take the whole dashboard with it.
+var ErrWriteQueueFull = errors.New("terminal write queue is full")
 
 var lastID atomic.Int64
 
@@ -118,6 +134,17 @@ type state struct {
 	// guarded by mu.
 	view      string
 	viewDirty bool
+	// writes is the terminal's input queue, drained by one goroutine so
+	// the bytes reach the transport in the order they were typed. Neither
+	// half of that is decoration. Ordering: a command per write let the
+	// event loop start a goroutine per keystroke, and goroutines racing
+	// for the attachment's mutex arrive in whatever order the scheduler
+	// picks — a fast burst could deliver a wheel report or a keystroke
+	// out of sequence. Boundedness: nothing capped how many of those
+	// goroutines could exist, so a transport that stopped draining
+	// collected one per raw input event for as long as the human kept
+	// scrolling.
+	writes chan []byte
 }
 
 // New replays the terminal's seed and starts consuming its output stream.
@@ -129,6 +156,7 @@ func New(transport Transport, gate *Gate, cols, rows int) Model {
 		transport: transport, gate: gate,
 		cols: cols, rows: rows, termCols: cols, termRows: rows,
 		viewDirty: true,
+		writes:    make(chan []byte, writeQueue),
 	}
 	seed := transport.Seed()
 	// The seed names the size it was rendered at when the transport knows
@@ -137,7 +165,20 @@ func New(transport Transport, gate *Gate, cols, rows int) Model {
 	s.replaceReplica(seed.Resync, seed.Resize)
 	model := Model{id: lastID.Add(1), state: s}
 	go s.pump(model)
+	go s.deliver()
 	return model
+}
+
+// deliver carries queued input to the transport, one chunk at a time and
+// in order. It is the terminal's only writer, so a transport that blocks
+// parks exactly this goroutine — the queue behind it fills, and the
+// dashboard's event loop, which only ever enqueues, never waits on it.
+func (s *state) deliver() {
+	for data := range s.writes {
+		if err := s.transport.Write(data); err != nil {
+			diagnostic.Logger().Warn("terminal write failed", "error", err)
+		}
+	}
 }
 
 // replaceReplica seeds a fresh emulator with exact state and swaps it in,
@@ -351,9 +392,32 @@ func (m Model) Text() []string {
 	return lines
 }
 
-// Write delivers bytes to the hosted terminal.
-func (m Model) Write(data []byte) error { return m.state.transport.Write(data) }
-func (m Model) ID() int64               { return m.id }
+// Write hands bytes to the terminal's writer without waiting for the
+// transport to take them. It never blocks: the caller is the event loop,
+// and a keystroke that waits on a socket is a dashboard that has stopped
+// answering the keyboard.
+func (m Model) Write(data []byte) error {
+	s := m.state
+	// The lock is held across the send, and can be: the send is the
+	// non-blocking form, so it either takes a queue slot or reports a
+	// full one, and returns either way. Dropping the lock first would
+	// leave a window for Close to shut the queue between the check and
+	// the send, which is a send on a closed channel — a panic, on the
+	// event loop, at teardown.
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	if s.closed {
+		return io.ErrClosedPipe
+	}
+	select {
+	case s.writes <- data:
+		return nil
+	default:
+		return ErrWriteQueueFull
+	}
+}
+
+func (m Model) ID() int64 { return m.id }
 
 // SetSize is the deliberate resize: the dashboard's own window moved, a
 // zoom toggled, an attach returned. It asserts the new size on both the
@@ -576,6 +640,12 @@ func (m Model) Close() {
 		return
 	}
 	s.closed, s.scrollDelta = true, 0
+	// Under the lock, alongside the flag Write reads: the two together
+	// are what stop a write already inside Write from sending into a
+	// closed queue. The drain goroutine ends on the closed channel rather
+	// than parked on a send nothing will ever receive; the early return
+	// above is what makes closing it exactly once.
+	close(s.writes)
 	// Read it here, not after unlocking: a resync replaces this field at
 	// runtime, so an unlocked read races the swap and can close a pipe
 	// that has already been replaced — leaving the live emulator's drain

--- a/internal/ui/model.go
+++ b/internal/ui/model.go
@@ -353,6 +353,35 @@ type Model struct {
 	// async open/exit messages to the opening they belong to.
 	overlay           *overlayView
 	overlayGeneration int
+
+	// holdFrame says the message just handled changed nothing that is
+	// drawn, so View may answer with the frame it built last time
+	// instead of building another. Update clears it before every
+	// message; only a handler that knows its work is invisible sets it.
+	//
+	// The wheel is why it exists. Bubble Tea renders after every Update,
+	// and a trackpad flick is thousands of them — each one rebuilding
+	// every pane, every row and every band to arrive at the picture
+	// already on screen, while the keys pressed afterwards waited behind
+	// the pile. A wheel tick moves nothing on its own: the replica scroll
+	// is applied by the coalesced flush a frame later, and a tick
+	// forwarded to a mouse-aware agent comes back as terminal output on
+	// the gate's cadence. Either way the honest answer is the last frame.
+	holdFrame bool
+	// frame is that last frame. It is a pointer because View has a value
+	// receiver over a model the event loop throws away, and because every
+	// copy of a Model is the same dashboard — the terminal herd is held
+	// the same way. Only the event loop touches it: Bubble Tea renders on
+	// the goroutine it updates on.
+	frame *frame
+}
+
+// frame is the dashboard as View last built it. builds counts how many
+// times that happened, which is the measurable form of the bound this
+// whole mechanism exists to keep — see TestWheelBurstBuildsOneFrame.
+type frame struct {
+	content string
+	builds  int
 }
 
 // machineChoices is the Remote tab's rows: what the SSH configuration
@@ -522,6 +551,7 @@ func NewModelWithOptions(backend Backend, options Options) Model {
 		machines:           machineChoices(options.Hosts),
 		checkHost:          options.CheckHost,
 		hostInput:          newLineInput("user@host"),
+		frame:              &frame{},
 	}
 	for index, info := range model.providers {
 		if info.ID == options.DefaultProvider {
@@ -546,6 +576,10 @@ func (m Model) Init() tea.Cmd {
 }
 
 func (m Model) Update(message tea.Msg) (tea.Model, tea.Cmd) {
+	// Every message repaints unless the handler that takes it says
+	// otherwise, so the exemption has to be re-earned each time rather
+	// than inherited from the message before.
+	m.holdFrame = false
 	if m.ptyEnabled && m.ptyManager != nil {
 		// The coalesced wheel tick goes to the terminal that scheduled
 		// it — selection may have moved since; an unrouted tick would
@@ -840,7 +874,7 @@ func (m Model) Update(message tea.Msg) (tea.Model, tea.Cmd) {
 			// the same shape Send uses — never a burst of keystrokes.
 			if widget, ok := m.selectedPTY(); ok {
 				widget.ScrollToBottom()
-				return m, writeTerminalCmd(widget,
+				writeTerminal(widget,
 					[]byte("\x1b[200~"+msg.Content+"\x1b[201~"))
 			}
 			return m, nil
@@ -848,8 +882,9 @@ func (m Model) Update(message tea.Msg) (tea.Model, tea.Cmd) {
 		if m.overlay != nil {
 			// Bracketed paste, so a multi-line paste lands in the hosted
 			// program as one paste rather than a burst of keys.
-			return m, writeTerminalCmd(m.overlay.widget,
+			writeTerminal(m.overlay.widget,
 				[]byte("\x1b[200~"+msg.Content+"\x1b[201~"))
+			return m, nil
 		}
 		return m.updatePaste(msg)
 
@@ -970,10 +1005,27 @@ func (m Model) View() tea.View {
 		return view
 	}
 
+	// A held frame is exactly one message old — Bubble Tea renders after
+	// every Update it runs — so reusing it shows what the last message
+	// left on screen, which is what the held message did not change. The
+	// cursor is asked for again rather than kept: it costs a lookup, and
+	// it is where the agent's program put it, not where this frame was
+	// built.
+	if m.holdFrame && m.frame != nil && m.frame.content != "" {
+		view.SetContent(m.frame.content)
+		view.Cursor = m.ptyCursor()
+		return view
+	}
+
 	header := m.renderHeader()
 	body := m.renderBody()
 	footer := m.renderFooter()
-	view.SetContent(lipgloss.JoinVertical(lipgloss.Left, header, body, footer))
+	content := lipgloss.JoinVertical(lipgloss.Left, header, body, footer)
+	if m.frame != nil {
+		m.frame.content = content
+		m.frame.builds++
+	}
+	view.SetContent(content)
 	// The real terminal cursor sits where the agent's program put it —
 	// the Spanreed is the terminal, not a picture of one.
 	view.Cursor = m.ptyCursor()

--- a/internal/ui/overlay_test.go
+++ b/internal/ui/overlay_test.go
@@ -6,6 +6,7 @@ import (
 	"strings"
 	"sync"
 	"testing"
+	"time"
 
 	tea "charm.land/bubbletea/v2"
 
@@ -120,16 +121,29 @@ func TestOverlayFloatsOverTheDashboardAndOwnsTheKeyboard(t *testing.T) {
 		t.Fatalf("popup is missing its frame:\n%s", body)
 	}
 
-	// Keys land in the hosted program, byte for byte.
+	// Keys land in the hosted program, byte for byte. The write leaves
+	// through the terminal's own writer rather than a command the test
+	// can run, so the assertion waits for it instead of firing it.
 	updated, cmd := model.updateOverlayKey(tea.KeyPressMsg{Text: "j", Code: 'j'})
 	model = updated.(Model)
-	if cmd == nil {
-		t.Fatal("keypress produced no write")
+	if cmd != nil {
+		t.Fatal("keypress returned a command; writes are queued, not commanded")
 	}
-	cmd()
-	if got := session.recorded(); got != "j" {
-		t.Fatalf("forwarded bytes = %q, want %q", got, "j")
+	waitForWrites(t, session, "j")
+}
+
+// waitForWrites waits for the terminal's writer goroutine to deliver what
+// the event loop queued.
+func waitForWrites(t *testing.T, session *fakeOverlaySession, want string) {
+	t.Helper()
+	deadline := time.Now().Add(2 * time.Second)
+	for time.Now().Before(deadline) {
+		if session.recorded() == want {
+			return
+		}
+		time.Sleep(time.Millisecond)
 	}
+	t.Fatalf("forwarded bytes = %q, want %q", session.recorded(), want)
 }
 
 func TestOverlayCancelDestroysTheSessionUnread(t *testing.T) {

--- a/internal/ui/overlays.go
+++ b/internal/ui/overlays.go
@@ -162,7 +162,8 @@ func (m Model) updateOverlayKey(msg tea.KeyPressMsg) (tea.Model, tea.Cmd) {
 	if len(data) == 0 {
 		return m, nil
 	}
-	return m, writeTerminalCmd(m.overlay.widget, data)
+	writeTerminal(m.overlay.widget, data)
+	return m, nil
 }
 
 // cancelOverlay tears the popup down without an answer: the session dies
@@ -372,6 +373,18 @@ func choiceKey(host, path string) string {
 	return host + "\x00" + directoryKey(path)
 }
 
+// evalSymlinks is the one place this package walks a path against the
+// filesystem, named so a test can watch it. Nothing on the render path may
+// reach it: a dashboard frame is built for every message the event loop
+// takes, so an lstat chain in there turns a trackpad flick into thousands
+// of syscalls and starves every later key of its turn. See
+// TestRenderingAnAgentTouchesNoSymlinks.
+var evalSymlinks = filepath.EvalSymlinks
+
+// directoryKey is the comparable form of a path someone typed or a picker
+// returned — an answer about this machine's filesystem, and so a question
+// only the forms ask. Paths that arrive on a workspace.Context are already
+// canonical and compare with ==; see that type.
 func directoryKey(path string) string {
 	path = strings.TrimSpace(path)
 	if path == "" {
@@ -381,7 +394,7 @@ func directoryKey(path string) string {
 	if err == nil {
 		path = absolute
 	}
-	resolved, err := filepath.EvalSymlinks(path)
+	resolved, err := evalSymlinks(path)
 	if err == nil {
 		path = resolved
 	}

--- a/internal/ui/ptykeys.go
+++ b/internal/ui/ptykeys.go
@@ -66,22 +66,28 @@ func (m Model) updateTerminalKey(msg tea.KeyPressMsg) (tea.Model, tea.Cmd) {
 	}
 	// Typing while scrolled back reads as "take me to the action".
 	widget.ScrollToBottom()
-	send := writeTerminalCmd(widget, data)
+	writeTerminal(widget, data)
 	if selected, ok := m.selectedAgent(); ok &&
 		selected.ProcessLive &&
 		(selected.Attention == agent.AttentionWaiting ||
 			selected.EffectiveMark() == agent.MarkAttention) {
 		m.markAttentionSeen(selected.ID)
-		return m, tea.Batch(send, clearAttentionCmd(m.backend, selected.ID))
+		return m, clearAttentionCmd(m.backend, selected.ID)
 	}
-	return m, send
+	return m, nil
 }
 
-func writeTerminalCmd(widget pty.Model, data []byte) tea.Cmd {
-	return func() tea.Msg {
-		if err := widget.Write(data); err != nil {
-			diagnostic.Logger().Warn("terminal write failed", "error", err)
-		}
-		return nil
+// writeTerminal hands input to a terminal from the event loop itself,
+// with no command and so no goroutine. The widget queues the bytes and
+// its own writer delivers them in order; the call cannot block, so the
+// loop is free to take the next message whatever the transport is doing.
+//
+// It was a tea.Cmd until a trackpad found the flaw: Bubble Tea starts
+// every returned command in its own goroutine, and a mouse-aware agent
+// turns each raw wheel tick into one write, so a burst against a stalled
+// attachment grew a goroutine per tick with nothing bounding the pile.
+func writeTerminal(widget pty.Model, data []byte) {
+	if err := widget.Write(data); err != nil {
+		diagnostic.Logger().Warn("terminal write failed", "error", err)
 	}
 }

--- a/internal/ui/selection.go
+++ b/internal/ui/selection.go
@@ -72,14 +72,21 @@ func (m Model) handleMouse(msg tea.MouseMsg) (tea.Model, tea.Cmd) {
 				if direction > 0 {
 					button = 65
 				}
-				return m, writeTerminalCmd(widget, []byte(fmt.Sprintf(
+				writeTerminal(widget, []byte(fmt.Sprintf(
 					"\x1b[<%d;%d;%dM", button, col+1, row+1)))
 			}
+			// Forwarding the tick changed nothing this frame draws; what
+			// the program makes of it arrives as terminal output, on the
+			// gate's own cadence.
+			m.holdFrame = true
 			return m, nil
 		}
 		// Wheel deltas coalesce through the widget, so a trackpad burst
 		// lands as one update; the scheduled flush returns through
-		// Update's message forwarding.
+		// Update's message forwarding. Until that flush the replica has
+		// not moved, so this frame is the last one over again — say so,
+		// and the burst costs one dashboard build instead of hundreds.
+		m.holdFrame = true
 		return m, widget.QueueScroll(-direction * 3)
 	}
 	m.moveSelectionIn(paneInteraction, direction*3)
@@ -159,7 +166,8 @@ func (m Model) handleTerminalMouse(msg tea.MouseMsg) (tea.Model, tea.Cmd) {
 			if col, row, ok := m.gridCellAt(mouse.X, mouse.Y); ok {
 				press := fmt.Sprintf("\x1b[<0;%d;%dM", col+1, row+1)
 				release := fmt.Sprintf("\x1b[<0;%d;%dm", col+1, row+1)
-				return m, writeTerminalCmd(widget, []byte(press+release))
+				writeTerminal(widget, []byte(press+release))
+				return m, nil
 			}
 		}
 		return m, nil

--- a/internal/ui/state.go
+++ b/internal/ui/state.go
@@ -294,12 +294,23 @@ type checkoutBadge struct {
 // agentCheckout names the execution root an agent runs in. Git gets its
 // familiar checkout/worktree language; custom resolvers may provide an
 // execution_root_label, with a generic root label as fallback.
+//
+// The two roots are compared as strings because they arrive comparable:
+// every context reaching here passed through workspace normalization,
+// which put Root and ExecutionRoot through the same canonical form — real
+// symlink resolution for a local machine, cleaning for a remote one.
+// Resolving them again here would have been redundant on the local path
+// and wrong on the remote one, since the only filesystem this process can
+// stat is the wrong one. It also cost a pair of EvalSymlinks walks per
+// render: this is read from the terminal bar, which the dashboard rebuilds
+// on every message, so a wheel burst turned into a burst of lstat calls.
+// Context.Tail has always compared them this way.
 func agentCheckout(managedAgent agent.Agent) checkoutBadge {
 	value := effectiveWorkspace(managedAgent)
 	if value.ExecutionRoot == "" {
 		return checkoutBadge{}
 	}
-	primary := directoryKey(value.ExecutionRoot) == directoryKey(value.Root)
+	primary := value.ExecutionRoot == value.Root
 	if label := strings.TrimSpace(value.Metadata["execution_root_label"]); label != "" {
 		return checkoutBadge{text: label, primary: primary}
 	}

--- a/internal/ui/wheel_test.go
+++ b/internal/ui/wheel_test.go
@@ -1,0 +1,308 @@
+package ui
+
+// The wheel's cost. A trackpad flick is thousands of messages, and each
+// one of them used to buy a full dashboard build — and, over a
+// mouse-aware agent, a goroutine holding a write. These pin the bounds
+// that replaced both.
+
+import (
+	"context"
+	"runtime"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+
+	tea "charm.land/bubbletea/v2"
+	"github.com/charmbracelet/x/ansi"
+
+	"github.com/trentkm/stormlight/internal/agent"
+	"github.com/trentkm/stormlight/internal/pty"
+	"github.com/trentkm/stormlight/internal/workspace"
+)
+
+// wheelTransport is one agent's terminal for these tests: a seeded
+// replica, an output channel the test feeds by hand, and a write side
+// that can be told to stop draining.
+type wheelTransport struct {
+	seed   string
+	output chan pty.Message
+
+	mu      sync.Mutex
+	writes  int
+	bytes   []byte
+	blocked chan struct{}
+}
+
+func newWheelTransport(seed string) *wheelTransport {
+	return &wheelTransport{seed: seed, output: make(chan pty.Message, 8)}
+}
+
+// block makes every write park until the test releases it, which is what
+// a daemon that has stopped answering looks like from here.
+func (w *wheelTransport) block() {
+	w.mu.Lock()
+	defer w.mu.Unlock()
+	w.blocked = make(chan struct{})
+}
+
+func (w *wheelTransport) release() {
+	w.mu.Lock()
+	gate := w.blocked
+	w.blocked = nil
+	w.mu.Unlock()
+	if gate != nil {
+		close(gate)
+	}
+}
+
+func (w *wheelTransport) Seed() pty.Message {
+	return pty.Message{Resync: []byte(w.seed)}
+}
+func (w *wheelTransport) Output() <-chan pty.Message { return w.output }
+func (w *wheelTransport) Write(data []byte) error {
+	w.mu.Lock()
+	w.writes++
+	w.bytes = append(w.bytes, data...)
+	gate := w.blocked
+	w.mu.Unlock()
+	if gate != nil {
+		<-gate
+	}
+	return nil
+}
+func (w *wheelTransport) Resize(context.Context, int, int) error { return nil }
+func (w *wheelTransport) Close()                                 { close(w.output) }
+
+func (w *wheelTransport) written() int {
+	w.mu.Lock()
+	defer w.mu.Unlock()
+	return w.writes
+}
+
+func (w *wheelTransport) delivered() string {
+	w.mu.Lock()
+	defer w.mu.Unlock()
+	return string(w.bytes)
+}
+
+// wheelBackend hands the terminal herd the one transport under test.
+type wheelBackend struct {
+	stubBackend
+	transport *wheelTransport
+}
+
+func (b wheelBackend) AttachTerminal(
+	context.Context, string, int, int,
+) (pty.Transport, error) {
+	return b.transport, nil
+}
+
+// wheelModelFixture is the dashboard as the wheel meets it: one agent,
+// its terminal live and zoomed, so every column of the body belongs to
+// the portal and a tick anywhere lands on it.
+func wheelModelFixture(t *testing.T, transport *wheelTransport) (Model, pty.Model) {
+	t.Helper()
+	model := NewModel(wheelBackend{transport: transport})
+	workspaceContext := workspace.DirectoryContext("/tmp/wheel")
+	model.agents = []agent.Agent{{
+		ID:          "wheel-1",
+		Name:        "wheel-1",
+		Provider:    agent.ProviderClaude,
+		ProcessLive: true,
+		Workspace:   workspaceContext,
+	}}
+	model.rebuildGroups(workspaceContext.ID, "wheel-1")
+
+	updated, cmd := model.Update(tea.WindowSizeMsg{Width: 180, Height: 55})
+	model = updated.(Model)
+	if cmd != nil {
+		cmd()
+	}
+	model.activePane = paneInteraction
+	model.ptyZoom = true
+	manager := model.ptyManager
+	t.Cleanup(manager.CloseAll)
+
+	widget, ok := model.selectedPTY()
+	if !ok {
+		t.Fatal("the agent's terminal never opened")
+	}
+	return model, widget
+}
+
+// scrollbackSeed is more lines than the fixture's grid holds, so there is
+// history above the screen for the wheel to reach.
+func scrollbackSeed(lines int) string {
+	rows := make([]string, lines)
+	for index := range rows {
+		rows[index] = "seeded line"
+	}
+	return strings.Join(rows, "\r\n")
+}
+
+func wheelUp() tea.MouseWheelMsg {
+	return tea.MouseWheelMsg{X: 40, Y: 10, Button: tea.MouseWheelUp}
+}
+
+// TestWheelBurstBuildsOneFrame is the bound at the event-loop boundary. A
+// wheel tick moves nothing by itself — the replica scrolls on the
+// coalesced flush a frame later — so a burst of them must cost no
+// dashboard builds at all, and the scroll must still land when the flush
+// arrives.
+func TestWheelBurstBuildsOneFrame(t *testing.T) {
+	transport := newWheelTransport(scrollbackSeed(200))
+	model, widget := wheelModelFixture(t, transport)
+
+	// Bubble Tea renders after every Update it runs, so the test does too.
+	model.View()
+	settled := model.frame.builds
+	if settled == 0 {
+		t.Fatal("the first render built no frame")
+	}
+
+	var flush tea.Cmd
+	for range 500 {
+		updated, cmd := model.Update(wheelUp())
+		model = updated.(Model)
+		if cmd != nil {
+			flush = cmd
+		}
+		model.View()
+	}
+	if built := model.frame.builds - settled; built != 0 {
+		t.Fatalf("500 wheel events built %d dashboards, want none", built)
+	}
+	if flush == nil {
+		t.Fatal("the burst scheduled no coalesced flush")
+	}
+
+	// The flush is what the held frame was waiting for: the accumulated
+	// delta lands there, and that paints.
+	updated, _ := model.Update(flush())
+	model = updated.(Model)
+	model.View()
+	if built := model.frame.builds - settled; built != 1 {
+		t.Fatalf("the flush built %d dashboards, want exactly 1", built)
+	}
+	if widget.Scrolled() == 0 {
+		t.Fatal("500 wheel events left the replica where it started")
+	}
+}
+
+// TestRenderingAnAgentTouchesNoSymlinks keeps the filesystem out of the
+// render path. A frame is built for every message the event loop takes,
+// so an lstat chain in there is paid thousands of times during a flick;
+// the roots a frame compares are canonical before they ever arrive.
+func TestRenderingAnAgentTouchesNoSymlinks(t *testing.T) {
+	transport := newWheelTransport("rendered")
+	model, _ := wheelModelFixture(t, transport)
+	// The worktree case: an execution root that is not the workspace's
+	// own, which is the comparison that used to resolve both of them.
+	value := workspace.Context{
+		ID:            "git:/tmp/wheel/.git",
+		Kind:          workspace.KindGit,
+		Name:          "wheel",
+		Root:          "/tmp/wheel",
+		ExecutionRoot: "/tmp/wheel/.claude/worktrees/fix",
+	}
+	model.agents[0].Workspace = value
+	model.rebuildGroups(value.ID, "wheel-1")
+
+	walks := 0
+	original := evalSymlinks
+	evalSymlinks = func(path string) (string, error) {
+		walks++
+		return original(path)
+	}
+	t.Cleanup(func() { evalSymlinks = original })
+
+	model.View()
+	if walks != 0 {
+		t.Fatalf("a dashboard frame walked %d paths through EvalSymlinks, want none", walks)
+	}
+	// And it still says which checkout the agent stands in.
+	bar := ansi.Strip(model.renderTerminalBar(model.agents[0], 120))
+	if !strings.Contains(bar, "worktree fix") {
+		t.Fatalf("the terminal bar stopped naming the worktree: %q", bar)
+	}
+}
+
+// TestBlockedTerminalBoundsWheelWrites is the other half of the bound. A
+// mouse-aware agent takes the wheel itself, so every raw tick forwards as
+// an SGR report; against a transport that has stopped draining, those
+// must queue behind one writer rather than each taking a goroutine and a
+// place in an unbounded pile.
+func TestBlockedTerminalBoundsWheelWrites(t *testing.T) {
+	transport := newWheelTransport("mouse")
+	model, widget := wheelModelFixture(t, transport)
+
+	// The hosted program asks for the mouse the only way it can: by
+	// saying so on its own output stream.
+	transport.output <- pty.Message{Bytes: []byte("\x1b[?1000h")}
+	deadline := time.Now().Add(2 * time.Second)
+	for !widget.MouseReporting() && time.Now().Before(deadline) {
+		time.Sleep(time.Millisecond)
+	}
+	if !widget.MouseReporting() {
+		t.Fatal("the terminal never noticed the mouse-tracking mode")
+	}
+
+	transport.block()
+	t.Cleanup(transport.release)
+	// Park the writer on a blocked write before measuring, so what the
+	// burst meets is a stalled transport rather than a race with one.
+	if err := widget.Write([]byte("wake")); err != nil {
+		t.Fatalf("priming write: %v", err)
+	}
+	for transport.written() == 0 && time.Now().Before(deadline) {
+		time.Sleep(time.Millisecond)
+	}
+
+	before := runtime.NumGoroutine()
+	const burst = 2000
+	for range burst {
+		updated, cmd := model.Update(wheelUp())
+		model = updated.(Model)
+		if cmd != nil {
+			t.Fatal("a forwarded wheel tick returned a command to run in a goroutine")
+		}
+		model.View()
+	}
+	if grew := runtime.NumGoroutine() - before; grew > 4 {
+		t.Fatalf("%d forwarded wheel ticks added %d goroutines", burst, grew)
+	}
+	// The queue filled and started refusing, which is the bound saying so
+	// out loud rather than growing.
+	if err := widget.Write([]byte("one more")); err != pty.ErrWriteQueueFull {
+		t.Fatalf("write past a full queue = %v, want ErrWriteQueueFull", err)
+	}
+	if got := transport.written(); got > 1 {
+		t.Fatalf("a blocked transport took %d writes, want the one it is parked on", got)
+	}
+}
+
+// TestTerminalInputKeepsItsOrder is the other half of moving writes off
+// commands. A command per keystroke meant a goroutine per keystroke, all
+// of them racing for the attachment's one mutex, so what reached the
+// agent was whatever order the scheduler happened to hand out. One queue
+// and one writer is what makes typing arrive as typed.
+func TestTerminalInputKeepsItsOrder(t *testing.T) {
+	transport := newWheelTransport("prompt")
+	model, _ := wheelModelFixture(t, transport)
+
+	const typed = "the quick brown fox"
+	for _, letter := range typed {
+		updated, _ := model.updateTerminalKey(
+			tea.KeyPressMsg{Text: string(letter), Code: letter})
+		model = updated.(Model)
+	}
+
+	deadline := time.Now().Add(2 * time.Second)
+	for transport.delivered() != typed && time.Now().Before(deadline) {
+		time.Sleep(time.Millisecond)
+	}
+	if got := transport.delivered(); got != typed {
+		t.Fatalf("the agent received %q, want %q", got, typed)
+	}
+}

--- a/internal/workspace/context.go
+++ b/internal/workspace/context.go
@@ -14,6 +14,15 @@ const (
 )
 
 // Context describes the workspace grouping and execution boundary for an agent.
+//
+// Every path on it is canonical by the time anyone reads one. normalize
+// puts Root, ExecutionRoot and ComponentRoot through a single canonical
+// form on the way in — symlinks resolved against the filesystem that owns
+// them for a local workspace, cleaned for a remote one, where no local
+// stat could say anything true. That is what makes them comparable with
+// ==, and it is the reason no consumer needs to resolve them again: doing
+// so downstream would be redundant work on the local path and an answer
+// about the wrong machine on the remote one.
 type Context struct {
 	// Host names the machine this workspace is on; empty means this one.
 	// It belongs to identity rather than decoration: two machines can


### PR DESCRIPTION
Rapid trackpad or wheel scrolling in the terminal pane could stop the whole
TUI for seconds. Nothing panicked — input arrived faster than the single
Bubble Tea event loop could drain it, and every later keystroke waited
behind the pile.

## What was happening

**Every raw wheel event rebuilt the whole dashboard.** `QueueScroll`
coalesces the terminal's scroll delta, but Bubble Tea renders after every
`Update`, so each raw `MouseWheelMsg` still ran a full `Model.View`: every
pane, every row, every band, to arrive at the picture already on screen.

**Mouse-aware agents fanned out a goroutine per tick.** Codex and Claude
Code enable mouse reporting, so `handleMouse` bypassed `QueueScroll` and
returned one `writeTerminalCmd` per raw event. Bubble Tea starts every
returned command in its own goroutine while windrunner serializes
attachment writes on one mutex — unbounded, and worst exactly when the
transport is slow.

## The fix

**The wheel holds the frame.** A tick moves nothing on its own: the replica
scroll is applied by the coalesced flush a frame later, and a tick
forwarded to a mouse-aware agent comes back as terminal output on the
gate's own cadence. So the handler marks the frame unchanged and `View`
answers with the one it built last time. A held frame is exactly one
message old, because Bubble Tea renders after every `Update` it runs.

**Terminal writes go through a bounded, ordered queue.** Each terminal
drains its own queue on one goroutine, and the event loop enqueues without
waiting on the transport. That bounds the goroutines, and it fixes an
ordering bug nobody had hit yet: goroutines racing for the attachment's
single mutex delivered keystrokes in whatever order the scheduler chose.

**`agentCheckout` stopped resolving symlinks.** Root and ExecutionRoot are
canonical before they arrive — `workspace.normalize` puts both through one
canonical form — so the walk was redundant, and on a remote workspace it
was worse than redundant: `EvalSymlinks` was answering about this machine's
filesystem for a path on another one.

## Measured

Real model, 180x55 dashboard, terminal with full scrollback, Apple M4:

| | per wheel event |
|---|---|
| before (full dashboard build) | 1.35 ms |
| after (held frame) | 16.5 us |

Worth noting against the original report: the symlink walk measured 8.5us
of that 1.35ms here, not the 60% a profile elsewhere attributed to it. The
dashboard build itself was the cost. Removing the filesystem work from the
render path is still right — and it takes a real remote-path bug with it —
but the bound is what fixes the freeze.

## Regression coverage

`internal/ui/wheel_test.go`, all four confirmed to fail with their fix
reverted:

- `TestWheelBurstBuildsOneFrame` — 500 wheel events build zero dashboards;
  the coalesced flush builds exactly one, and the replica really scrolled.
  (Reverted: 500 builds.)
- `TestRenderingAnAgentTouchesNoSymlinks` — a frame walks no paths through
  `EvalSymlinks`, and still names the worktree. (Reverted: 2 walks.)
- `TestBlockedTerminalBoundsWheelWrites` — 2000 forwarded ticks against a
  stalled transport add no goroutines and no commands; the queue refuses
  rather than growing. (Reverted: the run wedged past a 60s timeout.)
- `TestTerminalInputKeepsItsOrder` — typing arrives as typed.

`go test -race ./...` is clean, and the built binary starts and renders
under an isolated tmux/XDG/WINDRUNNER_DIR harness.