### PR TITLE
Add configurable tool overlays

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,6 +59,12 @@ of the display — and `Ctrl-q` returns to the dashboard. Closing the
 dashboard stops nothing: agents keep running in the daemon, terminals
 intact for the next run.
 
+Press `T` to configure user-and-machine-scoped Tool Overlays. A configured
+two- or three-key hotkey opens its executable and argument array in a
+Windrunner popup. `Ctrl-space` minimizes every tool overlay;
+its same hotkey restores the preserved terminal session. Tool overlays receive
+keyboard input, while mouse input remains with Stormlight.
+
 Conversations outlive their agents. Both providers name every session with
 an id their own `resume` command accepts, and Stormlight records it — with
 the task, workspace, and transcript path — in an append-only log at

--- a/README.md
+++ b/README.md
@@ -59,11 +59,12 @@ of the display — and `Ctrl-q` returns to the dashboard. Closing the
 dashboard stops nothing: agents keep running in the daemon, terminals
 intact for the next run.
 
-Press `T` to configure user-and-machine-scoped Tool Overlays. A configured
-two- or three-key hotkey opens its executable and argument array in a
-Windrunner popup. `Ctrl-space` minimizes every tool overlay;
-its same hotkey restores the preserved terminal session. Tool overlays receive
-keyboard input, while mouse input remains with Stormlight.
+Press `T` to configure user-and-machine-scoped Tool Overlays; `?` lists that
+manager key and every configured tool hotkey. A configured two- or three-key
+hotkey opens its executable and argument array in a Windrunner popup.
+`Ctrl-space` minimizes every tool overlay; its same hotkey restores the
+preserved terminal session. Tool overlays receive keyboard input, while mouse
+input remains with Stormlight.
 
 Conversations outlive their agents. Both providers name every session with
 an id their own `resume` command accepts, and Stormlight records it — with

--- a/README.md
+++ b/README.md
@@ -145,9 +145,11 @@ flags — `auto` (the default and the recommended way to run: never asks),
 `edits` (file edits apply immediately, shell and network still ask), or
 `ask` (approvals for consequential actions). In the New Agent form, press
 `m` to cycle the mode; `auto` agents are marked with an `AUTO` badge in the
-agent list. When an agent in a prompting mode does need an answer, the
-dashboard raises attention on it and `Enter` walks into its terminal —
-prompts are answered in the agent's own terminal, where the provider's real
+agent list. With the Task field focused, use the mouse wheel to scroll
+wrapped task text; Up/Down keyboard navigation remains available. When an
+agent in a prompting mode does need an answer, the dashboard raises attention
+on it and `Enter` walks into its terminal — prompts are answered in the
+agent's own terminal, where the provider's real
 UI lives.
 
 Inspect and control agents:

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -13,6 +13,7 @@ import (
 	"path/filepath"
 	"sort"
 	"strings"
+	"unicode"
 
 	toml "github.com/pelletier/go-toml/v2"
 	"github.com/trentkm/stormlight/internal/agent"
@@ -85,8 +86,20 @@ type Log struct {
 }
 
 type Tools struct {
-	Yazi string `toml:"yazi"`
-	Nvim string `toml:"nvim"`
+	Yazi     string                 `toml:"yazi"`
+	Nvim     string                 `toml:"nvim"`
+	Overlays map[string]ToolOverlay `toml:"overlays"`
+}
+
+// ToolOverlay is a user- and machine-scoped terminal program Stormlight can
+// float over the dashboard. Binary and Args are exec-style values: no shell
+// is involved.
+type ToolOverlay struct {
+	Title  string   `toml:"title"`
+	Binary string   `toml:"binary"`
+	Args   []string `toml:"args"`
+	Hotkey []string `toml:"hotkey"`
+	Host   string   `toml:"host"`
 }
 
 type WorkspaceOverride struct {
@@ -207,6 +220,7 @@ func (c Config) normalize(path string) (Config, []string, error) {
 			c.Hosts[name] = host
 		}
 	}
+	c.normalizeToolOverlays(warn)
 	for root, override := range c.Workspaces {
 		if _, err := agent.ParseMode(override.Mode); err != nil {
 			warn("workspaces.%q.mode: %v", root, err)
@@ -223,6 +237,118 @@ func (c Config) normalize(path string) (Config, []string, error) {
 		}
 	}
 	return c, warnings, nil
+}
+
+func (c *Config) normalizeToolOverlays(warn func(string, ...any)) {
+	seen := make(map[string]string)
+	for id, overlay := range c.Tools.Overlays {
+		if !validToolOverlayID(id) {
+			warn("tools.overlays.%q: id must start with a letter and contain only lowercase letters, digits, _ or -", id)
+			delete(c.Tools.Overlays, id)
+			continue
+		}
+		overlay.Title = strings.TrimSpace(overlay.Title)
+		overlay.Binary = strings.TrimSpace(overlay.Binary)
+		if overlay.Binary == "" {
+			warn("tools.overlays.%s.binary: required", id)
+			delete(c.Tools.Overlays, id)
+			continue
+		}
+		if overlay.Host != "" {
+			if _, ok := c.Hosts[overlay.Host]; !ok {
+				warn("tools.overlays.%s.host: %q is not configured under hosts", id, overlay.Host)
+				delete(c.Tools.Overlays, id)
+				continue
+			}
+		}
+		for index := range overlay.Hotkey {
+			overlay.Hotkey[index] = strings.ToLower(strings.TrimSpace(overlay.Hotkey[index]))
+		}
+		if err := validateToolOverlayHotkey(overlay.Hotkey); err != nil {
+			warn("tools.overlays.%s.hotkey: %v", id, err)
+			delete(c.Tools.Overlays, id)
+			continue
+		}
+		key := strings.Join(overlay.Hotkey, " ")
+		if other, exists := seen[key]; exists {
+			warn("tools.overlays.%s.hotkey: duplicates %s", id, other)
+			delete(c.Tools.Overlays, id)
+			continue
+		}
+		seen[key] = id
+		c.Tools.Overlays[id] = overlay
+	}
+	for id, overlay := range c.Tools.Overlays {
+		for otherID, other := range c.Tools.Overlays {
+			if id == otherID || len(overlay.Hotkey) >= len(other.Hotkey) {
+				continue
+			}
+			if equalToolHotkeys(overlay.Hotkey, other.Hotkey[:len(overlay.Hotkey)]) {
+				warn("tools.overlays.%s.hotkey: prefixes %s", id, otherID)
+				delete(c.Tools.Overlays, id)
+				break
+			}
+		}
+	}
+}
+
+func validToolOverlayID(id string) bool {
+	if id == "" {
+		return false
+	}
+	for index, letter := range id {
+		if (index == 0 && !unicode.IsLower(letter)) ||
+			(index > 0 && !(unicode.IsLower(letter) || unicode.IsDigit(letter) || letter == '_' || letter == '-')) {
+			return false
+		}
+	}
+	return true
+}
+
+func validateToolOverlayHotkey(hotkey []string) error {
+	if len(hotkey) < 2 || len(hotkey) > 3 {
+		return fmt.Errorf("must contain two or three keys")
+	}
+	for _, key := range hotkey {
+		if len(key) != 1 || key[0] < 'a' || key[0] > 'z' {
+			return fmt.Errorf("keys must be lowercase letters")
+		}
+	}
+	if !strings.ContainsRune("abcdpuvwy", rune(hotkey[0][0])) {
+		return fmt.Errorf("first key conflicts with a dashboard command")
+	}
+	return nil
+}
+
+func equalToolHotkeys(a, b []string) bool {
+	if len(a) != len(b) {
+		return false
+	}
+	for index := range a {
+		if a[index] != b[index] {
+			return false
+		}
+	}
+	return true
+}
+
+// SetToolOverlays validates and applies a replacement overlay set. It is used
+// by the dashboard manager before the configuration is written.
+func (c *Config) SetToolOverlays(overlays map[string]ToolOverlay) error {
+	candidate := *c
+	candidate.Tools.Overlays = make(map[string]ToolOverlay, len(overlays))
+	for id, overlay := range overlays {
+		candidate.Tools.Overlays[id] = overlay
+	}
+	normalized, warnings, err := candidate.normalize(Path())
+	if err != nil {
+		return err
+	}
+	if len(warnings) > 0 {
+		return fmt.Errorf("invalid tool overlays: %s", strings.Join(warnings, "; "))
+	}
+	*c = normalized
+	return nil
 }
 
 // ModeForDir returns the permission-mode override whose directory key
@@ -309,4 +435,41 @@ func (c Config) EffectiveTOML() (string, error) {
 		return "", fmt.Errorf("render config: %w", err)
 	}
 	return string(rendered), nil
+}
+
+// Save writes config atomically. The dashboard manager writes parsed TOML,
+// so comments and hand-written layout are not retained after an edit.
+func Save(c Config) error {
+	path := Path()
+	if path == "" {
+		return fmt.Errorf("cannot resolve the configuration directory")
+	}
+	rendered, err := toml.Marshal(c)
+	if err != nil {
+		return fmt.Errorf("render config: %w", err)
+	}
+	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+		return fmt.Errorf("create config directory: %w", err)
+	}
+	temporary, err := os.CreateTemp(filepath.Dir(path), ".config.toml-*")
+	if err != nil {
+		return fmt.Errorf("create config temp file: %w", err)
+	}
+	temporaryName := temporary.Name()
+	defer os.Remove(temporaryName)
+	if _, err := temporary.Write(rendered); err != nil {
+		_ = temporary.Close()
+		return fmt.Errorf("write config: %w", err)
+	}
+	if err := temporary.Chmod(0o600); err != nil {
+		_ = temporary.Close()
+		return fmt.Errorf("set config permissions: %w", err)
+	}
+	if err := temporary.Close(); err != nil {
+		return fmt.Errorf("close config: %w", err)
+	}
+	if err := os.Rename(temporaryName, path); err != nil {
+		return fmt.Errorf("replace config: %w", err)
+	}
+	return nil
 }

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -281,3 +281,38 @@ shell = "fish"
 		t.Fatal("a bad shell should not remove the host")
 	}
 }
+
+func TestToolOverlaysValidateHotkeysAndHosts(t *testing.T) {
+	path := writeConfig(t, `
+[hosts.remote]
+
+[tools.overlays.review]
+binary = "review-tool"
+hotkey = ["c", "r"]
+host = "remote"
+
+[tools.overlays.duplicate]
+binary = "other-tool"
+hotkey = ["c", "r"]
+host = "remote"
+
+[tools.overlays.conflict]
+binary = "conflict-tool"
+hotkey = ["n", "r"]
+`)
+	cfg, warnings, err := loadFrom(path)
+	if err != nil {
+		t.Fatalf("loadFrom: %v", err)
+	}
+	if len(cfg.Tools.Overlays) != 1 {
+		t.Fatalf("overlays = %#v", cfg.Tools.Overlays)
+	}
+	for _, got := range cfg.Tools.Overlays {
+		if got.Host != "remote" || len(got.Hotkey) != 2 || got.Hotkey[0] != "c" {
+			t.Fatalf("valid overlay = %#v", got)
+		}
+	}
+	if len(warnings) < 2 {
+		t.Fatalf("warnings = %#v", warnings)
+	}
+}

--- a/internal/config/template.go
+++ b/internal/config/template.go
@@ -37,6 +37,14 @@ const template = `# Stormlight configuration.
 # yazi = "/opt/homebrew/bin/yazi"
 # nvim = "/opt/homebrew/bin/nvim"
 
+# Tool overlays float an interactive program over the dashboard. Commands use
+# an executable plus arguments, never a shell string. Hotkeys are two or three
+# unused lowercase dashboard keys; press T to manage them in the TUI.
+# [tools.overlays.example]
+# title = "Review tool"
+# binary = "review-tool"
+# args = []
+# hotkey = ["c", "r"]
 # Per-directory dispatch defaults, applied when a flag or form choice
 # doesn't say otherwise. Keys may use ~ and match subdirectories.
 # [workspaces."~/repos/trusted-project"]

--- a/internal/ui/chrome.go
+++ b/internal/ui/chrome.go
@@ -131,6 +131,20 @@ func renderFooterRule(width int) string {
 }
 
 func (m Model) chordHints() string {
+	if len(m.toolPrefix) > 0 {
+		options := make([][2]string, 0)
+		for _, tool := range m.toolOverlays {
+			if len(tool.Hotkey) > len(m.toolPrefix) && startsToolHotkey(tool.Hotkey, m.toolPrefix) {
+				options = append(options, [2]string{tool.Hotkey[len(m.toolPrefix)], overlayTitle(tool)})
+			}
+		}
+		parts := []string{titleStyle().Render("Tool:")}
+		for _, option := range options {
+			parts = append(parts, accentStyle().Render(option[0])+" "+mutedStyle().Render(option[1]))
+		}
+		parts = append(parts, mutedStyle().Render("Esc cancel"))
+		return strings.Join(parts, "  ")
+	}
 	var label string
 	var options [][2]string
 	switch m.normalPrefix {
@@ -275,6 +289,7 @@ func (m Model) commandHints() []string {
 		if rowMode != "" {
 			hints = append(hints, rowMode)
 		}
+		hints = append(hints, m.toolFooterHints()...)
 		return append(hints, tail...)
 	}
 	switch m.activePane {

--- a/internal/ui/chrome.go
+++ b/internal/ui/chrome.go
@@ -289,7 +289,6 @@ func (m Model) commandHints() []string {
 		if rowMode != "" {
 			hints = append(hints, rowMode)
 		}
-		hints = append(hints, m.toolFooterHints()...)
 		return append(hints, tail...)
 	}
 	switch m.activePane {

--- a/internal/ui/chrome.go
+++ b/internal/ui/chrome.go
@@ -235,7 +235,7 @@ func (m Model) commandHints() []string {
 			// here — it is the one affordance in this field with nothing
 			// on screen to suggest it. The name row keeps its own label
 			// and cursor, and the line is only so wide.
-			hints := []string{"Enter launch", "Ctrl-j newline"}
+			hints := []string{"Enter launch", "Ctrl-j newline", "wheel"}
 			if m.nvimPath != "" {
 				hints = append(hints, "Ctrl-o Neovim")
 			}

--- a/internal/ui/dispatch.go
+++ b/internal/ui/dispatch.go
@@ -34,6 +34,33 @@ func (m Model) updateDispatch(msg tea.KeyPressMsg) (tea.Model, tea.Cmd) {
 	return updated, cmd
 }
 
+// updateDispatchMouse maps wheel input onto the textarea's established
+// Up/Down navigation. The textarea keeps its cursor in view after every
+// update, so this scrolls the wrapped viewport without changing task text.
+func (m Model) updateDispatchMouse(msg tea.MouseMsg) (tea.Model, tea.Cmd) {
+	wheel, ok := msg.(tea.MouseWheelMsg)
+	if !ok {
+		return m, nil
+	}
+	key := tea.KeyDown
+	switch wheel.Button {
+	case tea.MouseWheelUp:
+		key = tea.KeyUp
+	case tea.MouseWheelDown:
+		key = tea.KeyDown
+	default:
+		return m, nil
+	}
+
+	var cmds []tea.Cmd
+	for range max(3, m.taskInput.Height()) {
+		var cmd tea.Cmd
+		m.taskInput, cmd = m.taskInput.Update(tea.KeyPressMsg{Code: key})
+		cmds = append(cmds, cmd)
+	}
+	return m, tea.Batch(cmds...)
+}
+
 func (m Model) dispatchKey(msg tea.KeyPressMsg) (tea.Model, tea.Cmd) {
 	key := msg.String()
 	if m.formFocus == dispatchDirectory {

--- a/internal/ui/flows_test.go
+++ b/internal/ui/flows_test.go
@@ -286,7 +286,9 @@ func TestHelpModalOpensRendersAndDismisses(t *testing.T) {
 		t.Fatalf("? mode = %d", model.mode)
 	}
 	view := ansi.Strip(model.View().Content)
-	for _, want := range []string{"Keys", "Navigate", "Act", "any key closes"} {
+	for _, want := range []string{
+		"Keys", "Navigate", "Act", "Tools", "T", "configure tool overlays", "any key closes",
+	} {
 		if !strings.Contains(view, want) {
 			t.Fatalf("help modal missing %q", want)
 		}

--- a/internal/ui/input_test.go
+++ b/internal/ui/input_test.go
@@ -566,6 +566,41 @@ func TestDispatchTaskComposerKeepsTypingInView(t *testing.T) {
 	}
 }
 
+func TestDispatchTaskWheelScrollsWithoutChangingText(t *testing.T) {
+	model := dispatchTaskFixture(t, 80, 24)
+	task := strings.Join([]string{
+		"first task line",
+		"second task line",
+		"third task line",
+		"fourth task line",
+		"fifth task line",
+		"sixth task line",
+		"seventh task line",
+		"eighth task line",
+	}, "\n")
+	model.taskInput.SetValue(task)
+	model.syncTaskComposerSize()
+	for range strings.Count(task, "\n") + 1 {
+		model.taskInput.CursorUp()
+	}
+
+	before := strings.Join(taskComposerRows(t, model), "\n")
+	updated, _ := model.Update(tea.MouseWheelMsg{
+		X:      40,
+		Y:      12,
+		Button: tea.MouseWheelDown,
+	})
+	model = updated.(Model)
+	after := strings.Join(taskComposerRows(t, model), "\n")
+
+	if got := model.taskInput.Value(); got != task {
+		t.Fatalf("wheel changed task value: got %q, want %q", got, task)
+	}
+	if before == after {
+		t.Fatalf("wheel did not move the task viewport:\nbefore:\n%s\nafter:\n%s", before, after)
+	}
+}
+
 // The form's rows are a fixed budget: the composer takes what is left, and
 // the hint line below it is the first thing a miscount pushes off the
 // bottom of the modal. The path picker is the case that miscounted — it

--- a/internal/ui/layout.go
+++ b/internal/ui/layout.go
@@ -122,6 +122,10 @@ func (m Model) renderModeBody(width, contentHeight int) string {
 		modal = m.renderRenameModal(width, region)
 	case modeMark:
 		modal = m.renderMarkModal(width, region)
+	case modeTools:
+		modal = m.renderToolsModal(width, region)
+	case modeToolEdit:
+		modal = m.renderToolEditModal(width, region)
 	case modeInfo:
 		modal = m.renderInfoModal(width, region)
 	case modeHelp:

--- a/internal/ui/modals.go
+++ b/internal/ui/modals.go
@@ -132,6 +132,7 @@ func (m Model) renderHelpModal(width, height int) string {
 		title string
 		keys  [][2]string
 	}{
+		{"Tools", m.toolHelpKeys()},
 		{"Navigate", [][2]string{
 			{"h/l", "move between panes"},
 			{"j/k", "move in the pane; scroll Spanreed"},
@@ -187,6 +188,18 @@ func (m Model) renderHelpModal(width, height int) string {
 
 	modalWidth, modalHeight := modalDimensions(width, height, 64, len(lines)+2)
 	return renderModal(strings.Join(lines, "\n"), modalWidth, modalHeight)
+}
+
+func (m Model) toolHelpKeys() [][2]string {
+	keys := make([][2]string, 0, len(m.toolOverlays)+1)
+	keys = append(keys, [2]string{"T", "configure tool overlays"})
+	for _, tool := range m.toolOverlays {
+		keys = append(keys, [2]string{
+			toolHotkeyLabel(tool.Hotkey),
+			overlayTitle(tool),
+		})
+	}
+	return keys
 }
 
 func (m Model) beginRename() (tea.Model, tea.Cmd) {

--- a/internal/ui/model.go
+++ b/internal/ui/model.go
@@ -70,6 +70,8 @@ const (
 	modeHelp
 	modeHistory
 	modeAlert
+	modeTools
+	modeToolEdit
 )
 
 // isForm reports that a mode is one the human is filling in — a field, a
@@ -79,7 +81,7 @@ const (
 // this whole surface exists to remove.
 func (m mode) isForm() bool {
 	switch m {
-	case modeDispatch, modeAddWorkspace, modeRename, modeCompose:
+	case modeDispatch, modeAddWorkspace, modeRename, modeCompose, modeToolEdit:
 		return true
 	}
 	return false
@@ -335,6 +337,7 @@ type Model struct {
 	// saying so is what keeps the gap from reading as an empty morning.
 	reachingHosts []string
 
+	toolPrefix     []string
 	normalPrefix   string
 	sortMode       sortMode
 	dispatchPrefix string
@@ -368,6 +371,11 @@ type Model struct {
 	// the Spanreed, composited over the dashboard. The generation ties
 	// async open/exit messages to the opening they belong to.
 	overlay           *overlayView
+	minimizedOverlay  *overlayView
+	toolOverlays      []ToolOverlay
+	toolCursor        int
+	toolForm          toolOverlayForm
+	saveToolOverlays  func([]ToolOverlay) error
 	overlayGeneration int
 
 	// holdFrame says the message just handled changed nothing that is
@@ -487,13 +495,15 @@ func NewModel(backend Backend) Model {
 // Options carries user-configuration defaults into the dashboard. Zero
 // values mean "use the built-in behavior".
 type Options struct {
-	YaziPath        string
-	NvimPath        string
-	DefaultMode     agent.PermissionMode
-	DefaultProvider agent.Provider
-	ExpandedRows    bool
-	ModeForDir      func(string) (agent.PermissionMode, bool)
-	ProviderForDir  func(string) (agent.Provider, bool)
+	YaziPath         string
+	NvimPath         string
+	ToolOverlays     []ToolOverlay
+	SaveToolOverlays func([]ToolOverlay) error
+	DefaultMode      agent.PermissionMode
+	DefaultProvider  agent.Provider
+	ExpandedRows     bool
+	ModeForDir       func(string) (agent.PermissionMode, bool)
+	ProviderForDir   func(string) (agent.Provider, bool)
 	// SelectWorkspaceID names the workspace the first dashboard refresh
 	// should land on, for launches like `stormlight <path>`.
 	SelectWorkspaceID string
@@ -552,6 +562,8 @@ func NewModelWithOptions(backend Backend, options Options) Model {
 		cwdInput:           cwdInput,
 		nameInput:          nameInput,
 		taskInput:          taskInput,
+		toolOverlays:       sortToolOverlays(options.ToolOverlays),
+		saveToolOverlays:   options.SaveToolOverlays,
 		sendInput:          sendInput,
 		initialCwd:         cwd,
 		initialWorkspaceID: options.SelectWorkspaceID,
@@ -978,6 +990,10 @@ func (m Model) updateKey(msg tea.KeyPressMsg) (tea.Model, tea.Cmd) {
 		return m.updateRename(msg)
 	case modeMark:
 		return m.updateMark(msg)
+	case modeTools:
+		return m.updateTools(msg)
+	case modeToolEdit:
+		return m.updateToolEdit(msg)
 	case modeHistory:
 		return m.updateHistory(msg)
 	case modeAlert:
@@ -1058,6 +1074,11 @@ func (m Model) View() tea.View {
 
 func (m Model) updateNormal(msg tea.KeyPressMsg) (tea.Model, tea.Cmd) {
 	key := msg.String()
+	if tool, waiting := m.toolOverlayForKey(key); tool != nil {
+		return m.toggleToolOverlay(*tool)
+	} else if waiting {
+		return m, nil
+	}
 	// The seam chords work from this side too: the same keys that cycle
 	// inside the terminal cycle here, so the hands never relearn.
 	switch {
@@ -1115,9 +1136,12 @@ func (m Model) updateNormal(msg tea.KeyPressMsg) (tea.Model, tea.Cmd) {
 	case "q", "ctrl+c":
 		// The agents themselves live on in the windrunner daemon,
 		// terminals intact for the next run.
-		return m, tea.Sequence(closeAllPTYCmd(m.ptyManager), tea.Quit)
+		return m, tea.Sequence(closeMinimizedOverlayCmd(m.minimizedOverlay), closeAllPTYCmd(m.ptyManager), tea.Quit)
 	case "t":
 		return m, m.togglePTY()
+	case "T":
+		m.beginToolManager()
+		return m, nil
 	case "F":
 		// The full-screen escape hatch: the same terminal, every column
 		// of the display, via an interactive attachment.

--- a/internal/ui/model.go
+++ b/internal/ui/model.go
@@ -886,6 +886,9 @@ func (m Model) Update(message tea.Msg) (tea.Model, tea.Cmd) {
 			// beneath it.
 			return m, nil
 		}
+		if m.mode == modeDispatch && m.formFocus == dispatchTask {
+			return m.updateDispatchMouse(msg)
+		}
 		return m.handleMouse(msg)
 
 	case tea.PasteMsg:

--- a/internal/ui/overlay_test.go
+++ b/internal/ui/overlay_test.go
@@ -132,6 +132,57 @@ func TestOverlayFloatsOverTheDashboardAndOwnsTheKeyboard(t *testing.T) {
 	waitForWrites(t, session, "j")
 }
 
+func TestConfiguredToolChordMinimizesAndRestoresTheTool(t *testing.T) {
+	model := flowModelFixture(t, stubBackend{})
+	model.toolOverlays = []ToolOverlay{{
+		ID:     "review",
+		Title:  "Review tool",
+		Binary: "/opt/tools/review",
+		Hotkey: []string{"c", "r"},
+	}}
+	updated, _ := model.updateNormal(runeKey("c"))
+	model = updated.(Model)
+	updated, open := model.updateNormal(runeKey("r"))
+	model = updated.(Model)
+	if open == nil {
+		t.Fatal("c r did not start the configured tool")
+	}
+	spec := model.toolOverlaySpec(model.toolOverlays[0])
+	if spec.path != "/opt/tools/review" || spec.host != "" || spec.dir != "" {
+		t.Fatalf("tool spec = %#v", spec)
+	}
+	session := newFakeOverlaySession("TOOL")
+	updated, _ = model.handleOverlayOpened(overlayOpenedMsg{
+		generation: model.overlayGeneration,
+		spec:       spec,
+		session:    session,
+	})
+	model = updated.(Model)
+	if model.overlay == nil || model.overlay.spec.title != "Review tool" {
+		t.Fatalf("tool overlay = %#v", model.overlay)
+	}
+
+	updated, _ = model.updateOverlayKey(tea.KeyPressMsg{Code: tea.KeySpace, Mod: tea.ModCtrl})
+	model = updated.(Model)
+	if model.overlay != nil || model.minimizedOverlay == nil {
+		t.Fatalf("minimize state: overlay=%#v hidden=%#v", model.overlay, model.minimizedOverlay)
+	}
+	if session.isClosed() {
+		t.Fatal("minimize closed the tool session")
+	}
+
+	updated, _ = model.updateNormal(runeKey("c"))
+	model = updated.(Model)
+	updated, restore := model.updateNormal(runeKey("r"))
+	model = updated.(Model)
+	if model.overlay == nil || model.minimizedOverlay != nil {
+		t.Fatalf("restore state: overlay=%#v hidden=%#v", model.overlay, model.minimizedOverlay)
+	}
+	if restore == nil {
+		t.Fatal("restore did not re-arm the overlay")
+	}
+}
+
 // waitForWrites waits for the terminal's writer goroutine to deliver what
 // the event loop queued.
 func waitForWrites(t *testing.T, session *fakeOverlaySession, want string) {
@@ -266,5 +317,24 @@ func TestAFailureWithNothingToSayStillReports(t *testing.T) {
 	picked, ok := cmd().(directoryPickedMsg)
 	if !ok || picked.err == nil || !strings.Contains(picked.err.Error(), "status 1") {
 		t.Fatalf("exit result = %#v", picked)
+	}
+}
+
+func TestToolOverlayConsumesCtrlSpaceWhenMinimizeIsDisabled(t *testing.T) {
+	model := flowModelFixture(t, stubBackend{})
+	session := newFakeOverlaySession("tool")
+	model = openFakeOverlay(t, model, session, overlaySpec{
+		title:       "Tool",
+		minimizable: false,
+		cleanup:     func() {},
+	})
+
+	updated, cmd := model.updateOverlayKey(tea.KeyPressMsg{Code: tea.KeySpace, Mod: tea.ModCtrl})
+	model = updated.(Model)
+	if cmd != nil || model.overlay == nil || model.minimizedOverlay != nil {
+		t.Fatalf("ctrl-space state: overlay=%#v hidden=%#v cmd=%v", model.overlay, model.minimizedOverlay, cmd)
+	}
+	if got := session.recorded(); got != "" {
+		t.Fatalf("ctrl-space reached the hosted tool: %q", got)
 	}
 }

--- a/internal/ui/overlays.go
+++ b/internal/ui/overlays.go
@@ -19,11 +19,13 @@ import (
 // overlaySpec is one floating program the dashboard can host: what to run,
 // how to read its answer back, and how to clean up if it never answers.
 type overlaySpec struct {
-	title string
-	host  string
-	path  string
-	args  []string
-	dir   string
+	title       string
+	host        string
+	path        string
+	args        []string
+	dir         string
+	minimizable bool
+	toolID      string
 	// result turns the program's exit into a message. answer is what it
 	// left in its session — empty when it left none, which is what
 	// quitting without choosing looks like.
@@ -126,11 +128,16 @@ func (m Model) handleOverlayOpened(msg overlayOpenedMsg) (tea.Model, tea.Cmd) {
 // back. Cancel bumps the generation, so a late exit from a killed session
 // falls through the guard.
 func (m Model) handleOverlayExited(msg overlayExitedMsg) (tea.Model, tea.Cmd) {
-	if m.overlay == nil || msg.generation != m.overlay.generation {
+	view := m.overlay
+	if view != nil && msg.generation == view.generation {
+		m.overlay = nil
+	} else if hidden := m.minimizedOverlay; hidden != nil &&
+		msg.generation == hidden.generation {
+		view = hidden
+		m.minimizedOverlay = nil
+	} else {
 		return m, nil
 	}
-	view := m.overlay
-	m.overlay = nil
 	return m, func() tea.Msg {
 		// Read the answer before closing: Close destroys the session, and
 		// the session is where the answer is.
@@ -153,8 +160,15 @@ func (m Model) handleOverlayExited(msg overlayExitedMsg) (tea.Model, tea.Cmd) {
 }
 
 // updateOverlayKey forwards the keyboard to the floating program, byte for
-// byte; ctrl+q is the one key that stays ours, and it cancels.
+// byte. ctrl+q cancels; ctrl+space minimizes a long-lived tool.
 func (m Model) updateOverlayKey(msg tea.KeyPressMsg) (tea.Model, tea.Cmd) {
+	if msg.String() == "ctrl+space" || msg.String() == "ctrl+@" {
+		if m.overlay.spec.minimizable {
+			return m.minimizeOverlay()
+		}
+		// Ctrl-space belongs to the overlay host whether or not this tool opts in.
+		return m, nil
+	}
 	if msg.String() == "ctrl+q" {
 		return m.cancelOverlay()
 	}
@@ -164,6 +178,25 @@ func (m Model) updateOverlayKey(msg tea.KeyPressMsg) (tea.Model, tea.Cmd) {
 	}
 	writeTerminal(m.overlay.widget, data)
 	return m, nil
+}
+
+// minimizeOverlay hides a long-lived tool without interrupting its PTY.
+func (m Model) minimizeOverlay() (tea.Model, tea.Cmd) {
+	view := m.overlay
+	m.overlay = nil
+	view.widget.SetVisible(false)
+	m.minimizedOverlay = view
+	return m, nil
+}
+
+func closeMinimizedOverlayCmd(view *overlayView) tea.Cmd {
+	return func() tea.Msg {
+		if view != nil {
+			view.widget.Close()
+			view.spec.cleanup()
+		}
+		return nil
+	}
 }
 
 // cancelOverlay tears the popup down without an answer: the session dies

--- a/internal/ui/tools.go
+++ b/internal/ui/tools.go
@@ -494,7 +494,7 @@ func (m Model) toolFormHelp() string {
 	case 0:
 		return "Lowercase config ID; letters, digits, _ and - only."
 	case 1:
-		return "Optional label shown in the overlay list and footer."
+		return "Optional label shown in the overlay list and help."
 	case 2:
 		return "Command to run on this host; an absolute path is most reliable."
 	case 3:
@@ -506,12 +506,4 @@ func (m Model) toolFormHelp() string {
 	default:
 		return ""
 	}
-}
-
-func (m Model) toolFooterHints() []string {
-	hints := []string{"T tools"}
-	for _, tool := range m.toolOverlays {
-		hints = append(hints, toolHotkeyLabel(tool.Hotkey)+" "+overlayTitle(tool))
-	}
-	return hints
 }

--- a/internal/ui/tools.go
+++ b/internal/ui/tools.go
@@ -1,0 +1,517 @@
+package ui
+
+import (
+	"encoding/json"
+	"fmt"
+	"sort"
+	"strings"
+
+	tea "charm.land/bubbletea/v2"
+)
+
+// ToolOverlay is a configured interactive program. Its binary and arguments
+// are passed straight to the runtime rather than through a shell.
+type ToolOverlay struct {
+	ID     string
+	Title  string
+	Binary string
+	Args   []string
+	Hotkey []string
+	Host   string
+}
+
+type toolOverlayForm struct {
+	editing         int
+	focus           int
+	id              lineInput
+	title           lineInput
+	binary          lineInput
+	args            lineInput
+	hotkey          lineInput
+	host            lineInput
+	validation      string
+	validationField int
+	touched         [6]bool
+	submitted       bool
+}
+
+func sortToolOverlays(overlays []ToolOverlay) []ToolOverlay {
+	out := append([]ToolOverlay(nil), overlays...)
+	sort.Slice(out, func(i, j int) bool { return out[i].ID < out[j].ID })
+	return out
+}
+
+func overlayTitle(tool ToolOverlay) string {
+	if tool.Title != "" {
+		return tool.Title
+	}
+	return tool.ID
+}
+
+func toolHotkeyLabel(hotkey []string) string { return strings.Join(hotkey, " ") }
+
+func sameToolHotkey(a, b []string) bool {
+	if len(a) != len(b) {
+		return false
+	}
+	for index := range a {
+		if a[index] != b[index] {
+			return false
+		}
+	}
+	return true
+}
+
+func startsToolHotkey(full, prefix []string) bool {
+	return len(prefix) <= len(full) && sameToolHotkey(full[:len(prefix)], prefix)
+}
+
+// toolOverlayForKey consumes a configured multi-key chord before dashboard
+// commands. Config validation only permits unused roots, so this cannot hide
+// an existing dashboard action.
+func (m *Model) toolOverlayForKey(key string) (*ToolOverlay, bool) {
+	sequence := append(append([]string(nil), m.toolPrefix...), key)
+	var match *ToolOverlay
+	waiting := false
+	for index := range m.toolOverlays {
+		tool := &m.toolOverlays[index]
+		if sameToolHotkey(tool.Hotkey, sequence) {
+			match = tool
+		}
+		if len(sequence) < len(tool.Hotkey) && startsToolHotkey(tool.Hotkey, sequence) {
+			waiting = true
+		}
+	}
+	if match != nil {
+		m.toolPrefix = nil
+		return match, false
+	}
+	if waiting {
+		m.toolPrefix = sequence
+		return nil, true
+	}
+	if len(m.toolPrefix) > 0 {
+		m.toolPrefix = nil
+		return nil, true
+	}
+	return nil, false
+}
+
+func (m Model) toolOverlaySpec(tool ToolOverlay) overlaySpec {
+	return overlaySpec{
+		title:       overlayTitle(tool),
+		host:        tool.Host,
+		path:        tool.Binary,
+		args:        append([]string(nil), tool.Args...),
+		minimizable: true,
+		toolID:      tool.ID,
+		result: func(_ string, runErr error) tea.Msg {
+			if runErr != nil {
+				return actionMsg{err: fmt.Errorf("%s: %w", overlayTitle(tool), runErr)}
+			}
+			return actionMsg{}
+		},
+		cleanup: func() {},
+	}
+}
+
+func (m Model) toggleToolOverlay(tool ToolOverlay) (tea.Model, tea.Cmd) {
+	if hidden := m.minimizedOverlay; hidden != nil && hidden.spec.toolID == tool.ID {
+		return m.restoreMinimizedOverlay()
+	}
+	if hidden := m.minimizedOverlay; hidden != nil {
+		m.minimizedOverlay = nil
+		return m, tea.Sequence(closeMinimizedOverlayCmd(hidden), m.openOverlay(m.toolOverlaySpec(tool)))
+	}
+	return m, m.openOverlay(m.toolOverlaySpec(tool))
+}
+
+func (m Model) restoreMinimizedOverlay() (tea.Model, tea.Cmd) {
+	view := m.minimizedOverlay
+	m.minimizedOverlay = nil
+	outerWidth, outerHeight := m.overlayDimensions()
+	_, resize := view.widget.SetSize(max(2, outerWidth-2), max(2, outerHeight-2))
+	view.widget.SetVisible(true)
+	m.overlay = view
+	return m, tea.Batch(resize, m.armPTYWait())
+}
+
+func (m *Model) beginToolManager() {
+	m.toolCursor = min(m.toolCursor, max(0, len(m.toolOverlays)-1))
+	m.mode = modeTools
+	m.clearComplaint(modeTools)
+}
+
+func (m *Model) beginToolEdit(index int) {
+	m.toolForm = toolOverlayForm{editing: index}
+	if index >= 0 {
+		tool := m.toolOverlays[index]
+		m.toolForm.id.SetValue(tool.ID)
+		m.toolForm.title.SetValue(tool.Title)
+		m.toolForm.binary.SetValue(tool.Binary)
+		if len(tool.Args) > 0 {
+			encoded, _ := json.Marshal(tool.Args)
+			m.toolForm.args.SetValue(string(encoded))
+		}
+		m.toolForm.hotkey.SetValue(strings.Join(tool.Hotkey, " "))
+		m.toolForm.host.SetValue(tool.Host)
+	}
+	m.toolForm.id = ensureToolInput(m.toolForm.id, "id")
+	m.toolForm.title = ensureToolInput(m.toolForm.title, "Title")
+	m.toolForm.binary = ensureToolInput(m.toolForm.binary, "Executable")
+	m.toolForm.args = ensureToolInput(m.toolForm.args, "Arguments as JSON array")
+	m.toolForm.hotkey = ensureToolInput(m.toolForm.hotkey, "c r")
+	m.toolForm.host = ensureToolInput(m.toolForm.host, "Local machine")
+	m.focusToolField(0)
+	m.mode = modeToolEdit
+	m.refreshToolValidation()
+	m.clearComplaint(modeToolEdit)
+}
+
+func ensureToolInput(input lineInput, placeholder string) lineInput {
+	if input.placeholder == "" {
+		value := input.Value()
+		input = newLineInput(placeholder)
+		input.SetValue(value)
+	}
+	return input
+}
+
+func (m *Model) focusToolField(index int) {
+	m.toolForm.focus = (index + 6) % 6
+	for field, input := range m.toolFormInputs() {
+		if field == m.toolForm.focus {
+			input.Focus()
+		} else {
+			input.Blur()
+		}
+		m.setToolFormInput(field, input)
+	}
+}
+
+func (m Model) toolFormInputs() []lineInput {
+	return []lineInput{m.toolForm.id, m.toolForm.title, m.toolForm.binary, m.toolForm.args, m.toolForm.hotkey, m.toolForm.host}
+}
+
+func (m *Model) setToolFormInput(index int, input lineInput) {
+	switch index {
+	case 0:
+		m.toolForm.id = input
+	case 1:
+		m.toolForm.title = input
+	case 2:
+		m.toolForm.binary = input
+	case 3:
+		m.toolForm.args = input
+	case 4:
+		m.toolForm.hotkey = input
+	case 5:
+		m.toolForm.host = input
+	}
+}
+
+func (m Model) updateTools(msg tea.KeyPressMsg) (tea.Model, tea.Cmd) {
+	switch msg.String() {
+	case "esc", "ctrl+c", "ctrl+[":
+		m.mode = modeNormal
+	case "j", "down":
+		if len(m.toolOverlays) > 0 {
+			m.toolCursor = min(len(m.toolOverlays)-1, m.toolCursor+1)
+		}
+	case "k", "up":
+		m.toolCursor = max(0, m.toolCursor-1)
+	case "n":
+		m.beginToolEdit(-1)
+	case "e":
+		if len(m.toolOverlays) > 0 {
+			m.beginToolEdit(m.toolCursor)
+		}
+	case "d":
+		if len(m.toolOverlays) > 0 {
+			tools := append([]ToolOverlay(nil), m.toolOverlays...)
+			tools = append(tools[:m.toolCursor], tools[m.toolCursor+1:]...)
+			if err := m.persistToolOverlays(tools); err != nil {
+				m.complain(err)
+			}
+		}
+	case "enter":
+		if len(m.toolOverlays) > 0 {
+			return m.toggleToolOverlay(m.toolOverlays[m.toolCursor])
+		}
+	}
+	return m, nil
+}
+
+func (m Model) updateToolEdit(msg tea.KeyPressMsg) (tea.Model, tea.Cmd) {
+	switch msg.String() {
+	case "esc", "ctrl+c", "ctrl+[":
+		m.mode = modeTools
+		return m, nil
+	case "tab", "down":
+		m.focusToolField(m.toolForm.focus + 1)
+		return m, nil
+	case "shift+tab", "up":
+		m.focusToolField(m.toolForm.focus - 1)
+		return m, nil
+	case "enter":
+		m.toolForm.submitted = true
+		m.refreshToolValidation()
+		if m.toolForm.validation == "" {
+			if err := m.submitToolForm(); err != nil {
+				m.toolForm.validation = err.Error()
+			}
+		}
+		return m, nil
+	}
+	input := m.toolFormInputs()[m.toolForm.focus].Update(msg)
+	m.setToolFormInput(m.toolForm.focus, input)
+	m.toolForm.touched[m.toolForm.focus] = true
+	m.refreshToolValidation()
+	return m, nil
+}
+
+func (m *Model) submitToolForm() error {
+	if err := m.validateToolForm(); err != nil {
+		return err
+	}
+	tool := ToolOverlay{
+		ID:     strings.TrimSpace(m.toolForm.id.Value()),
+		Title:  strings.TrimSpace(m.toolForm.title.Value()),
+		Binary: strings.TrimSpace(m.toolForm.binary.Value()),
+		Hotkey: strings.Fields(strings.ToLower(m.toolForm.hotkey.Value())),
+		Host:   strings.TrimSpace(m.toolForm.host.Value()),
+	}
+	if !validToolID(tool.ID) || tool.Binary == "" {
+		return fmt.Errorf("id and executable are required")
+	}
+	if len(strings.TrimSpace(m.toolForm.args.Value())) > 0 {
+		if err := json.Unmarshal([]byte(m.toolForm.args.Value()), &tool.Args); err != nil {
+			return fmt.Errorf("arguments must be a JSON string array: %w", err)
+		}
+	}
+	if err := validToolHotkey(tool.Hotkey); err != nil {
+		return err
+	}
+	tools := append([]ToolOverlay(nil), m.toolOverlays...)
+	if m.toolForm.editing >= 0 {
+		tools = append(tools[:m.toolForm.editing], tools[m.toolForm.editing+1:]...)
+	}
+	for _, other := range tools {
+		if other.ID == tool.ID {
+			return fmt.Errorf("another tool already uses id %q", tool.ID)
+		}
+		if sameToolHotkey(other.Hotkey, tool.Hotkey) || startsToolHotkey(other.Hotkey, tool.Hotkey) || startsToolHotkey(tool.Hotkey, other.Hotkey) {
+			return fmt.Errorf("Hotkey conflicts with %q", other.ID)
+		}
+	}
+	tools = append(tools, tool)
+	if err := m.persistToolOverlays(tools); err != nil {
+		return err
+	}
+	m.mode = modeTools
+	return nil
+}
+
+func validToolID(id string) bool {
+	if id == "" || id[0] < 'a' || id[0] > 'z' {
+		return false
+	}
+	for _, letter := range id[1:] {
+		if !(letter >= 'a' && letter <= 'z' || letter >= '0' && letter <= '9' || letter == '_' || letter == '-') {
+			return false
+		}
+	}
+	return true
+}
+
+func validToolHotkey(hotkey []string) error {
+	if len(hotkey) < 2 || len(hotkey) > 3 {
+		return fmt.Errorf("hotkey must contain two or three lowercase letters")
+	}
+	for _, key := range hotkey {
+		if len(key) != 1 || key[0] < 'a' || key[0] > 'z' {
+			return fmt.Errorf("hotkey must contain two or three lowercase letters")
+		}
+	}
+	if !strings.ContainsRune("abcdpuvwy", rune(hotkey[0][0])) {
+		return fmt.Errorf("hotkey starts with a dashboard command")
+	}
+	return nil
+}
+
+func (m *Model) refreshToolValidation() {
+	m.toolForm.validation = ""
+	m.toolForm.validationField = m.toolValidationField()
+	if m.toolForm.validationField >= 0 {
+		m.toolForm.validation = m.validateToolForm().Error()
+	}
+}
+
+func (m Model) toolValidationField() int {
+	id := strings.TrimSpace(m.toolForm.id.Value())
+	if !validToolID(id) {
+		return 0
+	}
+	if strings.TrimSpace(m.toolForm.binary.Value()) == "" {
+		return 2
+	}
+	args := strings.TrimSpace(m.toolForm.args.Value())
+	if args != "" {
+		var values []string
+		if err := json.Unmarshal([]byte(args), &values); err != nil || values == nil {
+			return 3
+		}
+	}
+	hotkey := strings.Fields(strings.ToLower(m.toolForm.hotkey.Value()))
+	if validToolHotkey(hotkey) != nil {
+		return 4
+	}
+	host := strings.TrimSpace(m.toolForm.host.Value())
+	if host != "" && !m.hasToolHost(host) {
+		return 5
+	}
+	for index, other := range m.toolOverlays {
+		if index == m.toolForm.editing {
+			continue
+		}
+		if other.ID == id {
+			return 0
+		}
+		if sameToolHotkey(other.Hotkey, hotkey) || startsToolHotkey(other.Hotkey, hotkey) || startsToolHotkey(hotkey, other.Hotkey) {
+			return 4
+		}
+	}
+	return -1
+}
+
+func (m Model) validateToolForm() error {
+	id := strings.TrimSpace(m.toolForm.id.Value())
+	if !validToolID(id) {
+		return fmt.Errorf("ID: start lowercase; use a-z, 0-9, _ or -")
+	}
+	if strings.TrimSpace(m.toolForm.binary.Value()) == "" {
+		return fmt.Errorf("Executable is required")
+	}
+	args := strings.TrimSpace(m.toolForm.args.Value())
+	if args != "" {
+		var values []string
+		if err := json.Unmarshal([]byte(args), &values); err != nil || values == nil {
+			return fmt.Errorf("Arguments: use a JSON string array")
+		}
+	}
+	hotkey := strings.Fields(strings.ToLower(m.toolForm.hotkey.Value()))
+	if err := validToolHotkey(hotkey); err != nil {
+		return err
+	}
+	host := strings.TrimSpace(m.toolForm.host.Value())
+	if host != "" && !m.hasToolHost(host) {
+		return fmt.Errorf("Host %q is not configured", host)
+	}
+	for index, other := range m.toolOverlays {
+		if index == m.toolForm.editing {
+			continue
+		}
+		if other.ID == id {
+			return fmt.Errorf("ID %q is already in use", id)
+		}
+		if sameToolHotkey(other.Hotkey, hotkey) || startsToolHotkey(other.Hotkey, hotkey) || startsToolHotkey(hotkey, other.Hotkey) {
+			return fmt.Errorf("hotkey conflicts with %q", other.ID)
+		}
+	}
+	return nil
+}
+
+func (m Model) hasToolHost(host string) bool {
+	for _, machine := range m.machines {
+		if machine.kind == machineHost && machine.name == host {
+			return true
+		}
+	}
+	return false
+}
+
+func (m *Model) persistToolOverlays(tools []ToolOverlay) error {
+	tools = sortToolOverlays(tools)
+	if m.saveToolOverlays != nil {
+		if err := m.saveToolOverlays(tools); err != nil {
+			return err
+		}
+	}
+	m.toolOverlays = tools
+	m.toolCursor = min(m.toolCursor, max(0, len(tools)-1))
+	return nil
+}
+
+func (m Model) renderToolsModal(width, height int) string {
+	lines := []string{"  " + titleStyle().Render("Tool overlays"), ""}
+	if len(m.toolOverlays) == 0 {
+		lines = append(lines, "  "+mutedStyle().Render("No configured tools"))
+	} else {
+		for index, tool := range m.toolOverlays {
+			prefix := "  "
+			if index == m.toolCursor {
+				prefix = accentStyle().Render("› ")
+			}
+			lines = append(lines, prefix+truncate(overlayTitle(tool), 28)+"  "+mutedStyle().Render(toolHotkeyLabel(tool.Hotkey)))
+		}
+	}
+	lines = append(lines, "", "  "+mutedStyle().Render("Enter open  n add  e edit  d delete  Esc close"))
+	modalWidth, modalHeight := modalDimensions(width, height, 60, len(lines)+2)
+	return renderModal(strings.Join(lines, "\n"), modalWidth, modalHeight)
+}
+
+func (m Model) renderToolEditModal(width, height int) string {
+	modalWidth, modalHeight := modalDimensions(width, height, 72, 20)
+	inputWidth := max(12, modalWidth-24)
+	labels := []string{"ID", "Title", "Executable", "Arguments", "Hotkey", "Host"}
+	inputs := m.toolFormInputs()
+	lines := []string{"  " + titleStyle().Render("Configure tool overlay"), ""}
+	for index, label := range labels {
+		inputs[index].SetWidth(inputWidth)
+		invalid := m.toolForm.validation != "" &&
+			m.toolForm.validationField == index &&
+			(m.toolForm.submitted || m.toolForm.touched[index])
+		ink := mutedStyle()
+		if invalid {
+			ink = errorStyle().Bold(true)
+		} else if m.toolForm.focus == index {
+			ink = accentStyle()
+		}
+		lines = append(lines, "  "+ink.Render(label)+"  "+inputs[index].View())
+		if invalid {
+			lines = append(lines, "    "+errorStyle().Render("! "+truncate(m.toolForm.validation, max(1, modalWidth-8))))
+		} else if m.toolForm.focus == index {
+			help := truncate(m.toolFormHelp(), max(1, modalWidth-6))
+			lines = append(lines, "    "+mutedStyle().Render(help))
+		}
+	}
+	lines = append(lines, "", "  "+mutedStyle().Render("Enter save  Tab fields  Esc cancel"))
+	return renderModal(strings.Join(lines, "\n"), modalWidth, modalHeight)
+}
+
+func (m Model) toolFormHelp() string {
+	switch m.toolForm.focus {
+	case 0:
+		return "Lowercase config ID; letters, digits, _ and - only."
+	case 1:
+		return "Optional label shown in the overlay list and footer."
+	case 2:
+		return "Command to run on this host; an absolute path is most reliable."
+	case 3:
+		return "Optional JSON string array passed after the executable."
+	case 4:
+		return "Two or three unused lowercase dashboard keys, for example c r."
+	case 5:
+		return "Blank runs here. A configured host runs the command on that machine."
+	default:
+		return ""
+	}
+}
+
+func (m Model) toolFooterHints() []string {
+	hints := []string{"T tools"}
+	for _, tool := range m.toolOverlays {
+		hints = append(hints, toolHotkeyLabel(tool.Hotkey)+" "+overlayTitle(tool))
+	}
+	return hints
+}

--- a/internal/ui/tools_test.go
+++ b/internal/ui/tools_test.go
@@ -5,6 +5,7 @@ import (
 	"testing"
 
 	tea "charm.land/bubbletea/v2"
+	"github.com/charmbracelet/x/ansi"
 )
 
 func TestToolOverlayFormValidatesInputBeforeSave(t *testing.T) {
@@ -41,5 +42,29 @@ func TestToolOverlayFormExplainsHost(t *testing.T) {
 	model.focusToolField(5)
 	if rendered := model.renderToolEditModal(100, 28); !strings.Contains(rendered, "Blank runs here") {
 		t.Fatalf("host guidance missing:\n%s", rendered)
+	}
+}
+
+func TestToolShortcutsAppearInHelpNotFooter(t *testing.T) {
+	model := flowModelFixture(t, stubBackend{})
+	model.toolOverlays = []ToolOverlay{{
+		ID:     "review",
+		Title:  "Review tool",
+		Binary: "/opt/tools/review",
+		Hotkey: []string{"c", "r"},
+	}}
+
+	footer := ansi.Strip(model.renderFooter())
+	for _, unwanted := range []string{"T tools", "c r Review tool"} {
+		if strings.Contains(footer, unwanted) {
+			t.Fatalf("footer includes tool hint %q: %q", unwanted, footer)
+		}
+	}
+
+	help := ansi.Strip(model.renderHelpModal(100, 50))
+	for _, want := range []string{"Tools", "T", "configure tool overlays", "c r", "Review tool"} {
+		if !strings.Contains(help, want) {
+			t.Fatalf("help missing %q:\n%s", want, help)
+		}
 	}
 }

--- a/internal/ui/tools_test.go
+++ b/internal/ui/tools_test.go
@@ -1,0 +1,45 @@
+package ui
+
+import (
+	"strings"
+	"testing"
+
+	tea "charm.land/bubbletea/v2"
+)
+
+func TestToolOverlayFormValidatesInputBeforeSave(t *testing.T) {
+	model := flowModelFixture(t, stubBackend{})
+	model.beginToolEdit(-1)
+	if !strings.Contains(model.toolForm.validation, "ID: start") {
+		t.Fatalf("initial validation = %q", model.toolForm.validation)
+	}
+
+	model.toolForm.id.SetValue("review")
+	model.toolForm.binary.SetValue("review-tool")
+	model.toolForm.hotkey.SetValue("c r")
+	model.focusToolField(3)
+	updated, _ := model.updateToolEdit(tea.KeyPressMsg{Text: "{", Code: '{'})
+	model = updated.(Model)
+	if !strings.Contains(model.toolForm.validation, "Arguments:") {
+		t.Fatalf("live validation = %q", model.toolForm.validation)
+	}
+	if !strings.Contains(model.renderToolEditModal(80, 24), "Arguments:") {
+		t.Fatal("validation is not rendered in the form")
+	}
+
+	updated, _ = model.updateToolEdit(tea.KeyPressMsg{Code: tea.KeyEnter})
+	model = updated.(Model)
+	if model.mode != modeToolEdit || len(model.toolOverlays) != 0 {
+		t.Fatalf("invalid form was saved: mode=%v tools=%#v", model.mode, model.toolOverlays)
+	}
+}
+
+func TestToolOverlayFormExplainsHost(t *testing.T) {
+	model := flowModelFixture(t, stubBackend{})
+	model.beginToolEdit(-1)
+
+	model.focusToolField(5)
+	if rendered := model.renderToolEditModal(100, 28); !strings.Contains(rendered, "Blank runs here") {
+		t.Fatalf("host guidance missing:\n%s", rendered)
+	}
+}

--- a/main.go
+++ b/main.go
@@ -503,8 +503,20 @@ func runDashboard(command *cobra.Command, cfg config.Config, openPath string) er
 		}
 	}()
 	options := ui.Options{
-		YaziPath: cfg.Tools.Yazi,
-		NvimPath: cfg.Tools.Nvim,
+		YaziPath:     cfg.Tools.Yazi,
+		NvimPath:     cfg.Tools.Nvim,
+		ToolOverlays: toolOverlayOptions(cfg.Tools.Overlays),
+		SaveToolOverlays: func(overlays []ui.ToolOverlay) error {
+			next := cfg
+			if err := next.SetToolOverlays(configToolOverlays(overlays)); err != nil {
+				return err
+			}
+			if err := config.Save(next); err != nil {
+				return err
+			}
+			cfg = next
+			return nil
+		},
 		Keys: ui.KeyBindings{
 			AgentsNext:     cfg.Keys.AgentsNext,
 			AgentsPrevious: cfg.Keys.AgentsPrevious,
@@ -565,6 +577,37 @@ func runDashboard(command *cobra.Command, cfg config.Config, openPath string) er
 	}
 	printFarewell(command.OutOrStdout())
 	return nil
+}
+
+func toolOverlayOptions(overlays map[string]config.ToolOverlay) []ui.ToolOverlay {
+	ids := slices.Sorted(maps.Keys(overlays))
+	tools := make([]ui.ToolOverlay, 0, len(ids))
+	for _, id := range ids {
+		overlay := overlays[id]
+		tools = append(tools, ui.ToolOverlay{
+			ID:     id,
+			Title:  overlay.Title,
+			Binary: overlay.Binary,
+			Args:   append([]string(nil), overlay.Args...),
+			Hotkey: append([]string(nil), overlay.Hotkey...),
+			Host:   overlay.Host,
+		})
+	}
+	return tools
+}
+
+func configToolOverlays(overlays []ui.ToolOverlay) map[string]config.ToolOverlay {
+	configured := make(map[string]config.ToolOverlay, len(overlays))
+	for _, overlay := range overlays {
+		configured[overlay.ID] = config.ToolOverlay{
+			Title:  overlay.Title,
+			Binary: overlay.Binary,
+			Args:   append([]string(nil), overlay.Args...),
+			Hotkey: append([]string(nil), overlay.Hotkey...),
+			Host:   overlay.Host,
+		}
+	}
+	return configured
 }
 
 // printFarewell speaks the oath on the way out. Only on a clean exit — an


### PR DESCRIPTION
## Summary
- add a generic Windrunner-backed overlay tool manager, with persistent config and multi-key hotkeys
- validate executable paths, arguments, IDs, hotkeys, and configured hosts directly in the form
- keep the footer focused on dashboard actions; `?` now lists `T` for tool configuration and configured tool shortcuts
- retain and minimize tool sessions with Ctrl-Space, and document tool configuration
- include the earlier New Agent task-box mouse-wheel scrolling change

## Testing
- env -u GOROOT GOPROXY=direct go build ./...
- env -u GOROOT GOPROXY=direct go test ./...