### PR TITLE
Stormlight signs itself with a storm, and marks what is elsewhere

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,11 +71,12 @@ workspace it left, with everything it had already said and done.
 
 - `yazi` for the directory picker (installed automatically by the Homebrew
   cask). Optional: `nvim` for task editing.
-- A [Nerd Font](https://www.nerdfonts.com) if you keep workspaces on other
-  machines. Their rows lead with a cloud, which is a Private Use Area
-  codepoint and renders as an empty box in a font that does not carry one.
-  Nothing else the dashboard draws needs it; the rest is ordinary Unicode,
-  and a workspace on this machine looks the same either way.
+- A [Nerd Font](https://www.nerdfonts.com). The wordmark opens with a
+  storm, and a workspace on another machine leads its row with a cloud.
+  Both are Private Use Area codepoints, so a font without them draws empty
+  boxes — and nothing can ask a terminal whether it has them, which is why
+  this is a requirement rather than something the dashboard can detect and
+  work around. The rest of what it draws is ordinary Unicode.
 
 ## Install
 

--- a/README.md
+++ b/README.md
@@ -79,6 +79,14 @@ workspace it left, with everything it had already said and done.
   them: this is a requirement rather than something the dashboard can
   detect and work around. The rest of what it draws is ordinary Unicode.
 
+  Which variant you install decides how large those two marks look, and
+  Stormlight has no say in it — a terminal glyph is the size the font drew
+  it. The `Mono` variants squeeze every glyph into a single cell; the plain
+  ones draw the same codepoint at close to twice the size and let it
+  overhang into the next column, which is roomy in the header and crowded
+  beside a workspace name. Either works: the marks are one column wide to
+  everything that measures them, whichever variant is painting.
+
 ## Install
 
 ```bash

--- a/README.md
+++ b/README.md
@@ -71,6 +71,11 @@ workspace it left, with everything it had already said and done.
 
 - `yazi` for the directory picker (installed automatically by the Homebrew
   cask). Optional: `nvim` for task editing.
+- A [Nerd Font](https://www.nerdfonts.com) if you keep workspaces on other
+  machines. Their rows lead with a cloud, which is a Private Use Area
+  codepoint and renders as an empty box in a font that does not carry one.
+  Nothing else the dashboard draws needs it; the rest is ordinary Unicode,
+  and a workspace on this machine looks the same either way.
 
 ## Install
 

--- a/README.md
+++ b/README.md
@@ -71,12 +71,13 @@ workspace it left, with everything it had already said and done.
 
 - `yazi` for the directory picker (installed automatically by the Homebrew
   cask). Optional: `nvim` for task editing.
-- A [Nerd Font](https://www.nerdfonts.com). The wordmark opens with a
-  storm, and a workspace on another machine leads its row with a cloud.
-  Both are Private Use Area codepoints, so a font without them draws empty
-  boxes — and nothing can ask a terminal whether it has them, which is why
-  this is a requirement rather than something the dashboard can detect and
-  work around. The rest of what it draws is ordinary Unicode.
+- A [Nerd Font](https://www.nerdfonts.com). Stormlight signs itself with a
+  storm — opening the wordmark, capping the hint row, and leading the line
+  it prints on the way out — and a workspace on another machine leads its
+  row with a cloud. Both are Private Use Area codepoints, so a font without
+  them draws empty boxes, and nothing can ask a terminal whether it has
+  them: this is a requirement rather than something the dashboard can
+  detect and work around. The rest of what it draws is ordinary Unicode.
 
 ## Install
 

--- a/README.md
+++ b/README.md
@@ -73,8 +73,8 @@ workspace it left, with everything it had already said and done.
   cask). Optional: `nvim` for task editing.
 - A [Nerd Font](https://www.nerdfonts.com). Stormlight signs itself with a
   storm — opening the wordmark, capping the hint row, and leading the line
-  it prints on the way out — and a workspace on another machine leads its
-  row with a cloud. Both are Private Use Area codepoints, so a font without
+  it prints on the way out — and a workspace on another machine is marked
+  with a windblown cloud, in the column before its counts. Both are Private Use Area codepoints, so a font without
   them draws empty boxes, and nothing can ask a terminal whether it has
   them: this is a requirement rather than something the dashboard can
   detect and work around. The rest of what it draws is ordinary Unicode.

--- a/internal/ui/chrome.go
+++ b/internal/ui/chrome.go
@@ -45,13 +45,13 @@ func (m Model) renderFooter() string {
 			Light: wordmarkStopsLight[1],
 			Dark:  wordmarkStopsDark[1],
 		}))
-	row := " " + glintStyle.Render("✦ ") + content
+	row := " " + glintStyle.Render(StormGlyph+" ") + content
 	if rightAligned {
 		// A true mirror of the left layout: the hints lead and the glint
 		// caps the row at the outermost position, one column in.
 		if pad := inner - lipgloss.Width(content); pad > 0 {
 			row = strings.Repeat(" ", pad) + content +
-				glintStyle.Render(" ✦") + " "
+				glintStyle.Render(" "+StormGlyph) + " "
 		}
 	}
 	return lipgloss.NewStyle().Width(width).MaxHeight(2).Render(

--- a/internal/ui/input_test.go
+++ b/internal/ui/input_test.go
@@ -2743,3 +2743,34 @@ func TestTheFooterIsCappedByTheStorm(t *testing.T) {
 		t.Errorf("the mark stayed on the left as well: %q", row)
 	}
 }
+
+// TestTheFrameStandsOffTheWall: the mark opens the header and caps the
+// footer, and both stand one column in. The header's sat flush against the
+// terminal's left edge — the only ink on screen touching it, with the
+// whole dashboard indented behind it, so the mark read as clipped rather
+// than placed.
+func TestTheFrameStandsOffTheWall(t *testing.T) {
+	model := flowModelFixture(t, &flowBackend{})
+	lines := strings.Split(ansi.Strip(model.View().Content), "\n")
+
+	marked := []int{}
+	for index, line := range lines {
+		if strings.Contains(line, StormGlyph) {
+			marked = append(marked, index)
+		}
+	}
+	if len(marked) != 2 {
+		t.Fatalf("the frame carries %d marks, want the header's and the "+
+			"footer's", len(marked))
+	}
+	for _, index := range marked {
+		line := lines[index]
+		// Columns, not bytes: the mark is multi-byte and what is being
+		// asked is where it lands on screen.
+		column := ansi.StringWidth(line[:strings.Index(line, StormGlyph)])
+		if column != 1 {
+			t.Errorf("line %d puts the mark in column %d, want 1: %q",
+				index, column, line[:min(24, len(line))])
+		}
+	}
+}

--- a/internal/ui/input_test.go
+++ b/internal/ui/input_test.go
@@ -2686,3 +2686,30 @@ func runeIndex(runes []rune, want rune) int {
 	}
 	return -1
 }
+
+// TestTheWordmarkOpensWithTheStorm: the header is the dashboard's identity
+// line, and the mark in front of the name is part of the name. It is also
+// the one glyph every run draws whether or not anything is happening, so a
+// change to it is a change every user sees on every launch — worth a test
+// that says which glyph, rather than one that says "some glyph".
+func TestTheWordmarkOpensWithTheStorm(t *testing.T) {
+	// Both ends of the shimmer: at rest, and with the band mid-sweep.
+	for _, phase := range []int{-1, 0, 4, 12} {
+		wordmark := ansi.Strip(renderWordmark(phase))
+		if !strings.HasPrefix(wordmark, wordmarkGlyph+" ") {
+			t.Errorf("phase=%d: wordmark = %q, want it to open with %q",
+				phase, wordmark, wordmarkGlyph)
+		}
+		if !strings.HasSuffix(wordmark, stormlightTitle) {
+			t.Errorf("phase=%d: wordmark = %q, want it to end in the name",
+				phase, wordmark)
+		}
+		// The glyph is one cell, so the header's gap arithmetic — which
+		// measures the wordmark to place the counters — is unchanged by it.
+		if got, want := ansi.StringWidth(wordmark),
+			len(stormlightTitle)+2; got != want {
+			t.Errorf("phase=%d: wordmark is %d columns, want %d: %q",
+				phase, got, want, wordmark)
+		}
+	}
+}

--- a/internal/ui/input_test.go
+++ b/internal/ui/input_test.go
@@ -2696,9 +2696,9 @@ func TestTheWordmarkOpensWithTheStorm(t *testing.T) {
 	// Both ends of the shimmer: at rest, and with the band mid-sweep.
 	for _, phase := range []int{-1, 0, 4, 12} {
 		wordmark := ansi.Strip(renderWordmark(phase))
-		if !strings.HasPrefix(wordmark, wordmarkGlyph+" ") {
+		if !strings.HasPrefix(wordmark, StormGlyph+" ") {
 			t.Errorf("phase=%d: wordmark = %q, want it to open with %q",
-				phase, wordmark, wordmarkGlyph)
+				phase, wordmark, StormGlyph)
 		}
 		if !strings.HasSuffix(wordmark, stormlightTitle) {
 			t.Errorf("phase=%d: wordmark = %q, want it to end in the name",
@@ -2711,5 +2711,35 @@ func TestTheWordmarkOpensWithTheStorm(t *testing.T) {
 			t.Errorf("phase=%d: wordmark is %d columns, want %d: %q",
 				phase, got, want, wordmark)
 		}
+	}
+}
+
+// TestTheFooterIsCappedByTheStorm: the header opens with the mark and the
+// footer closes with it, in the same sky stop — the frame signs both ends
+// or neither. The cap also swaps sides with the seam, so both layouts are
+// worth pinning: a mark that only survives one of them is a mark that
+// disappears when someone walks into a terminal.
+func TestTheFooterIsCappedByTheStorm(t *testing.T) {
+	model := NewModel(stubBackend{})
+	model.width = 100
+
+	left := ansi.Strip(model.renderFooter())
+	row := lastLine(left)
+	if !strings.HasPrefix(row, " "+StormGlyph+" ") {
+		t.Errorf("the hint row does not lead with the mark: %q", row)
+	}
+
+	// Walked in: the hints lead and the mark caps the far end instead.
+	model.ptyEnabled = true
+	model.activePane = paneInteraction
+	if !model.terminalFocused() {
+		t.Fatal("the terminal did not take focus; the mirrored footer is untested")
+	}
+	row = lastLine(ansi.Strip(model.renderFooter()))
+	if !strings.HasSuffix(strings.TrimRight(row, " "), StormGlyph) {
+		t.Errorf("the mirrored row does not end with the mark: %q", row)
+	}
+	if strings.HasPrefix(row, " "+StormGlyph) {
+		t.Errorf("the mark stayed on the left as well: %q", row)
 	}
 }

--- a/internal/ui/layout.go
+++ b/internal/ui/layout.go
@@ -20,7 +20,13 @@ func (m Model) renderHeader() string {
 	stats := agent.Count(m.agents)
 	// No chrome: the wordmark's own gradient is the identity, floating on
 	// the terminal background with the counters at the far edge.
-	left := renderWordmark(m.shimmerPhaseOrRest())
+	//
+	// It stands one column off the left wall, which is where the footer's
+	// own mark stands and where the panes between them begin. Flush against
+	// the edge the mark read as clipped rather than placed — the only ink
+	// on screen touching the terminal's border, with the whole dashboard
+	// indented behind it.
+	left := " " + renderWordmark(m.shimmerPhaseOrRest())
 	// The counters speak the rows' own language: same glyphs, same colors as
 	// statusVisual paints down the agent list, so the header doubles as the
 	// legend for everything below it.

--- a/internal/ui/machine_test.go
+++ b/internal/ui/machine_test.go
@@ -451,21 +451,24 @@ func TestTwoMachinesSameNameStillCollide(t *testing.T) {
 	}
 }
 
-// TestARemoteWorkspaceRowLeadsWithTheCloud: a row is read left to right,
-// and the first thing worth knowing about a workspace on another machine
-// is that it is on another machine. The initial answered that only after
-// the eye had crossed the name to reach the counts, which is the wrong end
-// of the row for the question asked first.
-func TestARemoteWorkspaceRowLeadsWithTheCloud(t *testing.T) {
+// TestARemoteWorkspaceRowIsMarkedBesideItsCounts: a workspace on another
+// machine is marked, and the mark sits with the counts rather than ahead
+// of the name. Ahead of the name it was the only thing on the pane
+// starting in that column, with every name indented behind it.
+//
+// The host's initial used to hold this column. It said more — which
+// machine, not merely another one — and it still says it in the expanded
+// row's subtitle, which is the place a machine is worth naming in full.
+func TestARemoteWorkspaceRowIsMarkedBesideItsCounts(t *testing.T) {
 	groups := buildWorkspaceGroups([]workspace.Context{
 		{ID: "git:/srv/api/.git", Kind: "git", Name: "here", Root: "/srv/api"},
+		// A host whose initial appears nowhere in the row's own text, so
+		// a leftover letter mark has nothing to hide behind.
 		{Host: "devbox", ID: "devbox:git:/opt/api/.git", Kind: "git",
 			Name: "there", Root: "/opt/api"},
 	}, nil)
 	model := Model{}
 
-	// Both paths paint the marks, and they paint them in the same columns:
-	// a row must not shift sideways when the cursor lands on it.
 	for _, focused := range []bool{false, true} {
 		local := ansi.Strip(
 			model.renderWorkspaceRow(groups[0], focused, focused, 30, false))
@@ -473,39 +476,55 @@ func TestARemoteWorkspaceRowLeadsWithTheCloud(t *testing.T) {
 			model.renderWorkspaceRow(groups[1], focused, focused, 30, false))
 
 		if strings.Contains(local, remoteGlyph) {
-			t.Errorf("focused=%v: a workspace on this machine is clouded: %q",
+			t.Errorf("focused=%v: a workspace on this machine is marked: %q",
 				focused, local)
 		}
-		cloud := strings.Index(remote, remoteGlyph)
-		if cloud < 0 {
-			t.Fatalf("focused=%v: no cloud on a remote workspace: %q",
+		glyph := strings.Index(remote, remoteGlyph)
+		if glyph < 0 {
+			t.Fatalf("focused=%v: no mark on a remote workspace: %q",
 				focused, remote)
 		}
-		// Nothing but the row's own furniture stands before it.
-		if lead := strings.TrimLeft(remote[:cloud], " ▌▏"); lead != "" {
-			t.Errorf("focused=%v: %q sits before the cloud: %q",
-				focused, lead, remote)
+		name := strings.Index(remote, "there")
+		if glyph < name {
+			t.Errorf("focused=%v: the mark leads the row: %q", focused, remote)
 		}
-		if name := strings.Index(remote, "there"); cloud > name {
-			t.Errorf("focused=%v: the cloud follows the name: %q",
-				focused, remote)
+		// Nothing but the gap stands between the name and the mark, and
+		// the counts follow it immediately: the mark belongs to that
+		// cluster, not to the name it is separated from.
+		between := remote[name+len("there") : glyph]
+		if strings.TrimLeft(between, " ") != "" {
+			t.Errorf("focused=%v: %q sits between the name and the mark: %q",
+				focused, between, remote)
 		}
-		// And the initial still answers which machine, where it always did.
-		if mark := strings.Index(remote, "D"); mark < 0 || mark < cloud {
-			t.Errorf("focused=%v: the host initial left the counts: %q",
+		if !strings.HasPrefix(remote[glyph:], remoteGlyph+" ·") {
+			t.Errorf("focused=%v: the counts do not follow the mark: %q",
+				focused, remote[glyph:])
+		}
+		// And the letter is gone rather than joined.
+		if strings.Contains(remote, "D") {
+			t.Errorf("focused=%v: the host initial is still marked: %q",
 				focused, remote)
 		}
 	}
+
+	// Dropping the letter is only affordable because the machine is named
+	// in full a line below, so that line is part of this behaviour rather
+	// than a neighbour of it.
+	expanded := model
+	expanded.rowsExpanded = true
+	row := ansi.Strip(expanded.renderWorkspaceRow(groups[1], false, false, 30, false))
+	if !strings.Contains(row, "devbox") {
+		t.Errorf("the expanded row does not name the machine: %q", row)
+	}
 }
 
-// TestARemoteWorkspaceRowSpendsItsMarksOutOfTheChips: the cloud and the
-// initial are four columns, and something has to pay for them. The chips
-// pay — they are fitted after both marks are spent, so a quiet tier drops
-// off the right rather than the name losing half its letters. Fitted
-// before, against the width a local row has, a twenty-two column pane
-// showed "there…" beside two chips where it should show "there-is-a…"
-// beside one.
-func TestARemoteWorkspaceRowSpendsItsMarksOutOfTheChips(t *testing.T) {
+// TestARemoteWorkspaceRowSpendsItsMarkOutOfTheChips: the mark is two
+// columns, and something has to pay for them. The chips pay — they are
+// fitted after the mark is spent, so a quiet tier drops off the right
+// rather than the name losing letters. Fitted before, against the width a
+// local row has, a twenty-two column pane showed "there…" beside two chips
+// where it should show "there-is-a…" beside one.
+func TestARemoteWorkspaceRowSpendsItsMarkOutOfTheChips(t *testing.T) {
 	// A name of one repeated letter so the name's columns can be counted
 	// out of the rendered row.
 	name := strings.Repeat("a", 20)
@@ -541,9 +560,14 @@ func TestARemoteWorkspaceRowSpendsItsMarksOutOfTheChips(t *testing.T) {
 }
 
 // TestARemoteWorkspaceRowStillFitsItsPane: name and gap both bottom out at
-// one column, so a pane narrow enough drives the row past its own width —
-// and a row wider than the pane wraps, which costs the list a line and
-// every row below it its place.
+// one column, so the row's fixed furniture — gutter, mark, the loudest
+// chip — is what decides the narrowest pane it can be drawn in. A row
+// wider than its pane wraps, which costs the list a line and every row
+// below it its place.
+//
+// From eleven: below that the mark and the chip alone are wider than the
+// pane, and the row has overhung by a column or two for as long as
+// anything has marked a remote workspace at all.
 func TestARemoteWorkspaceRowStillFitsItsPane(t *testing.T) {
 	remote := workspace.Context{
 		Host: "devbox", ID: "devbox:git:/opt/api/.git", Kind: "git",
@@ -562,11 +586,6 @@ func TestARemoteWorkspaceRowStillFitsItsPane(t *testing.T) {
 			Activity: agent.ActivityWorking},
 	})
 	model := Model{}
-	// From eleven: below that the mark and the loudest chip alone are wider
-	// than the pane, and the row has overhung by a column or two since long
-	// before there was a cloud on it. What is pinned here is that the cloud
-	// never adds to that — it is given up first, and every width that fit
-	// before still fits.
 	for _, width := range []int{11, 12, 14, 18, 20, 24, 28, 34, 44} {
 		for _, focused := range []bool{false, true} {
 			row := model.renderWorkspaceRow(
@@ -576,22 +595,6 @@ func TestARemoteWorkspaceRowStillFitsItsPane(t *testing.T) {
 					t.Errorf("width=%d focused=%v: row is %d columns: %q",
 						width, focused, got, ansi.Strip(line))
 				}
-			}
-		}
-	}
-	// And below it the cloud is the thing given up, so a pane that already
-	// had nothing to spare is not asked for two columns more.
-	for _, width := range []int{6, 8, 10} {
-		for _, focused := range []bool{false, true} {
-			row := ansi.Strip(model.renderWorkspaceRow(
-				groups[0], focused, focused, width, false))
-			if strings.Contains(row, remoteGlyph) {
-				t.Errorf("width=%d focused=%v: clouded a row with no room "+
-					"for it: %q", width, focused, row)
-			}
-			if !strings.Contains(row, "D") {
-				t.Errorf("width=%d focused=%v: the mark that names the "+
-					"machine went first: %q", width, focused, row)
 			}
 		}
 	}

--- a/internal/ui/machine_test.go
+++ b/internal/ui/machine_test.go
@@ -6,6 +6,7 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/charmbracelet/x/ansi"
 	"github.com/trentkm/stormlight/internal/agent"
 	"github.com/trentkm/stormlight/internal/workspace"
 )
@@ -447,5 +448,151 @@ func TestTwoMachinesSameNameStillCollide(t *testing.T) {
 	}
 	if groups[0].label != "srv/api" || groups[1].label != "opt/api" {
 		t.Fatalf("labels = %q, %q", groups[0].label, groups[1].label)
+	}
+}
+
+// TestARemoteWorkspaceRowLeadsWithTheCloud: a row is read left to right,
+// and the first thing worth knowing about a workspace on another machine
+// is that it is on another machine. The initial answered that only after
+// the eye had crossed the name to reach the counts, which is the wrong end
+// of the row for the question asked first.
+func TestARemoteWorkspaceRowLeadsWithTheCloud(t *testing.T) {
+	groups := buildWorkspaceGroups([]workspace.Context{
+		{ID: "git:/srv/api/.git", Kind: "git", Name: "here", Root: "/srv/api"},
+		{Host: "devbox", ID: "devbox:git:/opt/api/.git", Kind: "git",
+			Name: "there", Root: "/opt/api"},
+	}, nil)
+	model := Model{}
+
+	// Both paths paint the marks, and they paint them in the same columns:
+	// a row must not shift sideways when the cursor lands on it.
+	for _, focused := range []bool{false, true} {
+		local := ansi.Strip(
+			model.renderWorkspaceRow(groups[0], focused, focused, 30, false))
+		remote := ansi.Strip(
+			model.renderWorkspaceRow(groups[1], focused, focused, 30, false))
+
+		if strings.Contains(local, remoteGlyph) {
+			t.Errorf("focused=%v: a workspace on this machine is clouded: %q",
+				focused, local)
+		}
+		cloud := strings.Index(remote, remoteGlyph)
+		if cloud < 0 {
+			t.Fatalf("focused=%v: no cloud on a remote workspace: %q",
+				focused, remote)
+		}
+		// Nothing but the row's own furniture stands before it.
+		if lead := strings.TrimLeft(remote[:cloud], " ▌▏"); lead != "" {
+			t.Errorf("focused=%v: %q sits before the cloud: %q",
+				focused, lead, remote)
+		}
+		if name := strings.Index(remote, "there"); cloud > name {
+			t.Errorf("focused=%v: the cloud follows the name: %q",
+				focused, remote)
+		}
+		// And the initial still answers which machine, where it always did.
+		if mark := strings.Index(remote, "D"); mark < 0 || mark < cloud {
+			t.Errorf("focused=%v: the host initial left the counts: %q",
+				focused, remote)
+		}
+	}
+}
+
+// TestARemoteWorkspaceRowSpendsItsMarksOutOfTheChips: the cloud and the
+// initial are four columns, and something has to pay for them. The chips
+// pay — they are fitted after both marks are spent, so a quiet tier drops
+// off the right rather than the name losing half its letters. Fitted
+// before, against the width a local row has, a twenty-two column pane
+// showed "there…" beside two chips where it should show "there-is-a…"
+// beside one.
+func TestARemoteWorkspaceRowSpendsItsMarksOutOfTheChips(t *testing.T) {
+	// A name of one repeated letter so the name's columns can be counted
+	// out of the rendered row.
+	name := strings.Repeat("a", 20)
+	remote := workspace.Context{
+		Host: "devbox", ID: "devbox:git:/opt/api/.git", Kind: "git",
+		Name: name, Root: "/opt/api", ExecutionRoot: "/opt/api",
+	}
+	// Three tiers of population, so the chips ask for everything they can.
+	groups := buildWorkspaceGroups([]workspace.Context{remote}, []agent.Agent{
+		{ID: "a", Host: "devbox", Workspace: remote, ProcessLive: true,
+			Attention: agent.AttentionApproval},
+		{ID: "b", Host: "devbox", Workspace: remote, ProcessLive: true,
+			Attention: agent.AttentionWaiting},
+		{ID: "c", Host: "devbox", Workspace: remote, ProcessLive: true,
+			Activity: agent.ActivityWorking},
+	})
+	model := Model{}
+	for _, width := range []int{22, 24, 26, 28, 34} {
+		line := strings.Split(ansi.Strip(
+			model.renderWorkspaceRow(groups[0], false, false, width, false)), "\n")[0]
+		// What the row promised the name: the same floor fitCountChips
+		// fits the chips around.
+		contentWidth := max(1, width-1)
+		nameNeed := min(10, max(1, contentWidth/2))
+		// The ellipsis is one of the name's own columns, not a column
+		// taken from it.
+		got := strings.Count(line, "a") + strings.Count(line, "…")
+		if got < nameNeed {
+			t.Errorf("width=%d: the name kept %d columns, wanted %d: %q",
+				width, got, nameNeed, line)
+		}
+	}
+}
+
+// TestARemoteWorkspaceRowStillFitsItsPane: name and gap both bottom out at
+// one column, so a pane narrow enough drives the row past its own width —
+// and a row wider than the pane wraps, which costs the list a line and
+// every row below it its place.
+func TestARemoteWorkspaceRowStillFitsItsPane(t *testing.T) {
+	remote := workspace.Context{
+		Host: "devbox", ID: "devbox:git:/opt/api/.git", Kind: "git",
+		// Long enough that the name is what the row's remaining columns
+		// are spent on: a short name never reaches the width it was
+		// given, so it never proves the width was computed right.
+		Name: strings.Repeat("a", 40), Root: "/opt/api",
+		ExecutionRoot: "/opt/api",
+	}
+	groups := buildWorkspaceGroups([]workspace.Context{remote}, []agent.Agent{
+		{ID: "a", Host: "devbox", Workspace: remote, ProcessLive: true,
+			Attention: agent.AttentionApproval},
+		{ID: "b", Host: "devbox", Workspace: remote, ProcessLive: true,
+			Attention: agent.AttentionWaiting},
+		{ID: "c", Host: "devbox", Workspace: remote, ProcessLive: true,
+			Activity: agent.ActivityWorking},
+	})
+	model := Model{}
+	// From eleven: below that the mark and the loudest chip alone are wider
+	// than the pane, and the row has overhung by a column or two since long
+	// before there was a cloud on it. What is pinned here is that the cloud
+	// never adds to that — it is given up first, and every width that fit
+	// before still fits.
+	for _, width := range []int{11, 12, 14, 18, 20, 24, 28, 34, 44} {
+		for _, focused := range []bool{false, true} {
+			row := model.renderWorkspaceRow(
+				groups[0], focused, focused, width, false)
+			for _, line := range strings.Split(row, "\n") {
+				if got := ansi.StringWidth(line); got > width {
+					t.Errorf("width=%d focused=%v: row is %d columns: %q",
+						width, focused, got, ansi.Strip(line))
+				}
+			}
+		}
+	}
+	// And below it the cloud is the thing given up, so a pane that already
+	// had nothing to spare is not asked for two columns more.
+	for _, width := range []int{6, 8, 10} {
+		for _, focused := range []bool{false, true} {
+			row := ansi.Strip(model.renderWorkspaceRow(
+				groups[0], focused, focused, width, false))
+			if strings.Contains(row, remoteGlyph) {
+				t.Errorf("width=%d focused=%v: clouded a row with no room "+
+					"for it: %q", width, focused, row)
+			}
+			if !strings.Contains(row, "D") {
+				t.Errorf("width=%d focused=%v: the mark that names the "+
+					"machine went first: %q", width, focused, row)
+			}
+		}
 	}
 }

--- a/internal/ui/styles.go
+++ b/internal/ui/styles.go
@@ -79,22 +79,26 @@ func successStyle() lipgloss.Style {
 // indicator for the header, workspace names, and agent titles.
 const stormlightTitle = "Stormlight"
 
-// wordmarkGlyph opens the wordmark: Nerd Font U+E364,
-// nf-weather-night_alt_sleet_storm. The mark before the name now says the
-// name — a storm, where a four-pointed star said only "something bright".
+// StormGlyph is Stormlight's mark: Nerd Font U+E364,
+// nf-weather-night_alt_sleet_storm. It opens the wordmark, caps the
+// footer, and leads the oath printed on the way out — every place the
+// program signs its own name. A four-pointed star stood here before, and
+// said only "something bright".
 //
-// It is a Private Use Area codepoint, which is a harder bargain here than
-// anywhere else in the dashboard: the header is the first thing drawn and
-// the last thing a user would think to blame, so in a terminal without a
+// Exported for that last one: the farewell is printed by main after the
+// dashboard is gone, and one mark spelled in two places is one that drifts.
+//
+// It is a Private Use Area codepoint, which is a harder bargain than the
+// rest of the dashboard drives. The header is the first thing painted and
+// the last thing anyone would think to blame, so in a terminal without a
 // Nerd Font the identity line opens with an empty box. Nothing can ask a
 // terminal whether it has the glyph, so this is a requirement rather than
-// a degradation, and README says so.
+// something to detect and work around, and README says so.
 //
-// The footer keeps its ✦ (see renderFooter). The two marks share the
-// wordmark's sky stop and read as one family, but only this one stands in
-// for the name; the footer's is a cap on a row of hints, and it still
-// draws in every font.
-const wordmarkGlyph = "\ue364"
+// One cell wide — in lipgloss, and in a real terminal, which is what the
+// header's gap arithmetic assumes when it places the counters at the far
+// edge.
+const StormGlyph = "\ue364"
 
 // shimmerRest adds off-screen travel on both ends of each sweep so the glow
 // rests at the base shade between passes instead of wrapping abruptly.
@@ -167,7 +171,7 @@ func renderWordmark(phase int) string {
 			Light: wordmarkStopsLight[1],
 			Dark:  wordmarkStopsDark[1],
 		}))
-	out.WriteString(glint.Render(wordmarkGlyph + " "))
+	out.WriteString(glint.Render(StormGlyph + " "))
 	for index, letter := range runes {
 		t := 0.0
 		if len(runes) > 1 {

--- a/internal/ui/styles.go
+++ b/internal/ui/styles.go
@@ -79,8 +79,8 @@ func successStyle() lipgloss.Style {
 // indicator for the header, workspace names, and agent titles.
 const stormlightTitle = "Stormlight"
 
-// StormGlyph is Stormlight's mark: Nerd Font U+E364,
-// nf-weather-night_alt_sleet_storm. It opens the wordmark, caps the
+// StormGlyph is Stormlight's mark: Nerd Font U+F067E,
+// nf-md-weather_lightning_rainy. It opens the wordmark, caps the
 // footer, and leads the oath printed on the way out — every place the
 // program signs its own name. A four-pointed star stood here before, and
 // said only "something bright".
@@ -97,8 +97,19 @@ const stormlightTitle = "Stormlight"
 //
 // One cell wide — in lipgloss, and in a real terminal, which is what the
 // header's gap arithmetic assumes when it places the counters at the far
-// edge.
-const StormGlyph = "\ue364"
+// edge. It sits in Plane 15 rather than the Basic Multilingual Plane's
+// private area, which changes nothing about that: both are Private Use,
+// both measure one column.
+//
+// It comes from the Material Design set rather than the Weather Icons set
+// the mark started in, and the reason is size. Patched into a Mono
+// variant, every glyph is squeezed into one cell, and the two sets do not
+// arrive there the same: measured in JetBrains Mono Nerd Font Mono, the
+// weather icon inked 446x462 against a capital M's 456x730, while this one
+// fills 600x544. Same column, half again the ink, which is the only sense
+// in which a terminal glyph can be made bigger — the cell belongs to the
+// font, not to us.
+const StormGlyph = "\U000f067e"
 
 // shimmerRest adds off-screen travel on both ends of each sweep so the glow
 // rests at the base shade between passes instead of wrapping abruptly.

--- a/internal/ui/styles.go
+++ b/internal/ui/styles.go
@@ -79,6 +79,23 @@ func successStyle() lipgloss.Style {
 // indicator for the header, workspace names, and agent titles.
 const stormlightTitle = "Stormlight"
 
+// wordmarkGlyph opens the wordmark: Nerd Font U+E364,
+// nf-weather-night_alt_sleet_storm. The mark before the name now says the
+// name — a storm, where a four-pointed star said only "something bright".
+//
+// It is a Private Use Area codepoint, which is a harder bargain here than
+// anywhere else in the dashboard: the header is the first thing drawn and
+// the last thing a user would think to blame, so in a terminal without a
+// Nerd Font the identity line opens with an empty box. Nothing can ask a
+// terminal whether it has the glyph, so this is a requirement rather than
+// a degradation, and README says so.
+//
+// The footer keeps its ✦ (see renderFooter). The two marks share the
+// wordmark's sky stop and read as one family, but only this one stands in
+// for the name; the footer's is a cap on a row of hints, and it still
+// draws in every font.
+const wordmarkGlyph = "\ue364"
+
 // shimmerRest adds off-screen travel on both ends of each sweep so the glow
 // rests at the base shade between passes instead of wrapping abruptly.
 const shimmerRest = 14
@@ -150,7 +167,7 @@ func renderWordmark(phase int) string {
 			Light: wordmarkStopsLight[1],
 			Dark:  wordmarkStopsDark[1],
 		}))
-	out.WriteString(glint.Render("✦ "))
+	out.WriteString(glint.Render(wordmarkGlyph + " "))
 	for index, letter := range runes {
 		t := 0.0
 		if len(runes) > 1 {

--- a/internal/ui/workspaces.go
+++ b/internal/ui/workspaces.go
@@ -479,7 +479,7 @@ func renderSelectedWorkspaceRow(
 }
 
 // remoteGlyph leads the row of a workspace that lives on another machine:
-// Nerd Font U+E310, nf-weather-cloudy_gusts. It says "somewhere else" and
+// Nerd Font U+F059D, nf-md-weather_windy. It says "somewhere else" and
 // nothing more, which is exactly what the first glance asks — the row is
 // read left to right, and where a workspace is outranks how many agents
 // are in it.
@@ -494,7 +494,12 @@ func renderSelectedWorkspaceRow(
 // Ambiguous, so a terminal configured to draw ambiguous glyphs wide will
 // spend two on it and take a column off the name. The same is already
 // true of the arcs and diamonds this dashboard is built from.
-const remoteGlyph = "\ue310"
+//
+// From the Material Design set for the same reason StormGlyph is: the
+// gusts it keeps are drawn to fill the cell, where the Weather Icons
+// cloud this started as inked barely half of what a capital M does. See
+// StormGlyph for the measurements.
+const remoteGlyph = "\U000f059d"
 
 // remoteMark is how a workspace on another machine says which machine:
 // that machine's initial, in the column before the counts.

--- a/internal/ui/workspaces.go
+++ b/internal/ui/workspaces.go
@@ -205,18 +205,14 @@ func (m Model) renderWorkspaceRow(
 		lipgloss.Width(displayName),
 		min(10, max(1, contentWidth/2)),
 	)
-	// A workspace on another machine is marked in the columns themselves,
-	// not only in the subtitle: compact rows have no subtitle, and where a
-	// workspace is is the one thing about it not worth guessing at. Two
-	// marks, because there are two questions. The cloud leads the row and
-	// answers the one asked at a glance — this one is somewhere else. The
-	// initial rides with the counts and answers the one asked next —
-	// which machine. Neither rides with the name, so a remote workspace
-	// is not also a truncated one.
-	lead, mark := "", ""
+	// A workspace on another machine is marked in the column itself, not
+	// only in the subtitle: compact rows have no subtitle, and where a
+	// workspace is is the one thing about it not worth guessing at. The
+	// mark rides with the counts rather than the name, so a remote
+	// workspace is not also a truncated one.
+	mark := ""
 	if group.context.Host != "" {
-		lead = remoteGlyph + " "
-		mark = remoteMark(group.context.Host) + " "
+		mark = remoteGlyph + " "
 	}
 	// Nothing marks this column. A selected-but-unfocused workspace is
 	// already named by the row that stays at full strength while its
@@ -224,36 +220,22 @@ func (m Model) renderWorkspaceRow(
 	// saying it a third time is texture, not information. The two columns
 	// remain so quiet rows line up with the focused row's marker.
 	gutter := "  "
-	// Both marks are spent before the chips are fitted. A remote row has
-	// four fewer columns to spend than a local one, and chips fitted
-	// against the local width would take them out of the name — which is
-	// the one part of the row the marks are placed to protect.
+	// The mark is spent before the chips are fitted. A remote row has two
+	// fewer columns to spend than a local one, and chips fitted against
+	// the local width would take them out of the name — which is the one
+	// part of the row the mark is placed away from to protect.
 	chips := fitCountChips(
 		workspaceCountChips(stats, len(group.agents)),
 		max(1, contentWidth-
 			lipgloss.Width(gutter)-
-			lipgloss.Width(lead)-
 			lipgloss.Width(mark)-1),
 		nameNeed,
 	)
-	// The cloud is the first thing a pane too narrow for everything gives
-	// up. The initial says what the cloud says and names the machine
-	// besides, so the row that can afford only one mark keeps the one that
-	// says more — and a row assembled from its floors (one column of name,
-	// one of gap, the loudest chip) is exactly as wide as its pane rather
-	// than two columns past it, which is a wrapped row and a list that
-	// loses its footing below it.
-	floorWidth := lipgloss.Width(gutter) + lipgloss.Width(lead) +
-		lipgloss.Width(mark) + lipgloss.Width(chipsPlain(chips)) + 2
-	if floorWidth > width {
-		lead = ""
-	}
 	suffix := mark + chipsPlain(chips)
 	nameWidth := max(
 		1,
 		contentWidth-
 			lipgloss.Width(gutter)-
-			lipgloss.Width(lead)-
 			lipgloss.Width(suffix)-1,
 	)
 	name := truncate(displayName, nameWidth)
@@ -261,7 +243,6 @@ func (m Model) renderWorkspaceRow(
 		1,
 		contentWidth-
 			lipgloss.Width(gutter)-
-			lipgloss.Width(lead)-
 			lipgloss.Width(name)-
 			lipgloss.Width(suffix),
 	)
@@ -273,7 +254,7 @@ func (m Model) renderWorkspaceRow(
 	tier := attentionTierOf(stats)
 	if focused || danger {
 		return renderSelectedWorkspaceRow(
-			" "+lead,
+			" ",
 			name,
 			gap,
 			suffix,
@@ -301,13 +282,10 @@ func (m Model) renderWorkspaceRow(
 		renderedName = shimmerText(name, m.shimmerPhaseOrRest(), nil)
 	}
 	styledSuffix := chipsStyled(chips)
-	styledLead := ""
 	if mark != "" {
 		styledSuffix = mutedStyle().Render(mark) + styledSuffix
-		styledLead = mutedStyle().Render(lead)
 	}
 	top := gutter +
-		styledLead +
 		renderedName +
 		strings.Repeat(" ", gap) +
 		styledSuffix
@@ -478,17 +456,28 @@ func renderSelectedWorkspaceRow(
 	return lipgloss.JoinVertical(lipgloss.Left, topLine, bottomLine)
 }
 
-// remoteGlyph leads the row of a workspace that lives on another machine:
-// Nerd Font U+F059D, nf-md-weather_windy. It says "somewhere else" and
-// nothing more, which is exactly what the first glance asks — the row is
-// read left to right, and where a workspace is outranks how many agents
-// are in it.
+// remoteGlyph marks a workspace that lives on another machine: Nerd Font
+// U+F059D, nf-md-weather_windy. It rides in the column before the counts,
+// where a letter — the host's initial — used to.
 //
-// It is a Private Use Area codepoint, so it needs a patched font and there
-// is no way to ask a terminal whether it has one. Without a Nerd Font the
-// column is a box. That is the price of the mark, and it is why remoteMark
-// below stays a plain letter: the two marks fail differently, and the one
-// that names the machine should not fail at all.
+// The letter said more: it named which machine, where the glyph can only
+// say "not this one". It went anyway, because the row has to be looked at
+// as well as read. A lone capital sitting between a workspace name and a
+// cluster of status glyphs read as an initial of something, and the eye
+// stopped to work out what. The glyph reads as a mark at a glance and
+// stops nothing. Which machine is a question the expanded row answers in
+// full, in its subtitle, where a name beats an initial anyway.
+//
+// It led the row for a while, in the column before the name. That put it
+// where nothing else on the pane starts and left the names indented
+// behind it — a mark can sit ahead of a row or beside its counts, and
+// beside the counts is where this pane already keeps the things that are
+// true of a workspace rather than part of its name.
+//
+// It is a Private Use Area codepoint, so it needs a patched font and
+// there is no way to ask a terminal whether it has one. Without a Nerd
+// Font the column is a box — which is the whole cost of having dropped
+// the letter, since a box says less than "D" did.
 //
 // One cell wide, here and in the emulator both — PUA is East Asian
 // Ambiguous, so a terminal configured to draw ambiguous glyphs wide will
@@ -500,26 +489,6 @@ func renderSelectedWorkspaceRow(
 // cloud this started as inked barely half of what a capital M does. See
 // StormGlyph for the measurements.
 const remoteGlyph = "\U000f059d"
-
-// remoteMark is how a workspace on another machine says which machine:
-// that machine's initial, in the column before the counts.
-//
-// The cloud above answers "somewhere else" at a glance; a dashboard worth
-// having several machines on is one where "which" is the next question,
-// and an initial answers it in the same two columns. It reads as a mark
-// rather than a word when there is only one host to tell apart.
-//
-// It is a plain letter, not a superscript: the superscript capitals exist
-// for most of the alphabet and not all of it, and a host beginning with Q
-// or Z should not render as a box. Two machines sharing an initial share
-// a mark — the subtitle carries the name in full, which is where an
-// ambiguity is worth resolving rather than in a single column.
-func remoteMark(host string) string {
-	for _, letter := range host {
-		return strings.ToUpper(string(letter))
-	}
-	return ""
-}
 
 // workspaceDetail is the expanded row's subtitle: quiet middot-joined
 // tokens — resolver kind, home-relative root, and the component when it

--- a/internal/ui/workspaces.go
+++ b/internal/ui/workspaces.go
@@ -205,20 +205,18 @@ func (m Model) renderWorkspaceRow(
 		lipgloss.Width(displayName),
 		min(10, max(1, contentWidth/2)),
 	)
-	chips := fitCountChips(
-		workspaceCountChips(stats, len(group.agents)),
-		max(1, contentWidth-lipgloss.Width("  ")-1),
-		nameNeed,
-	)
-	suffix := chipsPlain(chips)
-	// A workspace on another machine is marked in the column itself, not
-	// only in the subtitle: compact rows have no subtitle, and which
-	// machine a workspace is on is the one thing about it not worth
-	// guessing at. The marker rides with the counts rather than the name
-	// so that a remote workspace is not also a truncated one.
-	remote := group.context.Host != ""
-	if remote {
-		suffix = remoteMark(group.context.Host) + " " + suffix
+	// A workspace on another machine is marked in the columns themselves,
+	// not only in the subtitle: compact rows have no subtitle, and where a
+	// workspace is is the one thing about it not worth guessing at. Two
+	// marks, because there are two questions. The cloud leads the row and
+	// answers the one asked at a glance — this one is somewhere else. The
+	// initial rides with the counts and answers the one asked next —
+	// which machine. Neither rides with the name, so a remote workspace
+	// is not also a truncated one.
+	lead, mark := "", ""
+	if group.context.Host != "" {
+		lead = remoteGlyph + " "
+		mark = remoteMark(group.context.Host) + " "
 	}
 	// Nothing marks this column. A selected-but-unfocused workspace is
 	// already named by the row that stays at full strength while its
@@ -226,15 +224,44 @@ func (m Model) renderWorkspaceRow(
 	// saying it a third time is texture, not information. The two columns
 	// remain so quiet rows line up with the focused row's marker.
 	gutter := "  "
+	// Both marks are spent before the chips are fitted. A remote row has
+	// four fewer columns to spend than a local one, and chips fitted
+	// against the local width would take them out of the name — which is
+	// the one part of the row the marks are placed to protect.
+	chips := fitCountChips(
+		workspaceCountChips(stats, len(group.agents)),
+		max(1, contentWidth-
+			lipgloss.Width(gutter)-
+			lipgloss.Width(lead)-
+			lipgloss.Width(mark)-1),
+		nameNeed,
+	)
+	// The cloud is the first thing a pane too narrow for everything gives
+	// up. The initial says what the cloud says and names the machine
+	// besides, so the row that can afford only one mark keeps the one that
+	// says more — and a row assembled from its floors (one column of name,
+	// one of gap, the loudest chip) is exactly as wide as its pane rather
+	// than two columns past it, which is a wrapped row and a list that
+	// loses its footing below it.
+	floorWidth := lipgloss.Width(gutter) + lipgloss.Width(lead) +
+		lipgloss.Width(mark) + lipgloss.Width(chipsPlain(chips)) + 2
+	if floorWidth > width {
+		lead = ""
+	}
+	suffix := mark + chipsPlain(chips)
 	nameWidth := max(
 		1,
-		contentWidth-lipgloss.Width(gutter)-lipgloss.Width(suffix)-1,
+		contentWidth-
+			lipgloss.Width(gutter)-
+			lipgloss.Width(lead)-
+			lipgloss.Width(suffix)-1,
 	)
 	name := truncate(displayName, nameWidth)
 	gap := max(
 		1,
 		contentWidth-
 			lipgloss.Width(gutter)-
+			lipgloss.Width(lead)-
 			lipgloss.Width(name)-
 			lipgloss.Width(suffix),
 	)
@@ -246,7 +273,7 @@ func (m Model) renderWorkspaceRow(
 	tier := attentionTierOf(stats)
 	if focused || danger {
 		return renderSelectedWorkspaceRow(
-			" ",
+			" "+lead,
 			name,
 			gap,
 			suffix,
@@ -274,10 +301,13 @@ func (m Model) renderWorkspaceRow(
 		renderedName = shimmerText(name, m.shimmerPhaseOrRest(), nil)
 	}
 	styledSuffix := chipsStyled(chips)
-	if remote {
-		styledSuffix = mutedStyle().Render(remoteMark(group.context.Host)+" ") + styledSuffix
+	styledLead := ""
+	if mark != "" {
+		styledSuffix = mutedStyle().Render(mark) + styledSuffix
+		styledLead = mutedStyle().Render(lead)
 	}
 	top := gutter +
+		styledLead +
 		renderedName +
 		strings.Repeat(" ", gap) +
 		styledSuffix
@@ -367,7 +397,7 @@ func chipsStyled(chips []countChip) string {
 }
 
 func renderSelectedWorkspaceRow(
-	activityMarker string,
+	lead string,
 	name string,
 	gap int,
 	suffix string,
@@ -380,7 +410,7 @@ func renderSelectedWorkspaceRow(
 	shimmerPhase int,
 	theme rowTheme,
 ) string {
-	top := activityMarker + name + strings.Repeat(" ", gap) + suffix
+	top := lead + name + strings.Repeat(" ", gap) + suffix
 	if width < 3 || lipgloss.Width(top) > max(0, width-2) {
 		if focused {
 			if !expanded {
@@ -407,30 +437,31 @@ func renderSelectedWorkspaceRow(
 	baseStyle := lipgloss.NewStyle().
 		Foreground(theme.text).
 		Background(theme.background)
-	activityStyle := baseStyle.Copy()
 	renderedName := baseStyle.Copy().Bold(true).Render(name)
 	switch {
 	case tier == tierUrgent:
-		activityStyle = activityStyle.
+		// Urgent attention outranks the working glow, the same way it
+		// does on the quiet path.
+		renderedName = baseStyle.Copy().
 			Foreground(colorWaiting()).
-			Bold(true)
-		renderedName = activityStyle.Render(name)
+			Bold(true).
+			Render(name)
 	case tier == tierWaiting:
-		activityStyle = activityStyle.Foreground(colorWaiting())
+		// Deliberately nothing. A workspace someone is waiting in keeps a
+		// still name even while other agents work in it, so the amber chip
+		// is the only thing moving in the row. The case earns its place by
+		// holding the shimmer below off, not by painting anything.
 	case active:
-		activityStyle = activityStyle.
-			Foreground(colorWorking()).
-			Bold(true)
 		renderedName = shimmerText(name, shimmerPhase, theme.background)
 	}
 
 	contentWidth := width - 1
 	tailWidth := max(
 		0,
-		contentWidth-lipgloss.Width(activityMarker)-lipgloss.Width(name),
+		contentWidth-lipgloss.Width(lead)-lipgloss.Width(name),
 	)
 	topLine := markerStyle.Render(marker) +
-		activityStyle.Render(activityMarker) +
+		baseStyle.Render(lead) +
 		renderedName +
 		baseStyle.Copy().
 			Width(tailWidth).
@@ -447,17 +478,31 @@ func renderSelectedWorkspaceRow(
 	return lipgloss.JoinVertical(lipgloss.Left, topLine, bottomLine)
 }
 
-// workspaceDetail is the expanded row's subtitle: quiet middot-joined
-// tokens — resolver kind, home-relative root, and the component when it
-// adds information — indented under the name rather than justified across
-// the row.
-// remoteMark is how a workspace on another machine is marked: that
-// machine's initial, in the column before the counts.
+// remoteGlyph leads the row of a workspace that lives on another machine:
+// Nerd Font U+E310, nf-weather-cloudy_gusts. It says "somewhere else" and
+// nothing more, which is exactly what the first glance asks — the row is
+// read left to right, and where a workspace is outranks how many agents
+// are in it.
 //
-// A glyph could only say "somewhere else", and a dashboard worth having
-// several machines on is one where "which" is the question. An initial
-// answers it in the same two columns, and reads as a mark rather than a
-// word when there is only one host to tell apart.
+// It is a Private Use Area codepoint, so it needs a patched font and there
+// is no way to ask a terminal whether it has one. Without a Nerd Font the
+// column is a box. That is the price of the mark, and it is why remoteMark
+// below stays a plain letter: the two marks fail differently, and the one
+// that names the machine should not fail at all.
+//
+// One cell wide, here and in the emulator both — PUA is East Asian
+// Ambiguous, so a terminal configured to draw ambiguous glyphs wide will
+// spend two on it and take a column off the name. The same is already
+// true of the arcs and diamonds this dashboard is built from.
+const remoteGlyph = "\ue310"
+
+// remoteMark is how a workspace on another machine says which machine:
+// that machine's initial, in the column before the counts.
+//
+// The cloud above answers "somewhere else" at a glance; a dashboard worth
+// having several machines on is one where "which" is the next question,
+// and an initial answers it in the same two columns. It reads as a mark
+// rather than a word when there is only one host to tell apart.
 //
 // It is a plain letter, not a superscript: the superscript capitals exist
 // for most of the alphabet and not all of it, and a host beginning with Q
@@ -471,6 +516,10 @@ func remoteMark(host string) string {
 	return ""
 }
 
+// workspaceDetail is the expanded row's subtitle: quiet middot-joined
+// tokens — resolver kind, home-relative root, and the component when it
+// adds information — indented under the name rather than justified across
+// the row.
 func workspaceDetail(value workspace.Context, width int) string {
 	width = max(1, width)
 	kind := strings.ToLower(strings.TrimSpace(value.Kind))

--- a/main.go
+++ b/main.go
@@ -578,8 +578,19 @@ func printFarewell(out io.Writer) {
 	if err != nil || info.Mode()&os.ModeCharDevice == 0 {
 		return
 	}
-	fmt.Fprintln(file,
-		"\x1b[38;2;125;207;255m✦\x1b[0m \x1b[2mJourney before destination.\x1b[0m")
+	fmt.Fprintln(file, farewellLine())
+}
+
+// farewellLine is the oath as it is printed: Stormlight's own mark, then
+// the words dimmed behind it.
+//
+// The colour is spelled in raw ANSI rather than resolved through the
+// theme — it is the wordmark's sky stop, #7DCFFF, written out. This line
+// is printed after the dashboard has handed the terminal back, which is
+// no place to be starting up a palette for one glyph.
+func farewellLine() string {
+	return "\x1b[38;2;125;207;255m" + ui.StormGlyph +
+		"\x1b[0m \x1b[2mJourney before destination.\x1b[0m"
 }
 
 func newLogsCommand(logFile *string) *cobra.Command {

--- a/main_test.go
+++ b/main_test.go
@@ -10,6 +10,7 @@ import (
 
 	"github.com/trentkm/stormlight/internal/agent"
 	"github.com/trentkm/stormlight/internal/remote"
+	"github.com/trentkm/stormlight/internal/ui"
 	"github.com/trentkm/stormlight/internal/workspace"
 )
 
@@ -409,5 +410,24 @@ func TestTheReportedVersionIsPulledOutOfTheSentence(t *testing.T) {
 		if got := reportedVersion(reported); got != want {
 			t.Fatalf("reportedVersion(%q) = %q, want %q", reported, got, want)
 		}
+	}
+}
+
+// TestTheFarewellCarriesTheSameMark: the oath is the last thing the
+// program prints, and it prints from main rather than from the dashboard —
+// which is exactly how a mark gets spelled twice and drifts apart. It
+// takes the glyph from the package that draws the other two.
+func TestTheFarewellCarriesTheSameMark(t *testing.T) {
+	line := farewellLine()
+	if !strings.Contains(line, ui.StormGlyph) {
+		t.Errorf("the farewell dropped Stormlight's mark: %q", line)
+	}
+	if !strings.Contains(line, "Journey before destination.") {
+		t.Errorf("the farewell dropped the oath: %q", line)
+	}
+	// The mark leads, as it does in the header.
+	if strings.Index(line, ui.StormGlyph) >
+		strings.Index(line, "Journey") {
+		t.Errorf("the mark follows the words: %q", line)
 	}
 }


### PR DESCRIPTION
The dashboard drew a four-pointed star in the three places it named
itself, and said nothing at all about which machine a workspace was on
except a capital letter beside its counts. Both are Nerd Font marks now.

**The storm** — U+F067E, `nf-md-weather_lightning_rainy` — opens the
wordmark, caps the footer's hint row in both of its alignments, and leads
the oath printed on the way out. It lives in `ui.StormGlyph`, exported
because the farewell is printed by `main` after the dashboard has handed
the terminal back, and one mark spelled in two packages is one that
drifts. The wordmark also stands one column off the left wall now: it sat
flush against the terminal's edge, the only ink on screen doing so, with
the whole dashboard indented behind it.

**The wind** — U+F059D, `nf-md-weather_windy` — marks a workspace that
lives on another machine, in the column before its counts. It replaces
the host's initial that held that column. The letter said more (which
machine, not merely another one), but a lone capital between a name and a
cluster of status glyphs read as an initial of something and stopped the
eye. The expanded row's subtitle still names the machine in full, and a
test pins that line, since it is now the only place the machine is named.

Both marks come from the Material Design set rather than Weather Icons,
for size. Patched into a Mono variant every glyph is squeezed into one
cell, and the sets do not arrive there the same: measured in JetBrains
Mono Nerd Font Mono, the weather icons inked 446x462 and 464x370 against
a capital M's 456x730, where these fill 600x544 and 600x632. Same column,
roughly double the ink — which is the only sense in which a terminal
glyph can be made larger, since the cell belongs to the font.

**This makes a Nerd Font a requirement**, and README says so. These are
Private Use Area codepoints and nothing can ask a terminal whether it has
them, so a font without them draws empty boxes where the identity is.
README also carries the half of the size question that is not ours: the
`Mono` variants squeeze glyphs into the cell, the plain ones draw them at
nearly twice the size and let them overhang the next column.

Both are one cell wide to `ansi.StringWidth`, to the `x/vt` emulator, and
to a real terminal — checked against an `X` in a tmux pane, not assumed.

Along the way the row's count chips are now fitted *after* the mark is
spent. They were fitted against the width a local row has, so a
twenty-two column pane showed `there…` beside two chips where it should
show `there-is-a…` beside one: the mark's columns came out of the name
rather than out of a quiet tier.

Tests cover the wordmark at rest and mid-shimmer, both footer alignments,
the farewell line, the frame's inset at both ends, the mark's position
and the letter's absence, the chip accounting, and that rows still fit
their pane. Each was checked by mutation — reverting its site to `✦`, to
the letter, to the left-hand lead, or to the old chip budget — to confirm
it fails when it should.
