### PR TITLE
A terminal keeps the size the dashboard decided on

### DIFF
--- a/internal/pty/terminal.go
+++ b/internal/pty/terminal.go
@@ -117,7 +117,23 @@ type state struct {
 	// sizeGeneration counts changes to the terminal's size. A resync
 	// parses its state off-lock, which takes long enough for a resize to
 	// land in the middle; the counter is how the swap notices.
-	sizeGeneration        int
+	sizeGeneration int
+	// resizeSeq numbers the size assertions this widget has decided on;
+	// the newest is the only one still worth sending. assertedCols and
+	// assertedRows are the last size the hosted terminal actually took,
+	// which is not the same as the last one asked for — see assert.
+	resizeSeq                  uint64
+	assertedCols, assertedRows int
+	// assertFailing marks a run of failed assertions, so a terminal
+	// that refuses every one — a session whose process has exited is
+	// the usual way — is reported once rather than at the reconcile's
+	// cadence for as long as the dashboard is open (#100).
+	assertFailing bool
+	// resizeMu serializes assertions so a slow one cannot be overtaken
+	// by a newer one and land after it. It is held across the transport
+	// call, so it must never be taken while holding mu.
+	resizeMu sync.Mutex
+
 	scroll, scrollDelta   int
 	scrollPending, closed bool
 	// visible marks the terminal as on screen: only visible terminals
@@ -155,6 +171,9 @@ func New(transport Transport, gate *Gate, cols, rows int) Model {
 	s := &state{
 		transport: transport, gate: gate,
 		cols: cols, rows: rows, termCols: cols, termRows: rows,
+		// The attach asserted this size on the way in, so the widget
+		// starts already agreeing with the terminal it just opened.
+		assertedCols: cols, assertedRows: rows,
 		viewDirty: true,
 		writes:    make(chan []byte, writeQueue),
 	}
@@ -433,13 +452,76 @@ func (m Model) SetSize(cols, rows int) (Model, tea.Cmd) {
 		s.sizeGeneration++
 		s.viewDirty = true
 	}
+	s.resizeSeq++
+	seq := s.resizeSeq
 	s.mu.Unlock()
 	return m, func() tea.Msg {
-		ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
-		defer cancel()
-		_ = s.transport.Resize(ctx, cols, rows)
+		s.assert(seq, cols, rows)
 		return nil
 	}
+}
+
+// assert carries a decided size to the hosted terminal, and is the only
+// thing that does.
+//
+// The dashboard reconciles on every refresh and on every window size, and
+// Bubble Tea runs each returned command on a goroutine of its own — so a
+// drag across the screen puts several assertions in flight at once, each
+// naming the size the pane had when it was decided. They race, and the
+// one that reaches the daemon last is the one the agent's PTY keeps.
+// Nothing afterward disagrees with it: the widget believes its box, the
+// box is already right, and a reconcile that compares only the box has
+// nothing to correct. An intermediate size from the middle of a drag
+// therefore sticks, and the agent paints its narrow screen into the
+// corner of a wide pane until something else moves it (#155, #164).
+//
+// Two rules make that unreachable. A superseded assertion is dropped
+// rather than sent, and the send is serialized, so no assertion can
+// overtake a newer one on the way out.
+func (s *state) assert(seq uint64, cols, rows int) {
+	s.resizeMu.Lock()
+	defer s.resizeMu.Unlock()
+	s.mu.Lock()
+	stale := seq != s.resizeSeq || s.closed
+	s.mu.Unlock()
+	if stale {
+		return
+	}
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+	err := s.transport.Resize(ctx, cols, rows)
+
+	s.mu.Lock()
+	if err == nil {
+		s.assertedCols, s.assertedRows = cols, rows
+	}
+	// The failure is left unrecorded in the size on purpose: the
+	// terminal is still whatever size it was, and Asserted disagreeing
+	// with the box is what makes the next reconcile try again.
+	first := err != nil && !s.assertFailing
+	s.assertFailing = err != nil
+	s.mu.Unlock()
+	if first {
+		diagnostic.Logger().Warn("terminal resize failed",
+			"cols", cols, "rows", rows, "error", err)
+	}
+}
+
+// Asserted is the size the hosted terminal last accepted from this
+// widget. It trails Size whenever an assertion has not landed — refused,
+// timed out, or still in flight — and a reconcile that finds the two
+// apart re-asserts rather than assuming its last word was taken.
+//
+// It deliberately says nothing about what other viewers have done. A
+// terminal is shared, and a browser that resizes it moves this widget's
+// emulator through setTerminalSize without touching what this widget
+// asserted — so the dashboard insists on its own assertion landing
+// without fighting anyone else's (#155).
+func (m Model) Asserted() (int, int) {
+	s := m.state
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	return s.assertedCols, s.assertedRows
 }
 
 func (m Model) TerminalSize() (int, int) {

--- a/internal/ptyview/manager.go
+++ b/internal/ptyview/manager.go
@@ -110,7 +110,7 @@ func (g *Manager) Ensure(ctx context.Context, agentIDs []string, width, height i
 	}
 	var commands []tea.Cmd
 	for _, widget := range existing {
-		if cols, rows := widget.Size(); cols != width || rows != height {
+		if needsSize(widget, width, height) {
 			_, cmd := widget.SetSize(width, height)
 			if cmd != nil {
 				commands = append(commands, cmd)
@@ -135,6 +135,29 @@ func (g *Manager) Ensure(ctx context.Context, agentIDs []string, width, height i
 		}
 	}
 	return commands
+}
+
+// needsSize reports whether a terminal is due an assertion: either its
+// box moved, or the last one this widget sent never landed.
+//
+// The second half is the whole difference between a resize that is
+// asserted and a resize that is *held*. An assertion can be refused,
+// time out, or be dropped for a newer one that then loses the race to
+// the daemon, and in every one of those cases the box is already the
+// size the dashboard wants — so a reconcile comparing only the box sees
+// nothing to do, and the agent keeps painting at whatever size the
+// terminal was left holding (#155, #164).
+//
+// Comparing what the widget asserted, rather than the terminal's current
+// size, is what keeps this from fighting other viewers. A browser that
+// resizes the shared terminal moves the emulator and not this, so the
+// dashboard follows it as before instead of flapping against it.
+func needsSize(widget pty.Model, width, height int) bool {
+	if cols, rows := widget.Size(); cols != width || rows != height {
+		return true
+	}
+	cols, rows := widget.Asserted()
+	return cols != width || rows != height
 }
 
 // open builds an agent's terminal over the runtime's attachment.

--- a/internal/ptyview/manager_test.go
+++ b/internal/ptyview/manager_test.go
@@ -1,0 +1,217 @@
+package ptyview
+
+import (
+	"context"
+	"errors"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/trentkm/stormlight/internal/pty"
+)
+
+// fakeTransport records the sizes asserted on the daemon, in the order
+// they arrive there — which is the order that decides what size the
+// agent's PTY ends up at.
+type fakeTransport struct {
+	mu      sync.Mutex
+	applied []pty.Size
+	refuse  bool
+	output  chan pty.Message
+}
+
+func newFakeTransport() *fakeTransport {
+	return &fakeTransport{output: make(chan pty.Message)}
+}
+
+func (t *fakeTransport) Seed() pty.Message          { return pty.Message{} }
+func (t *fakeTransport) Output() <-chan pty.Message { return t.output }
+func (t *fakeTransport) Write([]byte) error         { return nil }
+func (t *fakeTransport) Close()                     {}
+
+func (t *fakeTransport) Resize(_ context.Context, cols, rows int) error {
+	t.mu.Lock()
+	defer t.mu.Unlock()
+	if t.refuse {
+		return errors.New("daemon said no")
+	}
+	t.applied = append(t.applied, pty.Size{Cols: cols, Rows: rows})
+	return nil
+}
+
+// refusing makes the next assertions fail, as a busy or unreachable
+// daemon does.
+func (t *fakeTransport) refusing(refuse bool) {
+	t.mu.Lock()
+	defer t.mu.Unlock()
+	t.refuse = refuse
+}
+
+func (t *fakeTransport) count() int {
+	t.mu.Lock()
+	defer t.mu.Unlock()
+	return len(t.applied)
+}
+
+// last is the size the daemon is left holding.
+func (t *fakeTransport) last() pty.Size {
+	t.mu.Lock()
+	defer t.mu.Unlock()
+	if len(t.applied) == 0 {
+		return pty.Size{}
+	}
+	return t.applied[len(t.applied)-1]
+}
+
+type fakeBackend struct{ transport *fakeTransport }
+
+func (b *fakeBackend) AttachTerminal(
+	_ context.Context, _ string, _, _ int,
+) (pty.Transport, error) {
+	return b.transport, nil
+}
+
+// A drag across the screen is a burst of window sizes, and the dashboard
+// answers each one with its own Ensure — Bubble Tea runs every returned
+// command on its own goroutine, so the assertions race. The one that
+// reaches the daemon last decides the agent's real PTY size, and it is
+// not necessarily the last one the dashboard decided on.
+//
+// When a stale intermediate lands after the final size, the widget is
+// left believing its box, the daemon holding something smaller, and
+// nothing reconciles the two: Ensure re-asserts only when the box
+// changes, and the box is already right. The agent then paints its
+// narrow screen into the corner of a wide pane for good (#155, #164).
+func TestAStaleResizeCannotLandAfterANewerOne(t *testing.T) {
+	transport := newFakeTransport()
+	manager := NewManager(&fakeBackend{transport: transport})
+	ctx := context.Background()
+
+	manager.Ensure(ctx, []string{"agent"}, 100, 40)
+
+	// Two overlapping reconciles, as two window sizes from one drag.
+	// Holding the first's command and running it second is exactly what
+	// two command goroutines are free to do.
+	stale := manager.Ensure(ctx, []string{"agent"}, 168, 42)
+	current := manager.Ensure(ctx, []string{"agent"}, 249, 71)
+	for _, resize := range current {
+		resize()
+	}
+	for _, resize := range stale {
+		resize()
+	}
+
+	widget, ok := manager.Widget("agent")
+	if !ok {
+		t.Fatal("no widget for the agent")
+	}
+	cols, rows := widget.Size()
+	if cols != 249 || rows != 71 {
+		t.Fatalf("box = %dx%d, want 249x71", cols, rows)
+	}
+	if got := transport.last(); got.Cols != 249 || got.Rows != 71 {
+		t.Errorf("daemon left at %dx%d, want 249x71 — the size the "+
+			"dashboard last decided on", got.Cols, got.Rows)
+	}
+
+	// And the reconcile that follows must repair it, whatever landed:
+	// the box has not changed, so this is the only chance left.
+	for _, resize := range manager.Ensure(ctx, []string{"agent"}, 249, 71) {
+		resize()
+	}
+	if got := transport.last(); got.Cols != 249 || got.Rows != 71 {
+		t.Errorf("after a further reconcile the daemon is still %dx%d, "+
+			"want 249x71: nothing reclaims the pane", got.Cols, got.Rows)
+	}
+}
+
+// A refused assertion is the same failure wearing different clothes: the
+// box is the size the dashboard wants, so nothing about it says the
+// terminal never moved. The next reconcile is the only thing standing
+// between that and a pane stuck at the wrong size for good.
+func TestARefusedResizeIsTriedAgain(t *testing.T) {
+	transport := newFakeTransport()
+	manager := NewManager(&fakeBackend{transport: transport})
+	ctx := context.Background()
+
+	manager.Ensure(ctx, []string{"agent"}, 100, 40)
+	transport.refusing(true)
+	for _, resize := range manager.Ensure(ctx, []string{"agent"}, 249, 71) {
+		resize()
+	}
+	if got := transport.last(); got.Cols == 249 {
+		t.Fatal("the refusal did not take; the test proves nothing")
+	}
+
+	transport.refusing(false)
+	for _, resize := range manager.Ensure(ctx, []string{"agent"}, 249, 71) {
+		resize()
+	}
+	if got := transport.last(); got.Cols != 249 || got.Rows != 71 {
+		t.Errorf("daemon left at %dx%d after the refusal cleared, "+
+			"want 249x71", got.Cols, got.Rows)
+	}
+}
+
+// The steady state has to stay quiet. Reconciling runs on every refresh,
+// several times a second, and a widget whose assertion landed has
+// nothing to say to the daemon.
+func TestAnUnchangedTerminalAssertsNothing(t *testing.T) {
+	transport := newFakeTransport()
+	manager := NewManager(&fakeBackend{transport: transport})
+	ctx := context.Background()
+
+	manager.Ensure(ctx, []string{"agent"}, 249, 71)
+	for range 5 {
+		for _, resize := range manager.Ensure(ctx, []string{"agent"}, 249, 71) {
+			resize()
+		}
+	}
+	if count := transport.count(); count != 0 {
+		t.Errorf("%d resizes asserted on a terminal that never moved, "+
+			"want none: the attach already carried the size", count)
+	}
+}
+
+// The other half of #155, and the reason this compares what the widget
+// asserted rather than the terminal's own size: a terminal is shared,
+// and a viewer that moves it is not something the dashboard argues with.
+// Two dashboards of different sizes would otherwise resize each other's
+// agents forever.
+func TestAnotherViewersResizeIsFollowedNotFought(t *testing.T) {
+	transport := newFakeTransport()
+	manager := NewManager(&fakeBackend{transport: transport})
+	ctx := context.Background()
+
+	manager.Ensure(ctx, []string{"agent"}, 249, 71)
+	widget, ok := manager.Widget("agent")
+	if !ok {
+		t.Fatal("no widget for the agent")
+	}
+	// A browser lays itself out and moves the shared terminal.
+	transport.output <- pty.Message{Resize: &pty.Size{Cols: 80, Rows: 24}}
+	waitFor(t, func() bool {
+		cols, rows := widget.TerminalSize()
+		return cols == 80 && rows == 24
+	}, "the emulator never followed the other viewer")
+
+	for range 3 {
+		for _, resize := range manager.Ensure(ctx, []string{"agent"}, 249, 71) {
+			resize()
+		}
+	}
+	if count := transport.count(); count != 0 {
+		t.Errorf("%d resizes sent back at the other viewer, want none", count)
+	}
+}
+
+func waitFor(t *testing.T, condition func() bool, complaint string) {
+	t.Helper()
+	for range 200 {
+		if condition() {
+			return
+		}
+		time.Sleep(time.Millisecond)
+	}
+	t.Fatal(complaint)
+}


### PR DESCRIPTION
## The symptom

The terminal pane lands in the upper-left corner of its box and stays there — the agent painting ~98 columns into a 249-column pane, blank to the right and below — until something moves the real window.

Measured on a live dashboard: window **319x75**, so `ptyGridDimensions` makes the terminal box **249x71**, while `stty -f` on the agent's PTY read **98x38** — a size the pane had at some earlier window. The dashboard had asserted 249x71; the daemon never took it.

## Two causes, one ending

`ensurePTYCmd` runs on every refresh (700ms) and every `WindowSizeMsg`, and Bubble Tea runs each returned command on its own goroutine. So a window drag puts several assertions in flight at once, each naming the size the pane had when it was decided, and **the one that reaches the daemon last is the one the PTY keeps** — which need not be the last one the dashboard decided on.

Separately, an assertion can just fail: `SetSize` discarded the error from `transport.Resize`, so a refusal or a 5s timeout was indistinguishable from success. (This is why the live log shows nothing — there was nothing to show.)

Either way the widget believes its box, the box is already right, and `Ensure` compared only the box. Nothing left to notice, no correction path — exactly the gap #164 recorded and the reclaim #155 left open.

## The fix

The widget tracks what the terminal *took*, not what it was last *asked for*:

- `assert` drops a superseded assertion rather than sending it, and serializes the send, so none can overtake a newer one.
- `Asserted()` reports the last size the transport accepted.
- `Ensure` re-asserts when `Asserted()` trails the box — so a resize is held until the terminal agrees, instead of fired once and assumed.

`Asserted` deliberately tracks *this widget's own* assertions rather than the terminal's current size, and that is the difference between insisting and flapping: a browser that resizes the shared terminal moves the emulator through `setTerminalSize` and not this, so the dashboard still follows other viewers instead of fighting them. That was #155's objection to a dashboard reclaim, and why #164 left it open.

The failure is logged now, once per run of failures rather than at the reconcile's cadence — an agent whose process has exited refuses every one (#100).

## Verification

- `TestAStaleResizeCannotLandAfterANewerOne` and `TestARefusedResizeIsTriedAgain` fail on main (`daemon left at 168x42, want 249x71`) and pass here.
- `TestAnUnchangedTerminalAssertsNothing` and `TestAnotherViewersResizeIsFollowedNotFought` pass both before and after — they guard the quiet steady state and the no-flapping boundary.
- End to end against a scratch daemon: a burst of sixteen window sizes settles the session at 249x71, and back to 130x46 on the way down.
- `go test -race ./...` clean.

Worth stating plainly: the **live harness converges on both builds** — a local unix socket makes the losing interleaving rare, so it demonstrates no regression rather than proving the fix. The deterministic unit reproduction is the discriminating evidence.

Fixes #164