### PR TITLE
The theme tests stop depending on which Node runs them

### DIFF
--- a/web/src/lib/mode.test.ts
+++ b/web/src/lib/mode.test.ts
@@ -1,5 +1,5 @@
 // @vitest-environment jsdom
-import { beforeEach, describe, expect, test } from "vitest";
+import { beforeEach, describe, expect, test, vi } from "vitest";
 import { chooseMode, followMode, mode, toggleMode } from "./mode.svelte";
 
 /**
@@ -10,6 +10,18 @@ import { chooseMode, followMode, mode, toggleMode } from "./mode.svelte";
  * guarding is that the two never disagree — a module that decided the
  * theme for itself would paint one answer and store another.
  */
+
+// Not jsdom's storage and not Node's: newer Node ships an experimental
+// localStorage global that shadows jsdom's and throws on use — the same
+// webstorage trap AGENTS.md documents for CI. A ten-line Map is the
+// same on every runner.
+const stored = new Map<string, string>();
+vi.stubGlobal("localStorage", {
+  getItem: (key: string) => stored.get(key) ?? null,
+  setItem: (key: string, value: string) => stored.set(key, String(value)),
+  removeItem: (key: string) => stored.delete(key),
+  clear: () => stored.clear(),
+});
 
 /** A stand-in for the media query jsdom does not implement. */
 function preferring(light: boolean) {


### PR DESCRIPTION
`web/src/lib/mode.test.ts` cleared `localStorage` in its `beforeEach` without stubbing storage, so on a Node that ships the experimental webstorage global — 25.x locally — all six theme tests died on `localStorage.clear is not a function`. Node's global shadows jsdom's and has no `clear`. CI's Node 22 never saw it, which is the whole problem: the suite only ran on one runner.

The fix is the one `web/src/components/canvas.test.ts` already carries: a Map-backed `vi.stubGlobal("localStorage", …)` — neither jsdom's storage nor Node's, and therefore the same on every runner. The tests that read back what was stored, and the one that makes `setItem` throw to prove a theme still applies, work against it unchanged.

Verified: 6 failures before the change on Node 25, 236 passing after; also green under `NODE_OPTIONS=--no-experimental-webstorage npm --prefix web test` and `npm --prefix web run check`. Test-only, so `web/dist` is unchanged.

Fixes #186