### PR TITLE
Sync agent names with provider sessions

### DIFF
--- a/README.md
+++ b/README.md
@@ -172,10 +172,13 @@ inventory to dispatch one peer per checkout. The dashboard polls the same
 workspace catalog, root inventory, and managed-agent roster, so all changes
 appear without a restart.
 
-Agent renames set the stored name, which the dashboard prefers over the
-generated task title. Workspace renames (press `R` in the Workspaces pane)
-are display-name overrides stored in the workspace catalog; the directory on
-disk is untouched.
+Explicit agent names are also applied to the provider's saved session: Claude
+accepts the name when a session starts or resumes, and a running Codex session
+receives its native `/rename` command once the session ID arrives. Completed
+Codex sessions are renamed through its app-server API. Later Codex renames sync
+immediately for local agents and on the next provider event for remote ones.
+Workspace renames (press `R` in the Workspaces pane) are display-name overrides
+stored in the workspace catalog; the directory on disk is untouched.
 
 IDs may be shortened as long as the prefix remains unambiguous.
 

--- a/internal/agent/agent.go
+++ b/internal/agent/agent.go
@@ -184,6 +184,10 @@ type Agent struct {
 	// `claude --resume` and `codex resume` take — reported by its hooks and
 	// notify surface. It is what lets a conversation outlive its window.
 	SessionID string `json:"session_id,omitempty"`
+	// SessionName is the last Stormlight name successfully written into the
+	// provider's own session index. It prevents every lifecycle hook from
+	// repeating the same provider-side write.
+	SessionName string `json:"session_name,omitempty"`
 	// TranscriptPath is the provider's own transcript file for this
 	// conversation (Claude Code session JSONL), reported by its hooks.
 	TranscriptPath string            `json:"transcript_path,omitempty"`

--- a/internal/app/service.go
+++ b/internal/app/service.go
@@ -189,10 +189,12 @@ func (s *Service) ListAgents(ctx context.Context) ([]agent.Agent, error) {
 
 func (s *Service) Dispatch(ctx context.Context, req DispatchRequest) (agent.Agent, error) {
 	req.Task = strings.TrimSpace(req.Task)
+	req.Name = strings.TrimSpace(req.Name)
 	if req.Mode == "" {
 		req.Mode = agent.DefaultMode
 	}
-	launch, err := s.providers.Resolve(req.Provider, req.Task, req.Mode)
+	launch, err := s.providers.ResolveNamed(
+		req.Provider, req.Task, req.Name, req.Mode)
 	if err != nil {
 		return agent.Agent{}, err
 	}
@@ -238,7 +240,8 @@ func (s *Service) Resume(
 	if mode == "" {
 		mode = agent.DefaultMode
 	}
-	launch, err := s.providers.Resume(record.Provider, record.SessionID, mode)
+	launch, err := s.providers.ResumeNamed(
+		record.Provider, record.SessionID, record.Name, mode)
 	if err != nil {
 		return agent.Agent{}, err
 	}
@@ -481,7 +484,36 @@ func (s *Service) RenameWorkspace(
 }
 
 func (s *Service) Rename(ctx context.Context, id, name string) error {
-	return s.runtime.Rename(ctx, id, name)
+	name = strings.TrimSpace(name)
+	if name == "" {
+		return fmt.Errorf("agent name cannot be empty")
+	}
+	if err := s.runtime.Rename(ctx, id, name); err != nil {
+		return err
+	}
+	// A remote agent is synchronized by its next provider hook, which runs
+	// beside that provider and therefore has the right binary and state.
+	managedAgent, err := s.find(ctx, id)
+	if err != nil {
+		diagnostic.Logger().Warn("renamed agent could not be listed for session sync",
+			"agent_id", id,
+			"error", err,
+		)
+		return nil
+	}
+	if managedAgent.Host != "" {
+		return nil
+	}
+	if err := s.SyncSessionName(ctx, id); err != nil {
+		// Stormlight's name is authoritative for its own UI. A provider
+		// index failure is retried by the next lifecycle event rather than
+		// turning a completed rename into a misleading failed action.
+		diagnostic.Logger().Warn("provider session name sync failed",
+			"agent_id", id,
+			"error", err,
+		)
+	}
+	return nil
 }
 
 func (s *Service) Capture(ctx context.Context, id string, lines int) (string, error) {
@@ -701,6 +733,53 @@ func (s *Service) Update(ctx context.Context, id string, update session.Update) 
 	}
 	s.recordHistory(ctx, id)
 	return nil
+}
+
+// SyncSessionName copies an explicit Stormlight name into the provider's own
+// session index. It is called from provider hooks so the operation runs on
+// the same machine as remote providers and their state.
+func (s *Service) SyncSessionName(ctx context.Context, id string) error {
+	managedAgent, err := s.find(ctx, id)
+	if err != nil {
+		return err
+	}
+	name := strings.TrimSpace(managedAgent.Name)
+	if name == "" || managedAgent.SessionID == "" ||
+		managedAgent.SessionName == name {
+		return nil
+	}
+	command, supported, err := s.providers.SessionNameCommand(
+		managedAgent.Provider,
+		name,
+	)
+	if err != nil {
+		return err
+	}
+	if managedAgent.ProcessLive && supported {
+		if sender, ok := s.runtime.(session.CommandSender); ok {
+			if err := sender.SendCommand(ctx, id, command); err != nil {
+				return err
+			}
+			return s.runtime.Update(
+				ctx,
+				id,
+				session.Update{SessionName: name},
+			)
+		}
+	}
+	supported, err = s.providers.SetSessionName(
+		ctx,
+		managedAgent.Provider,
+		managedAgent.SessionID,
+		name,
+	)
+	if err != nil {
+		return err
+	}
+	if !supported {
+		return nil
+	}
+	return s.runtime.Update(ctx, id, session.Update{SessionName: name})
 }
 
 // recordHistory mirrors the agent's current state into the session history

--- a/internal/app/service_test.go
+++ b/internal/app/service_test.go
@@ -19,6 +19,8 @@ type recordingRuntime struct {
 	session.Runtime
 	agents      []agent.Agent
 	workspaceID string
+	updates     []session.Update
+	commands    []string
 }
 
 type rootsResolver struct {
@@ -46,10 +48,28 @@ func (r rootsResolver) ExecutionRoots(
 }
 
 func (r *recordingRuntime) Update(
-	context.Context,
-	string,
-	session.Update,
+	_ context.Context,
+	id string,
+	update session.Update,
 ) error {
+	r.updates = append(r.updates, update)
+	for index := range r.agents {
+		if r.agents[index].ID != id {
+			continue
+		}
+		if update.SessionName != "" {
+			r.agents[index].SessionName = update.SessionName
+		}
+	}
+	return nil
+}
+
+func (r *recordingRuntime) SendCommand(
+	_ context.Context,
+	id string,
+	command string,
+) error {
+	r.commands = append(r.commands, id+":"+command)
 	return nil
 }
 
@@ -153,6 +173,90 @@ func TestUpdateRecordsSessionHistory(t *testing.T) {
 	}
 	if len(past) != 1 || past[0].SessionID != records[0].SessionID {
 		t.Fatalf("past = %#v", past)
+	}
+}
+
+func TestSessionNameSyncUsesLiveCodexCommand(t *testing.T) {
+	current := &recordingRuntime{
+		agents: []agent.Agent{{
+			ID:          "agent-one",
+			Provider:    agent.ProviderCodex,
+			Name:        "focused fixer",
+			SessionID:   "3308ff3d-2cbc-47ab-81b1-a8fa28940a14",
+			ProcessLive: true,
+		}},
+	}
+	registry := provider.NewRegistryWithSpecs([]provider.Spec{{
+		ID:     agent.ProviderCodex,
+		Binary: filepath.Join(t.TempDir(), "missing-codex"),
+	}})
+	service := NewService(current, registry, workspace.NewRegistry())
+
+	if err := service.SyncSessionName(context.Background(), "agent-one"); err != nil {
+		t.Fatal(err)
+	}
+	if err := service.SyncSessionName(context.Background(), "agent-one"); err != nil {
+		t.Fatal(err)
+	}
+	if !slices.Equal(
+		current.commands,
+		[]string{"agent-one:/rename focused fixer"},
+	) {
+		t.Fatalf("commands = %#v", current.commands)
+	}
+	if current.agents[0].SessionName != "focused fixer" ||
+		len(current.updates) != 1 {
+		t.Fatalf("agent = %#v, updates = %#v", current.agents[0], current.updates)
+	}
+}
+
+func TestCompletedSessionNameSyncWritesCodexOnce(t *testing.T) {
+	capture := filepath.Join(t.TempDir(), "calls")
+	binary := filepath.Join(t.TempDir(), "codex")
+	script := `#!/bin/sh
+set -eu
+IFS= read -r initialize
+printf '{"id":1,"result":{}}\n'
+IFS= read -r initialized
+IFS= read -r rename
+printf 'called\n' >> "$CAPTURE"
+printf '{"id":2,"result":{}}\n'
+while :; do sleep 1; done
+`
+	if err := os.WriteFile(binary, []byte(script), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	t.Setenv("CAPTURE", capture)
+	current := &recordingRuntime{
+		agents: []agent.Agent{{
+			ID:        "agent-one",
+			Provider:  agent.ProviderCodex,
+			Name:      "focused fixer",
+			SessionID: "3308ff3d-2cbc-47ab-81b1-a8fa28940a14",
+		}},
+	}
+	registry := provider.NewRegistryWithSpecs([]provider.Spec{{
+		ID:     agent.ProviderCodex,
+		Binary: binary,
+	}})
+	service := NewService(current, registry, workspace.NewRegistry())
+
+	if err := service.SyncSessionName(context.Background(), "agent-one"); err != nil {
+		t.Fatal(err)
+	}
+	if err := service.SyncSessionName(context.Background(), "agent-one"); err != nil {
+		t.Fatal(err)
+	}
+	calls, err := os.ReadFile(capture)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if string(calls) != "called\n" {
+		t.Fatalf("provider calls = %q", calls)
+	}
+	if current.agents[0].SessionName != "focused fixer" ||
+		len(current.updates) != 1 {
+		t.Fatalf("agent = %#v, updates = %#v", current.agents[0], current.updates)
 	}
 }
 

--- a/internal/fleet/fleet.go
+++ b/internal/fleet/fleet.go
@@ -362,6 +362,18 @@ func (f *Runtime) Send(ctx context.Context, id, message string) error {
 	return runtime.Send(ctx, id, message)
 }
 
+func (f *Runtime) SendCommand(ctx context.Context, id, command string) error {
+	runtime, err := f.memberFor(ctx, id)
+	if err != nil {
+		return err
+	}
+	sender, ok := runtime.(session.CommandSender)
+	if !ok {
+		return fmt.Errorf("runtime cannot send provider commands")
+	}
+	return sender.SendCommand(ctx, id, command)
+}
+
 func (f *Runtime) Interrupt(ctx context.Context, id string) error {
 	runtime, err := f.memberFor(ctx, id)
 	if err != nil {

--- a/internal/fleet/fleet_test.go
+++ b/internal/fleet/fleet_test.go
@@ -20,6 +20,7 @@ type stub struct {
 	agents    []agent.Agent
 	listErr   error
 	sent      []string
+	commands  []string
 	deleted   []string
 	launched  []session.DispatchRequest
 	lists     int
@@ -50,6 +51,13 @@ func (s *stub) Send(_ context.Context, id, message string) error {
 	s.mu.Lock()
 	defer s.mu.Unlock()
 	s.sent = append(s.sent, id+":"+message)
+	return nil
+}
+
+func (s *stub) SendCommand(_ context.Context, id, command string) error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.commands = append(s.commands, id+":"+command)
 	return nil
 }
 
@@ -165,6 +173,17 @@ func TestOperationsFollowTheAgentToItsHost(t *testing.T) {
 	}
 	if len(devbox.sent) != 1 || len(local.sent) != 0 {
 		t.Fatalf("message went to the wrong machine: local=%v devbox=%v", local.sent, devbox.sent)
+	}
+	if err := f.SendCommand(
+		context.Background(),
+		"bbb",
+		"/rename remote-agent",
+	); err != nil {
+		t.Fatalf("SendCommand: %v", err)
+	}
+	if len(devbox.commands) != 1 || len(local.commands) != 0 {
+		t.Fatalf("command went to the wrong machine: local=%v devbox=%v",
+			local.commands, devbox.commands)
 	}
 	if err := f.Delete(context.Background(), "aaa"); err != nil {
 		t.Fatalf("Delete: %v", err)

--- a/internal/provider/provider.go
+++ b/internal/provider/provider.go
@@ -30,6 +30,7 @@ type Adapter interface {
 	ID() agent.Provider
 	Label() string
 	Resolve(prompt string, mode agent.PermissionMode) (Launch, error)
+	ResolveNamed(prompt, name string, mode agent.PermissionMode) (Launch, error)
 	// Binary is the program this provider runs, as a name to look up
 	// rather than a path some machine already resolved. It is what a
 	// host is asked about when the question is whether that machine can
@@ -41,6 +42,7 @@ type Adapter interface {
 	// is a fact about that provider rather than about the code.
 	CanResume() bool
 	Resume(sessionID string, mode agent.PermissionMode) (Launch, error)
+	ResumeNamed(sessionID, name string, mode agent.PermissionMode) (Launch, error)
 	// SessionFromTranscript reads the provider's conversation id out of a
 	// transcript path. The recorded session id is the primary handle —
 	// both providers report it on every lifecycle event — but a record
@@ -64,6 +66,10 @@ type commandAdapter struct {
 	// conversation, not how to reopen one. Like argsFor it keeps the
 	// variable argument last, so extra args slot in the same way for both.
 	resumeFor func(sessionID string, mode agent.PermissionMode) ([]string, error)
+	// nameFor returns provider arguments that apply a human-facing name to
+	// the session. Providers without a launch-time naming surface leave it
+	// nil and may synchronize later through SetSessionName.
+	nameFor func(name string) []string
 	// sessionFor reads the provider's conversation id out of a transcript
 	// path; an empty result means this path names nothing resumable.
 	sessionFor func(transcriptPath string) string
@@ -82,7 +88,15 @@ func (a commandAdapter) Label() string {
 }
 
 func (a commandAdapter) Resolve(prompt string, mode agent.PermissionMode) (Launch, error) {
-	return a.launch(a.argsFor, prompt, mode)
+	return a.ResolveNamed(prompt, "", mode)
+}
+
+func (a commandAdapter) ResolveNamed(
+	prompt string,
+	name string,
+	mode agent.PermissionMode,
+) (Launch, error) {
+	return a.launch(a.argsFor, prompt, name, mode)
 }
 
 func (a commandAdapter) CanResume() bool {
@@ -93,10 +107,18 @@ func (a commandAdapter) Resume(
 	sessionID string,
 	mode agent.PermissionMode,
 ) (Launch, error) {
+	return a.ResumeNamed(sessionID, "", mode)
+}
+
+func (a commandAdapter) ResumeNamed(
+	sessionID string,
+	name string,
+	mode agent.PermissionMode,
+) (Launch, error) {
 	if !a.CanResume() {
 		return Launch{}, fmt.Errorf("%s cannot resume a conversation", a.label)
 	}
-	return a.launch(a.resumeFor, sessionID, mode)
+	return a.launch(a.resumeFor, sessionID, name, mode)
 }
 
 func (a commandAdapter) SessionFromTranscript(transcriptPath string) string {
@@ -109,6 +131,7 @@ func (a commandAdapter) SessionFromTranscript(transcriptPath string) string {
 func (a commandAdapter) launch(
 	build func(string, agent.PermissionMode) ([]string, error),
 	value string,
+	name string,
 	mode agent.PermissionMode,
 ) (Launch, error) {
 	path, err := exec.LookPath(a.binary)
@@ -119,7 +142,24 @@ func (a commandAdapter) launch(
 	if err != nil {
 		return Launch{}, err
 	}
+	args = a.withName(args, name)
 	return Launch{Path: path, Program: a.binary, Args: a.withExtra(args)}, nil
+}
+
+// withName slots launch-time naming flags before the prompt or resume id.
+// The final argument is deliberately kept final for the same reason as
+// withExtra: it is the one variable value both launch forms share.
+func (a commandAdapter) withName(args []string, name string) []string {
+	if a.nameFor == nil || len(args) == 0 {
+		return args
+	}
+	nameArgs := a.nameFor(name)
+	if len(nameArgs) == 0 {
+		return args
+	}
+	combined := slices.Clone(args[:len(args)-1])
+	combined = append(combined, nameArgs...)
+	return append(combined, args[len(args)-1])
 }
 
 // withExtra slots the user's extra args in just before the final argument.
@@ -177,6 +217,7 @@ func NewRegistryWithSpecs(specs []Spec) *Registry {
 			binary:     "claude",
 			argsFor:    claudeArgs,
 			resumeFor:  claudeResumeArgs,
+			nameFor:    claudeNameArgs,
 			sessionFor: claudeSessionID,
 		},
 	}
@@ -252,6 +293,17 @@ func (r *Registry) Resolve(
 	prompt string,
 	mode agent.PermissionMode,
 ) (Launch, error) {
+	return r.ResolveNamed(id, prompt, "", mode)
+}
+
+// ResolveNamed builds a fresh launch and applies a provider-native session
+// name when the provider exposes one at startup.
+func (r *Registry) ResolveNamed(
+	id agent.Provider,
+	prompt string,
+	name string,
+	mode agent.PermissionMode,
+) (Launch, error) {
 	adapter, ok := r.adapters[id]
 	if !ok {
 		return Launch{}, fmt.Errorf("unsupported provider %q", id)
@@ -262,13 +314,24 @@ func (r *Registry) Resolve(
 	if mode == "" {
 		mode = agent.DefaultMode
 	}
-	return adapter.Resolve(prompt, mode)
+	return adapter.ResolveNamed(prompt, name, mode)
 }
 
 // Resume builds the launch that reopens a provider's recorded session.
 func (r *Registry) Resume(
 	id agent.Provider,
 	sessionID string,
+	mode agent.PermissionMode,
+) (Launch, error) {
+	return r.ResumeNamed(id, sessionID, "", mode)
+}
+
+// ResumeNamed reopens a provider session and reapplies its stored name when
+// the provider accepts names on resumed launches.
+func (r *Registry) ResumeNamed(
+	id agent.Provider,
+	sessionID string,
+	name string,
 	mode agent.PermissionMode,
 ) (Launch, error) {
 	adapter, ok := r.adapters[id]
@@ -287,7 +350,7 @@ func (r *Registry) Resume(
 	if mode == "" {
 		mode = agent.DefaultMode
 	}
-	return adapter.Resume(sessionID, mode)
+	return adapter.ResumeNamed(sessionID, name, mode)
 }
 
 // SessionID resolves the conversation id a record holds: the recorded id
@@ -519,6 +582,14 @@ func claudeArgs(prompt string, mode agent.PermissionMode) ([]string, error) {
 		return nil, err
 	}
 	return append(args, prompt), nil
+}
+
+func claudeNameArgs(name string) []string {
+	name = strings.TrimSpace(name)
+	if name == "" {
+		return nil
+	}
+	return []string{"--name", name}
 }
 
 func claudeLifecycleArgs(mode agent.PermissionMode) ([]string, error) {

--- a/internal/provider/provider_test.go
+++ b/internal/provider/provider_test.go
@@ -226,6 +226,69 @@ func TestBuiltinSpecOverridesBinaryAndAppendsExtraArgs(t *testing.T) {
 	}
 }
 
+func TestClaudeNamedLaunchesNameFreshAndResumedSessions(t *testing.T) {
+	registry := NewRegistryWithSpecs([]Spec{{
+		ID:     agent.ProviderClaude,
+		Binary: "echo",
+	}})
+
+	fresh, err := registry.ResolveNamed(
+		agent.ProviderClaude,
+		"do work",
+		"focused fixer",
+		agent.ModeAsk,
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !slices.Equal(
+		fresh.Args[len(fresh.Args)-3:],
+		[]string{"--name", "focused fixer", "do work"},
+	) {
+		t.Fatalf("named Claude launch = %#v", fresh.Args)
+	}
+
+	resumed, err := registry.ResumeNamed(
+		agent.ProviderClaude,
+		"5f2b8c14-0000-4000-8000-000000000001",
+		"focused fixer",
+		agent.ModeAsk,
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !slices.Equal(
+		resumed.Args[len(resumed.Args)-3:],
+		[]string{
+			"--name",
+			"focused fixer",
+			"--resume=5f2b8c14-0000-4000-8000-000000000001",
+		},
+	) {
+		t.Fatalf("named Claude resume = %#v", resumed.Args)
+	}
+}
+
+func TestProvidersWithoutLaunchNamingKeepTheirArguments(t *testing.T) {
+	registry := NewRegistryWithSpecs([]Spec{{
+		ID:     agent.ProviderCodex,
+		Binary: "echo",
+	}})
+	unnamed, err := registry.Resolve(
+		agent.ProviderCodex, "do work", agent.ModeAsk)
+	if err != nil {
+		t.Fatal(err)
+	}
+	named, err := registry.ResolveNamed(
+		agent.ProviderCodex, "do work", "focused fixer", agent.ModeAsk)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !slices.Equal(named.Args, unnamed.Args) {
+		t.Fatalf("Codex was given unsupported launch args: %#v", named.Args)
+	}
+}
+
 // Resume launches must carry the same lifecycle wiring a fresh dispatch
 // gets — a resumed agent that reports nothing would sit on the dashboard
 // exactly like the broken-hooks failure mode the wiring exists to prevent.

--- a/internal/provider/session_name.go
+++ b/internal/provider/session_name.go
@@ -103,12 +103,16 @@ func setCodexSessionName(
 		return err
 	}
 	waited := false
-	defer func() {
-		if !waited {
-			_ = command.Process.Kill()
-			_ = command.Wait()
+	stop := func() {
+		if waited {
+			return
 		}
-	}()
+		_ = stdin.Close()
+		_ = command.Process.Kill()
+		_ = command.Wait()
+		waited = true
+	}
+	defer stop()
 
 	encoder := json.NewEncoder(stdin)
 	decoder := json.NewDecoder(bufio.NewReader(stdout))
@@ -126,6 +130,7 @@ func setCodexSessionName(
 		return err
 	}
 	if err := readRPCResponse(decoder, 1); err != nil {
+		stop()
 		return withCommandError(err, stderr.String())
 	}
 	if err := encoder.Encode(map[string]any{
@@ -144,15 +149,13 @@ func setCodexSessionName(
 		return err
 	}
 	if err := readRPCResponse(decoder, 2); err != nil {
+		stop()
 		return withCommandError(err, stderr.String())
 	}
 	// app-server is a service, not a one-shot command: after initialization
 	// it can remain alive even when stdin closes. The successful response is
 	// the transaction boundary, so terminate the helper and reap it here.
-	_ = stdin.Close()
-	_ = command.Process.Kill()
-	_ = command.Wait()
-	waited = true
+	stop()
 	return nil
 }
 

--- a/internal/provider/session_name.go
+++ b/internal/provider/session_name.go
@@ -1,0 +1,188 @@
+package provider
+
+import (
+	"bufio"
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"os/exec"
+	"strings"
+	"time"
+
+	"github.com/trentkm/stormlight/internal/agent"
+)
+
+// SetSessionName writes a human-facing name through the provider's supported
+// out-of-band API. The bool reports capability: custom providers and providers
+// named entirely through launch arguments return false.
+func (r *Registry) SetSessionName(
+	ctx context.Context,
+	id agent.Provider,
+	sessionID string,
+	name string,
+) (bool, error) {
+	if id != agent.ProviderCodex {
+		return false, nil
+	}
+	adapter, ok := r.adapters[id]
+	if !ok {
+		return false, nil
+	}
+	sessionID = strings.TrimSpace(sessionID)
+	name = strings.TrimSpace(name)
+	if sessionID == "" {
+		return true, fmt.Errorf("session id cannot be empty")
+	}
+	if name == "" {
+		return true, fmt.Errorf("session name cannot be empty")
+	}
+	ctx, cancel := context.WithTimeout(ctx, 5*time.Second)
+	defer cancel()
+	path, err := exec.LookPath(adapter.Binary())
+	if err != nil {
+		return true, fmt.Errorf("%s is not installed or not on PATH", adapter.Binary())
+	}
+	if err := setCodexSessionName(ctx, path, sessionID, name); err != nil {
+		return true, fmt.Errorf("name Codex session: %w", err)
+	}
+	return true, nil
+}
+
+// SessionNameCommand returns the provider-native command that names the
+// currently running session. Codex only updates its TUI's in-memory name
+// through /rename; an app-server write from another process updates the index
+// but leaves exit and resume hints using the UUID.
+func (r *Registry) SessionNameCommand(
+	id agent.Provider,
+	name string,
+) (string, bool, error) {
+	if id != agent.ProviderCodex {
+		return "", false, nil
+	}
+	if _, ok := r.adapters[id]; !ok {
+		return "", false, nil
+	}
+	name = strings.TrimSpace(name)
+	if name == "" {
+		return "", true, fmt.Errorf("session name cannot be empty")
+	}
+	if strings.ContainsAny(name, "\r\n") {
+		return "", true, fmt.Errorf("session name must be one line")
+	}
+	return "/rename " + name, true, nil
+}
+
+type rpcResponse struct {
+	ID    json.RawMessage `json:"id"`
+	Error *struct {
+		Code    int    `json:"code"`
+		Message string `json:"message"`
+	} `json:"error,omitempty"`
+}
+
+func setCodexSessionName(
+	ctx context.Context,
+	binary string,
+	sessionID string,
+	name string,
+) error {
+	command := exec.CommandContext(ctx, binary, "app-server", "--stdio")
+	stdin, err := command.StdinPipe()
+	if err != nil {
+		return err
+	}
+	stdout, err := command.StdoutPipe()
+	if err != nil {
+		return err
+	}
+	var stderr bytes.Buffer
+	command.Stderr = &stderr
+	if err := command.Start(); err != nil {
+		return err
+	}
+	waited := false
+	defer func() {
+		if !waited {
+			_ = command.Process.Kill()
+			_ = command.Wait()
+		}
+	}()
+
+	encoder := json.NewEncoder(stdin)
+	decoder := json.NewDecoder(bufio.NewReader(stdout))
+	if err := encoder.Encode(map[string]any{
+		"method": "initialize",
+		"id":     1,
+		"params": map[string]any{
+			"clientInfo": map[string]string{
+				"name":    "stormlight",
+				"title":   "Stormlight",
+				"version": "unknown",
+			},
+		},
+	}); err != nil {
+		return err
+	}
+	if err := readRPCResponse(decoder, 1); err != nil {
+		return withCommandError(err, stderr.String())
+	}
+	if err := encoder.Encode(map[string]any{
+		"method": "initialized",
+	}); err != nil {
+		return err
+	}
+	if err := encoder.Encode(map[string]any{
+		"method": "thread/name/set",
+		"id":     2,
+		"params": map[string]string{
+			"threadId": sessionID,
+			"name":     name,
+		},
+	}); err != nil {
+		return err
+	}
+	if err := readRPCResponse(decoder, 2); err != nil {
+		return withCommandError(err, stderr.String())
+	}
+	// app-server is a service, not a one-shot command: after initialization
+	// it can remain alive even when stdin closes. The successful response is
+	// the transaction boundary, so terminate the helper and reap it here.
+	_ = stdin.Close()
+	_ = command.Process.Kill()
+	_ = command.Wait()
+	waited = true
+	return nil
+}
+
+func readRPCResponse(decoder *json.Decoder, id int) error {
+	for {
+		var response rpcResponse
+		if err := decoder.Decode(&response); err != nil {
+			if err == io.EOF {
+				return fmt.Errorf("app server closed before response %d", id)
+			}
+			return fmt.Errorf("decode app-server response: %w", err)
+		}
+		if string(response.ID) != fmt.Sprint(id) {
+			continue
+		}
+		if response.Error != nil {
+			return fmt.Errorf(
+				"app-server error %d: %s",
+				response.Error.Code,
+				response.Error.Message,
+			)
+		}
+		return nil
+	}
+}
+
+func withCommandError(err error, stderr string) error {
+	stderr = strings.TrimSpace(stderr)
+	if stderr == "" {
+		return err
+	}
+	return fmt.Errorf("%w: %s", err, stderr)
+}

--- a/internal/provider/session_name_test.go
+++ b/internal/provider/session_name_test.go
@@ -1,0 +1,137 @@
+package provider
+
+import (
+	"context"
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/trentkm/stormlight/internal/agent"
+)
+
+func TestCodexSessionNameUsesAppServerProtocol(t *testing.T) {
+	capture := filepath.Join(t.TempDir(), "request.json")
+	binary := fakeAppServer(t, `
+IFS= read -r initialize
+printf '{"id":1,"result":{}}\n'
+IFS= read -r initialized
+IFS= read -r rename
+printf '%s\n' "$rename" > "$CAPTURE"
+printf '{"id":2,"result":{}}\n'
+while :; do sleep 1; done
+`)
+	t.Setenv("CAPTURE", capture)
+	registry := NewRegistryWithSpecs([]Spec{{
+		ID:     agent.ProviderCodex,
+		Binary: binary,
+	}})
+
+	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+	defer cancel()
+	supported, err := registry.SetSessionName(
+		ctx,
+		agent.ProviderCodex,
+		"3308ff3d-2cbc-47ab-81b1-a8fa28940a14",
+		`focused "fixer"`,
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !supported {
+		t.Fatal("Codex session naming reported unsupported")
+	}
+	encoded, err := os.ReadFile(capture)
+	if err != nil {
+		t.Fatal(err)
+	}
+	var request struct {
+		Method string `json:"method"`
+		ID     int    `json:"id"`
+		Params struct {
+			ThreadID string `json:"threadId"`
+			Name     string `json:"name"`
+		} `json:"params"`
+	}
+	if err := json.Unmarshal(encoded, &request); err != nil {
+		t.Fatalf("decode request %q: %v", encoded, err)
+	}
+	if request.Method != "thread/name/set" || request.ID != 2 ||
+		request.Params.ThreadID != "3308ff3d-2cbc-47ab-81b1-a8fa28940a14" ||
+		request.Params.Name != `focused "fixer"` {
+		t.Fatalf("request = %#v", request)
+	}
+}
+
+func TestCodexLiveSessionNameUsesRenameCommand(t *testing.T) {
+	registry := NewRegistryWithSpecs([]Spec{{
+		ID:     agent.ProviderCodex,
+		Binary: "echo",
+	}})
+
+	command, supported, err := registry.SessionNameCommand(
+		agent.ProviderCodex,
+		"  focused fixer  ",
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !supported || command != "/rename focused fixer" {
+		t.Fatalf("command = %q, supported = %t", command, supported)
+	}
+}
+
+func TestCodexSessionNameReportsAppServerErrors(t *testing.T) {
+	binary := fakeAppServer(t, `
+IFS= read -r initialize
+printf '{"id":1,"result":{}}\n'
+IFS= read -r initialized
+IFS= read -r rename
+printf '{"id":2,"error":{"code":-32602,"message":"thread not found"}}\n'
+`)
+	registry := NewRegistryWithSpecs([]Spec{{
+		ID:     agent.ProviderCodex,
+		Binary: binary,
+	}})
+
+	supported, err := registry.SetSessionName(
+		context.Background(),
+		agent.ProviderCodex,
+		"3308ff3d-2cbc-47ab-81b1-a8fa28940a14",
+		"focused fixer",
+	)
+	if !supported {
+		t.Fatal("Codex session naming reported unsupported")
+	}
+	if err == nil || !strings.Contains(err.Error(), "thread not found") {
+		t.Fatalf("error = %v", err)
+	}
+}
+
+func TestCustomProvidersDoNotClaimSessionNaming(t *testing.T) {
+	registry := NewRegistryWithSpecs([]Spec{{
+		ID:     agent.Provider("other"),
+		Binary: "echo",
+	}})
+	supported, err := registry.SetSessionName(
+		context.Background(),
+		agent.Provider("other"),
+		"session",
+		"name",
+	)
+	if err != nil || supported {
+		t.Fatalf("supported=%v error=%v", supported, err)
+	}
+}
+
+func fakeAppServer(t *testing.T, body string) string {
+	t.Helper()
+	path := filepath.Join(t.TempDir(), "codex")
+	script := "#!/bin/sh\nset -eu\n" + strings.TrimSpace(body) + "\n"
+	if err := os.WriteFile(path, []byte(script), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	return path
+}

--- a/internal/session/runtime.go
+++ b/internal/session/runtime.go
@@ -23,6 +23,13 @@ type Runtime interface {
 	SetWorkspace(context.Context, string, workspace.Context) error
 }
 
+// CommandSender is an optional runtime capability for provider-native control
+// commands. Unlike Send, a control command does not represent a model turn and
+// must not change the agent's activity.
+type CommandSender interface {
+	SendCommand(context.Context, string, string) error
+}
+
 // TerminalStreamer is an optional runtime capability: a runtime whose
 // terminals can be attached to directly — an exact state snapshot followed
 // by the live byte stream, with input and resize flowing back.
@@ -135,6 +142,9 @@ type Update struct {
 	// SessionID records the provider's own conversation id when an event
 	// carries it; empty means "leave as is".
 	SessionID string
+	// SessionName records a provider-side name write; empty means "leave as
+	// is". It is separate from Name, Stormlight's desired display name.
+	SessionName string
 	// TranscriptPath records the provider's own transcript file when a
 	// hook reports it; empty means "leave as is".
 	TranscriptPath string

--- a/internal/windrun/remote_test.go
+++ b/internal/windrun/remote_test.go
@@ -330,7 +330,12 @@ func TestRemoteRosterAndTerminalCrossTheBridge(t *testing.T) {
 		Cwd:      t.TempDir(),
 		Launch: session.Launch{
 			Path: "/bin/sh",
-			Args: []string{"-c", `printf 'ready\n'; read line; printf 'heard:%s\n' "$line"; sleep 60`},
+			Args: []string{"-c", `printf 'ready\n'
+read line
+printf 'heard:%s\n' "$line"
+read command
+printf 'command:%s\n' "$command"
+sleep 60`},
 		},
 	})
 	if err != nil {
@@ -355,6 +360,29 @@ func TestRemoteRosterAndTerminalCrossTheBridge(t *testing.T) {
 		t.Fatalf("Send: %v", err)
 	}
 	waitForScreen(t, runtime, dispatched.ID, "heard:over the bridge")
+
+	if err := runtime.Update(
+		context.Background(),
+		dispatched.ID,
+		session.Update{Activity: agent.ActivityIdle},
+	); err != nil {
+		t.Fatalf("set idle: %v", err)
+	}
+	if err := runtime.SendCommand(
+		context.Background(),
+		dispatched.ID,
+		"/rename listener",
+	); err != nil {
+		t.Fatalf("SendCommand: %v", err)
+	}
+	waitForScreen(t, runtime, dispatched.ID, "command:/rename listener")
+	agents, err = runtime.ListAgents(context.Background())
+	if err != nil {
+		t.Fatalf("ListAgents after command: %v", err)
+	}
+	if agents[0].Activity != agent.ActivityIdle {
+		t.Fatalf("control command changed activity: %+v", agents[0])
+	}
 
 	// An attachment is its own connection through the tunnel, and its
 	// seed is the exact state rather than a re-render.

--- a/internal/windrun/runtime.go
+++ b/internal/windrun/runtime.go
@@ -450,6 +450,24 @@ func (r *Runtime) Attach(ctx context.Context, id string) (session.AttachResult, 
 }
 
 func (r *Runtime) Send(ctx context.Context, id, message string) error {
+	if err := r.sendInput(id, message); err != nil {
+		return err
+	}
+	return r.Update(ctx, id, session.Update{Activity: agent.ActivityWorking})
+}
+
+// SendCommand types a provider-native slash command without claiming that a
+// model turn started. Codex processes /rename inside the live TUI, which is
+// the only path that updates both its persisted index and its exit hint.
+func (r *Runtime) SendCommand(_ context.Context, id, command string) error {
+	command = strings.TrimSpace(command)
+	if !strings.HasPrefix(command, "/") || strings.Contains(command, "\n") {
+		return fmt.Errorf("provider command must be a single-line slash command")
+	}
+	return r.sendInput(id, command)
+}
+
+func (r *Runtime) sendInput(id, message string) error {
 	sessionID, err := r.sessionIDFor(id)
 	if err != nil {
 		return err
@@ -472,7 +490,7 @@ func (r *Runtime) Send(ctx context.Context, id, message string) error {
 	if err := r.client.Input(sessionID, []byte("\r")); err != nil {
 		return err
 	}
-	return r.Update(ctx, id, session.Update{Activity: agent.ActivityWorking})
+	return nil
 }
 
 func (r *Runtime) Interrupt(ctx context.Context, id string) error {

--- a/internal/windrun/update.go
+++ b/internal/windrun/update.go
@@ -28,6 +28,9 @@ func applyUpdate(managedAgent agent.Agent, update session.Update) agent.Agent {
 	if update.SessionID != "" {
 		managedAgent.SessionID = update.SessionID
 	}
+	if update.SessionName != "" {
+		managedAgent.SessionName = update.SessionName
+	}
 	if update.TranscriptPath != "" {
 		managedAgent.TranscriptPath = update.TranscriptPath
 	}

--- a/internal/windrun/update_test.go
+++ b/internal/windrun/update_test.go
@@ -1,0 +1,22 @@
+package windrun
+
+import (
+	"testing"
+
+	"github.com/trentkm/stormlight/internal/agent"
+	"github.com/trentkm/stormlight/internal/session"
+)
+
+func TestApplyUpdateRecordsProviderSessionName(t *testing.T) {
+	managedAgent := agent.Agent{
+		Name:        "focused fixer",
+		SessionName: "old name",
+	}
+	updated := applyUpdate(
+		managedAgent,
+		session.Update{SessionName: "focused fixer"},
+	)
+	if updated.SessionName != "focused fixer" {
+		t.Fatalf("session name = %q", updated.SessionName)
+	}
+}

--- a/main.go
+++ b/main.go
@@ -1580,6 +1580,14 @@ func newProviderEventCommand(cfg config.Config) *cobra.Command {
 					"agent", id,
 					"error", err,
 				)
+				return nil
+			}
+			if err := service.SyncSessionName(ctx, id); err != nil {
+				diagnostic.Logger().Warn("sync provider session name",
+					"provider", providerID,
+					"agent", id,
+					"error", err,
+				)
 			}
 			return nil
 		},


### PR DESCRIPTION
## Summary

- pass Stormlight agent names to Claude Code via `--name`
- rename live Codex sessions through `/rename` and completed sessions through app-server `thread/name/set`
- route provider naming commands through the session runtime and avoid duplicate writes
- document provider session naming behavior

Fixes #210

## Validation

- `go test ./...`
- `go vet ./...`
- `go build -o stormlight .`
- isolated Codex end-to-end run confirmed the exit hint resolves by `test-session-name3`